### PR TITLE
Taylor overhaul

### DIFF
--- a/herbie/programs.rkt
+++ b/herbie/programs.rkt
@@ -10,7 +10,7 @@
          location-do location-get
          eval-prog
 	 compile expression-cost program-cost
-         free-variables)
+         free-variables replace-expression)
 
 (define (location-induct
 	 prog
@@ -96,6 +96,16 @@
              (free-variables body (append vars constants))]
             [`(,f ,args ...)
              (remove-duplicates (append-map (curryr free-variables bound) args))])))
+
+(define (replace-expression program from to)
+  (cond
+   [(equal? program from)
+    to]
+   [(list? program)
+    (for/list ([subexpr program])
+      (replace-expression subexpr from to))]
+   [else
+    program]))
 
 (define (location-do loc prog f)
   (cond


### PR DESCRIPTION
Three main differences in the Taylor overhaul:
+ All known bugs with leaving out terms or returning terms in a weird order are fixed
+ When possible, exponents are grouped, so that instead of `(* (sqr a) (sqr x))` you get `(sqr (* a x))`
+ Instead of expansions around 0 and infinity, expansions with arbitrary transformation functions are allowed (using the `#:transforms` parameter to `approximate`)

The new code is also slow.