### PR TITLE
Fix single precision

### DIFF
--- a/herbie/config.rkt
+++ b/herbie/config.rkt
@@ -10,12 +10,10 @@
 
 (define *flags*
   (make-parameter
-   #hash([generate . (simplify rm)]
-         [reduce   . (regimes taylor simplify avg-error)]
-	 [precision . (double)]
-         [regimes  . ()]
-         [simplify . ()]
+   #hash([precision . (double)]
          [setup    . (simplify)]
+         [generate . (rr taylor simplify)]
+         [reduce   . (regimes taylor simplify avg-error)])))
 
 (define (toggle-flag! category flag)
   (*flags*

--- a/herbie/config.rkt
+++ b/herbie/config.rkt
@@ -16,7 +16,6 @@
          [regimes  . ()]
          [simplify . ()]
          [setup    . (simplify)]
-         [localize . (cache)])))
 
 (define (toggle-flag! category flag)
   (*flags*

--- a/herbie/config.rkt
+++ b/herbie/config.rkt
@@ -13,7 +13,6 @@
    #hash([generate . (simplify rm)]
          [reduce   . (regimes taylor simplify avg-error)]
 	 [precision . (double)]
-         [sample   . (double)]
          [regimes  . ()]
          [simplify . ()]
          [setup    . (simplify)]

--- a/herbie/interface/interact.rkt
+++ b/herbie/interface/interact.rkt
@@ -64,7 +64,7 @@
 				     (program-variables prog)))]
 	 [context (prepare-points prog samplers)])
     (*pcontext* context)
-    (*analyze-context* ((flag 'localize 'cache) context #f))
+    (*analyze-context* context)
     (debug #:from 'progress #:depth 3 "[2/2] Setting up program.")
     (^table^ (setup-prog prog (*setup-fuel*)))
     (void)))

--- a/herbie/interface/interact.rkt
+++ b/herbie/interface/interact.rkt
@@ -109,37 +109,40 @@
   (void))
 
 (define (gen-series!)
-  (define series-expansions
-    (apply
-     append
-     (for/list ([location (^locs^)]
-		[n (sequence-tail (in-naturals) 1)])
-       (debug #:from 'progress #:depth 4 "[" n "/" (length (^locs^)) "] generating series at" location)
-       (taylor-alt (^next-alt^) location))))
-  (^children^ (append (^children^) series-expansions))
+  (when ((flag 'generate 'taylor) #t #f)
+    (define series-expansions
+      (apply
+       append
+       (for/list ([location (^locs^)]
+                  [n (sequence-tail (in-naturals) 1)])
+         (debug #:from 'progress #:depth 4 "[" n "/" (length (^locs^)) "] generating series at" location)
+         (taylor-alt (^next-alt^) location))))
+    (^children^ (append (^children^) series-expansions)))
   (^gened-series^ #t)
   (void))
 
 (define (gen-rewrites!)
+  (define alt-rewrite ((flag 'generate 'rr) alt-rewrite-rm alt-rewrite-expression))
   (define rewritten
     (apply append
 	   (for/list ([location (^locs^)]
 		      [n (sequence-tail (in-naturals) 1)])
 	     (debug #:from 'progress #:depth 4 "[" n "/" (length (^locs^)) "] rewriting at" location)
-	     (alt-rewrite-rm (alt-add-event (^next-alt^) '(start rm)) #:root location))))
+	     (alt-rewrite (alt-add-event (^next-alt^) '(start rm)) #:root location))))
   (^children^
    (append (^children^) rewritten))
   (^gened-rewrites^ #t)
   (void))
 
 (define (simplify!)
-  (define simplified
-    (for/list ([child (^children^)]
-	       [n (sequence-tail (in-naturals) 1)])
-      (debug #:from 'progress #:depth 4 "[" n "/" (length (^children^)) "] simplifiying candidate" child)
-      (with-handlers ([exn:fail? (λ (e) (println "Failed while simplifying candidate" child) (raise e))])
-	(apply alt-apply child (simplify child)))))
-  (^children^ simplified)
+  (when ((flag 'generate 'simplify) #t #f)
+    (define simplified
+      (for/list ([child (^children^)]
+                 [n (sequence-tail (in-naturals) 1)])
+        (debug #:from 'progress #:depth 4 "[" n "/" (length (^children^)) "] simplifiying candidate" child)
+        (with-handlers ([exn:fail? (λ (e) (println "Failed while simplifying candidate" child) (raise e))])
+          (apply alt-apply child (simplify child)))))
+    (^children^ simplified))
   (^simplified^ #t)
   (void))
 

--- a/herbie/main.rkt
+++ b/herbie/main.rkt
@@ -28,7 +28,7 @@
   (let* ([samplers (or samplers (map (curryr cons sample-default) (program-variables prog)))]
 	 [context (prepare-points prog samplers)])
     (parameterize ([*pcontext* context]
-		   [*analyze-context* ((flag 'localize 'cache) context #f)]
+		   [*analyze-context* context]
 		   [*start-prog* prog])
       (debug #:from 'progress #:depth 3 "[2/2] Setting up program.")
       (let* ([alt-table (setup-prog prog fuel)]

--- a/herbie/plot.rkt
+++ b/herbie/plot.rkt
@@ -60,8 +60,8 @@
 (define (herbie-plot #:port [port #f] #:kind [kind 'auto] #:title [title #f] . renderers)
   (define thunk
     (if port
-        (lambda () (plot-file (cons (y-axis) renderers) port kind #:y-min 0 #:y-max 64))
-        (lambda () (plot (cons (y-axis) renderers) #:y-min 0 #:y-max 64))))
+        (lambda () (plot-file (cons (y-axis) renderers) port kind #:y-min 0 #:y-max (*bit-width*)))
+        (lambda () (plot (cons (y-axis) renderers) #:y-min 0 #:y-max (*bit-width*)))))
   (with-herbie-plot #:title title thunk))
 
 (define (plot-cand-error altn #:axis [axis 0])

--- a/herbie/points.rkt
+++ b/herbie/points.rkt
@@ -64,14 +64,14 @@
   (for/list ([i (range num)])
     (real->double-flonum (random-double-flonum))))
 
-(define (sample-default n) (((flag 'sample 'double) sample-double sample-float) n))
+(define (sample-default n) (((flag 'precision 'double) sample-double sample-float) n))
 
 (define ((sample-uniform a b) num)
   (build-list num (λ (_) (+ (* (random) (- b a)) a))))
 
 (define ((sample-grid stack) num)
-  (let* ([exponent-width ((flag 'sample 'double) 10 7)]
-	 [mantissa-width ((flag 'sample 'double) 52 23)]
+  (let* ([exponent-width (match (*bit-width*) [64 10] [32 7])]
+	 [mantissa-width (match (*bit-width*) [64 52] [32 23])]
 	 [num-steps-dim (exact->inexact (floor (sqrt (/ num stack))))]
 	 [exponent-step (/ (expt 2 exponent-width) num-steps-dim)]
 	 [mantissa-step (/ (expt 2 mantissa-width) num-steps-dim)])

--- a/herbie/reports/datafile.rkt
+++ b/herbie/reports/datafile.rkt
@@ -28,7 +28,7 @@
   (name status start result target inf- inf+ result-est vars input output time bits link) #:prefab)
 
 (struct report-info
-  (date commit branch seed flags points iterations note tests) #:prefab)
+  (date commit branch seed flags points iterations bit-width note tests) #:prefab)
 
 (define (make-report-info tests #:note [note ""])
   (report-info (current-date)
@@ -38,6 +38,7 @@
                (*flags*)
                (*num-points*)
                (*num-iterations*)
+               (*bit-width*)
                note
                tests))
 
@@ -64,7 +65,7 @@
   
   (define data
     (match info
-      [(report-info date commit branch seed flags points iterations note tests)
+      [(report-info date commit branch seed flags points iterations bit-width note tests)
        (make-hash
         `((date . ,(date->seconds date))
           (commit . ,commit)
@@ -75,6 +76,7 @@
                     (format "~a:~a" (car rec) fl)))
           (points . ,points)
           (iterations . ,iterations)
+          (bit_width . ,bit-width)
           (note . ,note)
           (tests . ,(map simplify-test tests))))]))
 
@@ -89,7 +91,8 @@
   (let* ([json (call-with-input-file file read-json)]
          [get (λ (field) (hash-ref json field))])
     (report-info (seconds->date (get 'date)) (get 'commit) (get 'branch) (get 'seed)
-                 (get 'flags) (get 'points) (get 'iterations) (hash-ref json 'note #f)
+                 (get 'flags) (get 'points) (get 'iterations) (get 'bit_width)
+                 (hash-ref json 'note #f)
                  (for/list ([test (get 'tests)])
                    (let ([get (λ (field) (hash-ref test field))])
                                         ; TODO: ignoring the result-est

--- a/herbie/reports/graph.js
+++ b/herbie/reports/graph.js
@@ -2,6 +2,7 @@ margin = 10;
 barheight = 10;
 width = 450;
 textbar = 20;
+precision = 64;
 precision_step = 8;
 
 function sort_by(type) {
@@ -16,7 +17,6 @@ function r10(d) {
 
 function make_graph(node, data, start, end) {
     var len = data.length;
-    var precision = 64; // TODO
 
     var a = d3.selectAll("script");
     var script = a[0][a[0].length - 1];
@@ -71,6 +71,9 @@ function draw_results(node) {
     window.width = node.attr("width") - 2 * margin;
     d3.json("results.json", function(err, data) {
         if (err) return console.error(err);
+        precision = data.bit_width;
+        precision_step = Math.round(precision / 8);
+
         data = data.tests;
         for (var i = 0; i < data.length; i++) {
             data[i].id = i

--- a/herbie/reports/make-index.rkt
+++ b/herbie/reports/make-index.rkt
@@ -26,7 +26,7 @@
   (printf "<ul id='reports'>\n")
   (for/list ([(folder info) (in-pairs infos)])
     (match info
-      [(report-info date commit branch seed flags points iterations note tests)
+      [(report-info date commit branch seed flags points iterations bit-width note tests)
        (printf "<li>")
        (printf "<a href='./~a/report.html'>~a</a>, on <abbr title='~a'>~a</abbr>"
                folder (date->string date) commit branch)

--- a/herbie/reports/make-report.rkt
+++ b/herbie/reports/make-report.rkt
@@ -24,7 +24,7 @@
 
 (define (make-report-page file info)
   (match info
-    [(report-info date commit branch seed flags points iterations note tests)
+    [(report-info date commit branch seed flags points iterations bit-width note tests)
 
      (define table-labels
        '("Test" "Start" "Result" "Target" "∞ ↔ ℝ" "Time"))


### PR DESCRIPTION
Fix the single-precision mode to work.

+ The single-precision is reflected in the graphs and plots we draw.
+ Removed the `sample:double` flag; `precision:double` changes the meaning of the `default` sampler.
+ Modified the new main loop to use the flags that control the main loop.