### PR TITLE
Reform sampler syntax

### DIFF
--- a/herbie/distributions.rkt
+++ b/herbie/distributions.rkt
@@ -32,9 +32,6 @@
     [(? number? x) (const x)]
     [`(uniform ,(? number? a) ,(? number? b)) (curry sample-uniform a b)]
     ['int sample-int]
-    [`(positive ,sub)
-     (define sub* (eval-sampler sub))
-     (λ () (let ([y (sub*)]) (and (not (zero? y)) (abs y))))]
     [(list (op op) (? number? lb) sub)
      (define sub* (eval-sampler sub))
      (λ () (let ([y (sub*)]) (and (op lb y) y)))]

--- a/herbie/distributions.rkt
+++ b/herbie/distributions.rkt
@@ -1,0 +1,46 @@
+#lang racket
+(require "common.rkt")
+(provide eval-sampler)
+
+(define (sample-float)
+  (floating-point-bytes->real (integer->integer-bytes (random-exp 32) 4 #f)))
+
+(define (sample-double)
+  (floating-point-bytes->real (integer->integer-bytes (random-exp 64) 8 #f)))
+
+(define (sample-default)
+  (((flag 'precision 'double) sample-double sample-float)))
+
+(define (sample-uniform a b)
+  (+ (* (random) (- b a)) a))
+
+(define (sample-int)
+  (- (random-exp 32) (expt 2 31)))
+
+(define (eval-op op)
+  (match op ['> >] ['< <] ['>= >=] ['<= <=]))
+
+(define-match-expander op
+  (λ (stx)
+    (syntax-case stx ()
+      [(_ val)
+       #'(and (or '< '> '>= '<=) (app eval-op val))])))
+
+(define (eval-sampler expr)
+  (match expr
+    ['default sample-default]
+    [(? number? x) (const x)]
+    [`(uniform ,(? number? a) ,(? number? b)) (curry sample-uniform a b)]
+    ['int sample-int]
+    [`(positive ,sub)
+     (define sub* (eval-sampler sub))
+     (λ () (let ([y (sub*)]) (and (not (zero? y)) (abs y))))]
+    [(list (op op) (? number? lb) sub)
+     (define sub* (eval-sampler sub))
+     (λ () (let ([y (sub*)]) (and (op lb y) y)))]
+    [(list (op op) sub (? number? ub))
+     (define sub* (eval-sampler sub))
+     (λ () (let ([y (sub*)]) (and (op y ub) y)))]
+    [(list (op op) (? number? lb) sub (? number? ub))
+     (define sub* (eval-sampler sub))
+     (λ () (let ([y (sub*)]) (and (op lb y ub) y)))]))

--- a/herbie/infer-regimes.rkt
+++ b/herbie/infer-regimes.rkt
@@ -4,6 +4,7 @@
 (require "programs.rkt")
 (require "matcher.rkt")
 (require "points.rkt")
+(require "distributions.rkt")
 (require "common.rkt")
 (require "syntax.rkt")
 (require "config.rkt")
@@ -127,7 +128,7 @@
 			  [prog2* (replace-subexpr (alt-program alt2) expr v)]
 			  [context
 			   (parameterize ([*num-points* (*binary-search-test-points*)])
-			     (prepare-points start-prog* (map (curryr cons sample-default)
+			     (prepare-points start-prog* (map (curryr cons (eval-sampler 'default))
 							      (program-variables start-prog*))))])
 		     (< (errors-score (errors prog1* context))
 			(errors-score (errors prog2* context)))))])

--- a/herbie/interface/interact.rkt
+++ b/herbie/interface/interact.rkt
@@ -4,6 +4,7 @@
 (require "../main.rkt")
 (require "../programs.rkt")
 (require "../points.rkt")
+(require "../distributions.rkt")
 (require "../localize-error.rkt")
 (require "../taylor.rkt")
 (require "../alt-table.rkt")
@@ -64,7 +65,7 @@
   (*start-prog* prog)
   (rollback-improve!)
   (debug #:from 'progress #:depth 3 "[1/2] Preparing points")
-  (let* ([samplers (or samplers (map (curryr cons sample-default)
+  (let* ([samplers (or samplers (map (curryr cons (eval-sampler 'default))
 				     (program-variables prog)))]
 	 [context (prepare-points prog samplers)])
     (^samplers^ samplers)

--- a/herbie/main.rkt
+++ b/herbie/main.rkt
@@ -2,6 +2,7 @@
 
 (require "common.rkt")
 (require "points.rkt")
+(require "distributions.rkt")
 (require "alternative.rkt")
 (require "localize-error.rkt")
 (require "simplify/simplify.rkt")
@@ -25,7 +26,7 @@
   (debug #:from 'progress #:depth 1 "[Phase 1 of 3] Setting up.")
   (debug #:from 'progress #:depth 3 "[1/2] Preparing points")
   (set! initial-fuel fuel)
-  (let* ([samplers (or samplers (map (curryr cons sample-default) (program-variables prog)))]
+  (let* ([samplers (or samplers (map (curryr cons (eval-sampler 'default)) (program-variables prog)))]
 	 [context (prepare-points prog samplers)])
     (parameterize ([*pcontext* context]
 		   [*analyze-context* context]

--- a/herbie/points.rkt
+++ b/herbie/points.rkt
@@ -7,7 +7,6 @@
 (require "config.rkt")
 
 (provide *pcontext* in-pcontext mk-pcontext pcontext?
-	 sample-double sample-float sample-uniform sample-integer sample-default
          prepare-points prepare-points-period make-exacts
          errors errors-score sorted-context-list sort-context-on-expr
          random-subsample)
@@ -56,26 +55,6 @@
 				   ((eval-prog expr-prog mode:bf) (car p&e))))))])
     (list (map car p&e) (map cdr p&e))))
 
-(define (random-single-flonum)
-  (floating-point-bytes->real (integer->integer-bytes (random-exp 32) 4 #f)))
-
-(define (random-double-flonum)
-  (floating-point-bytes->real (integer->integer-bytes (random-exp 64) 8 #f)))
-
-(define (sample-float)
-  (real->double-flonum (random-single-flonum)))
-
-(define (sample-double)
-  (real->double-flonum (random-double-flonum)))
-
-(define (sample-default) (((flag 'precision 'double) sample-double sample-float)))
-
-(define ((sample-uniform a b))
-  (+ (* (random) (- b a)) a))
-
-(define (sample-integer)
-  (- (random-exp 32) (expt 2 31)))
-
 (define (make-period-points num periods)
   (let ([points-per-dim (floor (exp (/ (log num) (length periods))))])
     (apply list-product
@@ -86,8 +65,7 @@
 		periods))))
 
 (define (sample sampler)
-  (let ([y (sampler)])
-    (or y (sample sampler))))
+  (or (sampler) (sample sampler)))
 
 (define (select-every skip l)
   (let loop ([l l] [count skip])

--- a/herbie/test.rkt
+++ b/herbie/test.rkt
@@ -3,7 +3,7 @@
 (require "common.rkt")
 (require "alternative.rkt")
 (require "programs.rkt")
-(require "points.rkt")
+(require "distributions.rkt")
 
 (provide (struct-out test) test-program test-samplers
          load-tests load-file test-target parse-test test-successful?)
@@ -23,31 +23,9 @@
 
 (struct test (name vars sampling-expr input output expected) #:prefab)
 
-(define (get-op op)
-  (match op ['> >] ['< <] ['>= >=] ['<= <=]))
-
-(define (get-sampler expr)
-  (match expr
-    ['default sample-default]
-    [`(positive ,e)
-     (define sub (get-sampler e))
-     (λ () (let ([y (sub)]) (and y (abs y))))]
-    [`(uniform ,a ,b) (sample-uniform a b)]
-    [(? number? x) (const x)]
-    ['integer sample-integer]
-    [`(,(and op (or '< '> '<= '>=)) ,a ,(? number? b))
-     (let ([sa (get-sampler a)] [test (curryr (get-op op) b)])
-       (λ () (let ([va (sa)]) (and (test va) va))))]
-    [`(,(and op (or '< '> '<= '>=)) ,(? number? a) ,b)
-     (let ([sb (get-sampler b)] [test (curry (get-op op) a)])
-       (λ () (let ([vb (sb)]) (and (test vb) vb))))]
-    [`(,(and op (or '< '> '<= '>=)) ,(? number? a) ,t ,(? number? b))
-     (let ([st (get-sampler t)] [test (λ (x) ((get-op op) a x b))])
-       (λ () (let ([vt (st)]) (and (test vt) vt))))]))
-
 (define (test-samplers test)
   (for/list ([var (test-vars test)] [samp (test-sampling-expr test)])
-    (cons var (get-sampler samp))))
+    (cons var (eval-sampler samp))))
 
 (define (var&dist expr)
   (match expr


### PR DESCRIPTION
This pulls point sampling into a new file, `distributions.rkt`, removing the parser code from `test.rkt` and the sampler code from `points.rkt`. The sampler API is also extended to allow returning `#f` to indicate that no point could be sampled and that the caller should try again, allowing for pre-conditions in future versions.

To improve modularity, sampling functions are not longer exposed, only the `eval-sampler` parser function. We should move to limit the callers of this function in the future.