### PR TITLE
Add package info and raco command information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ compile/nr*.c
 compile/nr*.out
 compile/nr.json
 compile/cost
+compiled/
 ml-toy
 papers
 www/demo

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 Copyright (c) 2015 Herbie Project
+Modified work Copyright 2016 Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/herbie/compile/results-to-csv.rkt
+++ b/herbie/compile/results-to-csv.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "../common.rkt")
-(require reports/datafile)
+(require "../reports/datafile.rkt")
 
 (define (results-to-csv infile outfile)
   (let ([lines (read-datafile infile)])

--- a/herbie/info.rkt
+++ b/herbie/info.rkt
@@ -1,0 +1,11 @@
+#lang info
+(define collection "herbie")
+(define compile-omit-paths '("test" "reports/bash-pred-test.rkt" "herbie-web" "util.rkt"))
+(define raco-commands '(("herbie" (submod herbie/interface/inout main) "improve floating point expression accuracy" 75)))
+(define deps '("base"
+               "math-lib"
+               "plot-lib"
+               "profile-lib"
+               "rackunit-lib"
+               "srfi-lite-lib"
+               "web-server-lib"))

--- a/herbie/interface/inout.rkt
+++ b/herbie/interface/inout.rkt
@@ -54,5 +54,5 @@
       (when (not (= 2 (length split-strings)))
         (error "Badly formatted input " tf))
       (toggle-flag! (string->symbol (car split-strings)) (string->symbol (cadr split-strings))))]
-   #:args _
+   #:args ()
    (run #:print-points print-points)))


### PR DESCRIPTION
This change allows Herbie to be installed as a Racket package, and provides the Herbie command line tool as a raco command. This uses the `herbie/interface/inout.rkt` entrypoint, rather than the report generation entrypoint. As far as I'm aware, that's the intended future main entrypoint once the CLI is cleaned up. Let me know if I should change it. The following small changes are included:

1. Changes the `#:args` from _ to () to declare no args are accepted,
rather than all args are ignored. Improves the command help output
2. Adds `compiled/` to the git ignore, which is the directory created by
DrRacket for zo files

Additionally, this change adds a notice to the license file indicating the copyright to my
patch is owned by Google (wrote this on corp laptop). This does not
change the terms of the MIT license in any way or affect any part of the project
other than this patch.

Herbie has not been added to the package catalog (yet). To install directly from this repo, run `raco pkg install git://github.com/uwplse/herbie?path=herbie`. 