### PR TITLE
Expand travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
 language: c
 sudo: false
 env:
-- RACKET_DIR=~/racket
+  global:
+    - RACKET_DIR=~/racket
+  matrix:
+    - RACKET_VERSION="6.1.1"
+    - RACKET_VERSION="6.2"
+    - RACKET_VERSION="6.2.1"
+    - RACKET_VERSION="6.3"
+    - RACKET_VERSION="6.4"
 before_install:
-- curl -L -o racket-install.sh http://mirror.racket-lang.org/installers/6.4/racket-6.4-x86_64-linux-debian-squeeze.sh
-- sh racket-install.sh --in-place --dest ~/racket
+  - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
+  - cat ../travis-racket/install-racket.sh | bash
+  - export PATH="${RACKET_DIR}/bin:${PATH}"
+install:
+  - raco pkg install --auto $TRAVIS_BUILD_DIR/herbie
 script:
-- "~/racket/bin/racket herbie/herbie.rkt --test bench/tutorial.rkt bench/hamming/"
+  - racket herbie/reports/travis.rkt bench/tutorial.rkt bench/hamming/
 notifications:
   slack:
     secure: QB8ib/gxZWZ8rY9H54BktIgx8LfjdqabSAkmWip0VHlUhrh2ULG566XgmB5h75eNzCil2cw76ma5wfSC0MNIQ1iDHKCxAgTE0+gcPcZAYGfucQ28sKGBG2wcuJfvBLG6lVDxj+luGUh3XohouTLYI9cg509JBgTgpcrXVexYAaE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ env:
   global:
     - RACKET_DIR=~/racket
   matrix:
-    - RACKET_VERSION="6.1.1"
-    - RACKET_VERSION="6.2"
-    - RACKET_VERSION="6.2.1"
     - RACKET_VERSION="6.3"
     - RACKET_VERSION="6.4"
 before_install:

--- a/herbie/info.rkt
+++ b/herbie/info.rkt
@@ -2,7 +2,7 @@
 (define collection "herbie")
 (define compile-omit-paths '("test" "reports/bash-pred-test.rkt" "herbie-web" "util.rkt"))
 (define raco-commands '(("herbie" (submod herbie/interface/inout main) "improve floating point expression accuracy" 75)))
-(define deps '("base"
+(define deps '(("base" #:version "6.3")
                "math-lib"
                "plot-lib"
                "profile-lib"


### PR DESCRIPTION
- Parallelizes travis over various racket versions to determine
herbie’s version support
- Installs racket via Greg Hendershott’s installation script to handle
installation of multiple versions
- Adds racket’s bin dir to `PATH` to allow referring to `racket` and
`raco` commands directly
- Changes installation from directly installing dependencies to
installing herbie as a package and picking up dependencies from its
`info.rkt` file
- Moves installation from `before_install` to `install`.