### PR TITLE
Use herbie.rkt in travis with seed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - docker build .
 script:
   - raco test herbie
-  - raco herbie --seed #{HERBIE_SEED} bench/tutorial.rkt bench/hamming/
+  - raco herbie --seed ${HERBIE_SEED} bench/tutorial.rkt bench/hamming/
 notifications:
   slack:
     secure: QB8ib/gxZWZ8rY9H54BktIgx8LfjdqabSAkmWip0VHlUhrh2ULG566XgmB5h75eNzCil2cw76ma5wfSC0MNIQ1iDHKCxAgTE0+gcPcZAYGfucQ28sKGBG2wcuJfvBLG6lVDxj+luGUh3XohouTLYI9cg509JBgTgpcrXVexYAaE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - docker build .
 script:
   - raco test herbie
-  - raco herbie --seed ${HERBIE_SEED} bench/tutorial.rkt bench/hamming/
+  - raco herbie --seed "${HERBIE_SEED}" bench/tutorial.rkt bench/hamming/
 notifications:
   slack:
     secure: QB8ib/gxZWZ8rY9H54BktIgx8LfjdqabSAkmWip0VHlUhrh2ULG566XgmB5h75eNzCil2cw76ma5wfSC0MNIQ1iDHKCxAgTE0+gcPcZAYGfucQ28sKGBG2wcuJfvBLG6lVDxj+luGUh3XohouTLYI9cg509JBgTgpcrXVexYAaE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - docker build .
 script:
   - raco test herbie
-  - raco herbie --seed "${HERBIE_SEED}" bench/tutorial.rkt bench/hamming/
+  - raco herbie --test --seed "${HERBIE_SEED}" bench/tutorial.rkt bench/hamming/
 notifications:
   slack:
     secure: QB8ib/gxZWZ8rY9H54BktIgx8LfjdqabSAkmWip0VHlUhrh2ULG566XgmB5h75eNzCil2cw76ma5wfSC0MNIQ1iDHKCxAgTE0+gcPcZAYGfucQ28sKGBG2wcuJfvBLG6lVDxj+luGUh3XohouTLYI9cg509JBgTgpcrXVexYAaE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,15 @@ env:
     - RACKET_DIR=~/racket
   matrix:
     - RACKET_VERSION="6.3"
+      HERBIE_SEED="#(2749829514 1059579101 312104142 915324965 966790849 1349306526)"
     - RACKET_VERSION="6.4"
+      HERBIE_SEED="#(2749829514 1059579101 312104142 915324965 966790849 1349306526)"
+    - RACKET_VERSION="6.4"
+      HERBIE_SEED="#f"
+matrix:
+  allow_failures:
+    - env: RACKET_VERSION="6.4"
+           HERBIE_SEED="#f"
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
   - cat ../travis-racket/install-racket.sh | bash
@@ -18,7 +26,7 @@ install:
   - docker build .
 script:
   - raco test herbie
-  - racket herbie/reports/travis.rkt bench/tutorial.rkt bench/hamming/
+  - raco herbie --seed #{HERBIE_SEED} bench/tutorial.rkt bench/hamming/
 notifications:
   slack:
     secure: QB8ib/gxZWZ8rY9H54BktIgx8LfjdqabSAkmWip0VHlUhrh2ULG566XgmB5h75eNzCil2cw76ma5wfSC0MNIQ1iDHKCxAgTE0+gcPcZAYGfucQ28sKGBG2wcuJfvBLG6lVDxj+luGUh3XohouTLYI9cg509JBgTgpcrXVexYAaE=

--- a/herbie/herbie.rkt
+++ b/herbie/herbie.rkt
@@ -103,8 +103,9 @@
     (profile? #t)]
    [("--timeout") s "Timeout for each test (in seconds)"
     (*timeout* (* 1000 (string->number s)))]
-   [("--seed") rs "The random seed vector to use in point generation"
-    (set-seed! (read (open-input-string rs)))]
+   [("--seed") rs "The random seed vector to use in point generation. If false (#f), a random seed is used'"
+    (define given-seed (read (open-input-string rs)))
+    (when given-seed (set-seed! given-seed))]
    [("--test") "Exit with failing status on the first unsuccessful input"
     (early-exit? #t)]
    [("--threads") th "Whether to use threads to run examples in parallel (yes|no|N)"
@@ -127,4 +128,3 @@
       (toggle-flag! (string->symbol (car split-strings)) (string->symbol (cadr split-strings))))]
    #:args files
    (run-herbie files))) ; TODO : Handle error
-


### PR DESCRIPTION
- Changes Travis to use the new `herbie.rkt` command line interface
- Adds support for explicitly requesting a random seed using the
`--seed` flag
- Specifies the exact seed used (using the seed from build #357.2 since
it was known to work) and adds an additional build job using a random
seed that’s allowed to fail.