### PR TITLE
Fix build phase of docker image caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 script:
   - raco test herbie
   - raco herbie --test --seed "${HERBIE_SEED}" bench/tutorial.rkt bench/hamming/
-after_success:
+before_cache:
   - docker save -o docker-images/herbie.image herbie
 notifications:
   slack:


### PR DESCRIPTION
The `after_success` phase runs after travis uploads cached directories, making this useless.