### PR TITLE
Fix typo in example rewriting on index page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -49,7 +49,7 @@
     <div class="before-after">
       <code class="before">sqrt(x + 1) - sqrt(x)</code>
       ⬇
-      <code class="after">1/(sqrt(x+1) - sqrt(x))</code>
+      <code class="after">1/(sqrt(x+1) + sqrt(x))</code>
     </div>
     <figcaption>
       Herbie can detect inaccurate floating point expressions


### PR DESCRIPTION
In the Index page sample for `sqrt(x + 1) - sqrt(x)`