### PR TITLE
Fix typo in ruleset

### DIFF
--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -26,7 +26,7 @@
 	(car results))))
 
 ; Commutativity
-(define-ruleset commutivity (arithmetic simplify)
+(define-ruleset commutativity (arithmetic simplify)
   [+-commutative     (+ a b)               (+ b a)]
   [*-commutative     (* a b)               (* b a)])
 


### PR DESCRIPTION
Not really significant. Just came across this. I don't suppose (or `grep` doesn't suppose) this is referenced anywhere by name.