### PR TITLE
New details page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,11 @@ env:
       HERBIE_SEED="#(2749829514 1059579101 312104142 915324965 966790849 1349306526)"
     - RACKET_VERSION="6.5"
       HERBIE_SEED="#(2749829514 1059579101 312104142 915324965 966790849 1349306526)"
-    - RACKET_VERSION="6.5"
+    - RACKET_VERSION="6.6"
+      HERBIE_SEED="#(2749829514 1059579101 312104142 915324965 966790849 1349306526)"
+    - RACKET_VERSION="6.7"
+      HERBIE_SEED="#(2749829514 1059579101 312104142 915324965 966790849 1349306526)"
+    - RACKET_VERSION="6.7"
       HERBIE_SEED="#f"
 matrix:
   allow_failures:
@@ -25,15 +29,15 @@ before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
   - cat ../travis-racket/install-racket.sh | bash
   - export PATH="${RACKET_DIR}/bin:${PATH}"
-  - docker load -i docker-images/herbie.image || true
+# - docker load -i docker-images/herbie.image || true
 install:
   - raco pkg install --auto $TRAVIS_BUILD_DIR/src
-  - docker build -t herbie .
+# - docker build -t herbie .
 script:
   - raco test src
   - racket $TRAVIS_BUILD_DIR/infra/travis.rkt --seed "${HERBIE_SEED}" bench/tutorial.fpcore bench/hamming/
-before_cache:
-  - docker save -o docker-images/herbie.image herbie
+#before_cache:
+# - docker save -o docker-images/herbie.image herbie
 notifications:
   slack:
     secure: QB8ib/gxZWZ8rY9H54BktIgx8LfjdqabSAkmWip0VHlUhrh2ULG566XgmB5h75eNzCil2cw76ma5wfSC0MNIQ1iDHKCxAgTE0+gcPcZAYGfucQ28sKGBG2wcuJfvBLG6lVDxj+luGUh3XohouTLYI9cg509JBgTgpcrXVexYAaE=

--- a/infra/index.css
+++ b/infra/index.css
@@ -37,6 +37,11 @@ figure a { color: black; text-decoration: none; display: block; }
 #reports td:nth-child(2), #reports th:nth-child(2) { text-align: center; display: none; }
 #reports td:nth-child(3) { text-align: center; }
 #reports thead { border-bottom: 1px solid black; height: 5em; vertical-align: bottom; }
+#results tr { position: relative; }
+#results a {
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0; z-index: 100;
+    padding: .5em;
+}
 
 #reports thead:after {
     position: absolute; width: 300px; text-align: left; right: -325px;

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -21,9 +21,9 @@
       (when url
         (eprintf "See <https://herbie.uwplse.org/~a/~a> for more.\n" *herbie-version* url)))))
 
+(define old-error-display-handler (error-display-handler))
 (error-display-handler
- (let ([error-display-handler* (error-display-handler)])
-   (λ (message err)
-     (if (exn:fail:user:herbie? err)
-         (display (herbie-error->string err) (current-error-port))
-         (error-display-handler message err)))))
+ (λ (message err)
+   (if (exn:fail:user:herbie? err)
+       (display (herbie-error->string err) (current-error-port))
+       (old-error-display-handler message err))))

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (require "config.rkt")
-(provide raise-herbie-error herbie-error->string exn:fail:user:herbie?)
+(provide raise-herbie-error herbie-error->string
+         (struct-out exn:fail:user:herbie))
 
 (struct exn:fail:user:herbie exn:fail:user (url location)
         #:extra-constructor-name make-exn:fail:user:herbie)

--- a/src/formats/tex.rkt
+++ b/src/formats/tex.rkt
@@ -297,18 +297,21 @@
            (car (hash-ref texify-constants expr))
            (symbol->string expr))]
         [`(if ,cond ,ift ,iff)
-          (let ([texed-branches
-                  (for/list ([branch (collect-branches expr loc)])
-                    (match branch
-                           [(list #t bexpr bloc)
-                            (format "~a & \\text{otherwise}"
-                              (texify bexpr #t (cons 2 bloc)))]
-                           [(list bcond bexpr bloc)
-                            (format "~a & \\text{when } ~a"
-                              (texify bexpr #t (cons 2 bloc))
-                              (texify bcond #t (cons 1 bloc)))]))])
-            (format "\\begin{cases} ~a \\end{cases}"
-                 (string-join texed-branches " \\\\ ")))]
+         (define NL "\\\\\n")
+         (define IND "\\;\\;\\;\\;")
+         (with-output-to-string
+           (λ ()
+             (printf "\\begin{array}{l}\n")
+             (for ([branch (collect-branches expr loc)])
+               (match branch
+                 [(list #t bexpr bloc)
+                  (printf "\\mathbf{else}:~a~a~a~a\n"
+                          NL IND (texify bexpr #t (cons 2 bloc)) NL)]
+                 [(list bcond bexpr bloc)
+                  (printf "\\mathbf{if}\\;~a:~a~a~a~a\n"
+                          (texify bcond #t (cons 1 bloc))
+                          NL IND (texify bexpr #t (cons 2 bloc)) NL)]))
+             (printf "\\end{array}")))]
         [`(,f ,args ...)
          (match (hash-ref texify-operators f)
            [(list template highlight-template self-paren-level arg-paren-level)

--- a/src/plot.rkt
+++ b/src/plot.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require math/flonum)
-(require plot/no-gui plot/pict)
+(require plot/no-gui)
 (require "common.rkt")
 (require "float.rkt")
 (require "points.rkt")
@@ -27,7 +27,7 @@
 
 (define double-ticks
   (ticks
-   (ticks-layout (ticks-scale (linear-ticks #:number 10) double-transform))
+   (ticks-layout (ticks-scale (linear-ticks #:number 10 #:base 10 #:divisors '(1 2 5)) double-transform))
    (λ (lft rgt pticks)
      (for/list ([ptick pticks])
        (~r (pre-tick-value ptick) #:notation 'exponential #:precision 0)))))
@@ -43,20 +43,21 @@
     #:sym 'fullcircle #:color (color-theme-line color) #:alpha alpha #:size 4))
 
 (define (error-axes pts #:axis [axis 0])
-  (error-points (map (const 1) pts) pts #:axis axis #:alpha 0))
+  (list
+   (y-tick-lines)
+   (error-points (map (const 1) pts) pts #:axis axis #:alpha 0)))
 
 (define (with-herbie-plot #:title [title #f] thunk)
-  (parameterize ([plot-width 400] [plot-height 200]
+  (parameterize ([plot-width 800] [plot-height 300]
                  [plot-background-alpha 0]
                  [plot-x-transform double-axis]
                  [plot-x-ticks double-ticks]
                  [plot-x-tick-label-anchor 'top]
-                 [plot-x-tick-label-angle 45]
                  [plot-x-label #f]
                  [plot-x-far-axis? #f]
-                 [plot-y-far-axis? #f]
-                 [plot-y-axis? #f]
-                 [plot-font-size 8]
+                 [plot-y-far-axis? #t]
+                 [plot-y-axis? #t]
+                 [plot-font-size 10]
                  [plot-y-ticks (linear-ticks #:number 9 #:base 32 #:divisors '(2 4 8))]
                  [plot-y-label title])
     (thunk)))
@@ -65,7 +66,7 @@
   (define thunk
     (if port
         (lambda () (plot-file (cons (y-axis) renderers) port kind #:y-min 0 #:y-max (*bit-width*)))
-        (lambda () (plot (cons (y-axis) renderers) #:y-min 0 #:y-max (*bit-width*)))))
+        (lambda () (plot-pict (cons (y-axis) renderers) #:y-min 0 #:y-max (*bit-width*)))))
   (with-herbie-plot #:title title thunk))
 
 (define (errors-by x errs pts)

--- a/src/plot.rkt
+++ b/src/plot.rkt
@@ -156,4 +156,4 @@
             #:width 2 #:color (color-theme-fit color)))
 
 (define (error-mark x-val)
-  (inverse (const x-val) #:color "gray"))
+  (inverse (const x-val) #:color "gray" #:width 3))

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -8,8 +8,9 @@
    [(< ms 3600000) (format "~am" (/ (round (/ ms 6000.0)) 10))]
    [else (format "~ahr" (/ (round (/ ms 360000.0)) 10))]))
 
-(define (format-bits r #:sign [sign #f])
+(define (format-bits r #:sign [sign #f] #:unit [unit? #f])
+  (define unit (if unit? "b" ""))
   (cond
    [(not r) ""]
-   [(and (> r 0) sign) (format "+~ab" (/ (round (* r 10)) 10))]
-   [else (format "~ab" (/ (round (* r 10)) 10))]))
+   [(and (> r 0) sign) (format "+~a~a" (/ (round (* r 10)) 10) unit)]
+   [else (format "~a~a" (/ (round (* r 10)) 10) unit)]))

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -1,0 +1,15 @@
+#lang racket
+(provide format-time format-bits)
+
+(define (format-time ms)
+  (cond
+   [(< ms 1000) (format "~a ms" (round ms))]
+   [(< ms 60000) (format "~a s" (/ (round (/ ms 100.0)) 10))]
+   [(< ms 3600000) (format "~a m" (/ (round (/ ms 6000.0)) 10))]
+   [else (format "~a hr" (/ (round (/ ms 360000.0)) 10))]))
+
+(define (format-bits r #:sign [sign #f])
+  (cond
+   [(not r) ""]
+   [(and (> r 0) sign) (format "+~a" (/ (round (* r 10)) 10))]
+   [else (format "~a" (/ (round (* r 10)) 10))]))

--- a/src/reports/common.rkt
+++ b/src/reports/common.rkt
@@ -3,13 +3,13 @@
 
 (define (format-time ms)
   (cond
-   [(< ms 1000) (format "~a ms" (round ms))]
-   [(< ms 60000) (format "~a s" (/ (round (/ ms 100.0)) 10))]
-   [(< ms 3600000) (format "~a m" (/ (round (/ ms 6000.0)) 10))]
-   [else (format "~a hr" (/ (round (/ ms 360000.0)) 10))]))
+   [(< ms 1000) (format "~ams" (round ms))]
+   [(< ms 60000) (format "~as" (/ (round (/ ms 100.0)) 10))]
+   [(< ms 3600000) (format "~am" (/ (round (/ ms 6000.0)) 10))]
+   [else (format "~ahr" (/ (round (/ ms 360000.0)) 10))]))
 
 (define (format-bits r #:sign [sign #f])
   (cond
    [(not r) ""]
-   [(and (> r 0) sign) (format "+~a" (/ (round (* r 10)) 10))]
-   [else (format "~a" (/ (round (* r 10)) 10))]))
+   [(and (> r 0) sign) (format "+~ab" (/ (round (* r 10)) 10))]
+   [else (format "~ab" (/ (round (* r 10)) 10))]))

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -19,7 +19,7 @@ section h1 {
 #graphs figcaption { text-align: left; }
 #graphs figure img { position: absolute; top: 0; left: 0; }
 #graphs figcaption button {
-    float: right; margin: 0 .25em;
+    float: right; margin: 0 .25em; cursor: pointer;
     border: 3px solid black; background: gray; color: transparent;
     height: 1.5em; width: 1.5em; border-radius: .75em;
     overflow: hidden;
@@ -29,6 +29,11 @@ section h1 {
 #graphs figcaption button.Input { border-color: red; background: pink; }
 #graphs figcaption button.inactive { background: white; }
 
+.tabbar { margin: -1.25em 0 0; padding: 0; list-style-type: none; list-style-position: inside; text-align: left; }
+.tabbar p { display: inline-block; margin: 0 .5em 0 0}
+.tabbar li { padding: .5ex; display: inline-block; margin: .1em; cursor: pointer; }
+.tabbar li:hover { background: #e4e4e4; }
+.tabbar li.selected { background: #d3d3d3; }
 h1 { margin: .67em .33em; text-align: center; vertical-align: top; font-size: 3em; font-weight: normal; }
 
 #large { margin: 2em 0; text-align: center; }
@@ -75,8 +80,3 @@ pre.shell code:before { content: "$ "; font-weight: bold; }
 #backtrace td:nth-child(3), #backtrace td:nth-child(4) { text-align: right; }
 #backtrace td.procedure { font-family: monospace; }
 
-.tabbar { margin: 0; padding: 0; list-style-type: none; list-style-position: inside; text-align: left; }
-.tabbar p { display: inline-block; margin: 0 1em 0 0}
-.tabbar li { padding: .5ex; display: inline-block; margin: .1em; cursor: pointer; }
-.tabbar li:hover { background: #e4e4e4; }
-.tabbar li.selected { background: #d3d3d3; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -3,12 +3,14 @@ a {color: #2A6496; text-decoration: none}
 a:hover {text-decoration: underline; color: #295785}
 
 section { margin: 5em 0; position: relative; }
+@media print { section { margin: 3em 0; } }
 section h1 {
     position: absolute; width: 300px; text-align: left; right: -340px; top: -15px;
     font-size: 24px; color: #aaa; transform: rotate(90deg); transform-origin: top left;
 }
 
 #program { background: #ddd; padding: 1em; text-align: center; font-size: 24px; }
+@media print { #program { padding: 0; background: transparent; margin: 2em 0; } }
 #program .program { display: inline-block; }
 #program .arrow { color: transparent; font-size: 0; }
 #program .arrow:after { content: "⬇"; color: black; font-size: 24px; }
@@ -37,6 +39,7 @@ section h1 {
 h1 { margin: .67em .33em; text-align: center; vertical-align: top; font-size: 3em; font-weight: normal; }
 
 #large { margin: 2em 0; text-align: center; }
+@media print { #large { margin-top: 0; }}
 #large div { margin: 0 1em; display: inline-block; vertical-align: top; }
 #large .number { font-size: 3em; display: block; }
 #large .icon { font-size: 3em; display: block; }
@@ -78,6 +81,10 @@ pre.shell code:before { content: "$ "; font-weight: bold; }
 .timeline-phase.simplify { background: #8ae234; }
 .timeline-phase.prune    { background: #ad7fa8; }
 .timeline-phase.regimes  { background: #a40000; }
+@media print {
+    .timeline { border: none; }
+    .timeline-phase { outline: 1px solid black; }
+}
 
 #backtrace table { width: 100%; }
 #backtrace th[colspan] { text-align: left; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -43,7 +43,7 @@ h1 { margin: .67em .33em; text-align: center; vertical-align: top; font-size: 3e
 a.icon { color: black; opacity: 0.5; text-decoration: none; font-weight: bold; }
 a.icon:hover { opacity: 1.0; }
 
-.history, .history ol { list-style: none inside; width: 800px; margin: 0; padding: 0; }
+.history, .history ol { list-style: none inside; width: 800px; margin: 0 0 2em; padding: 0; }
 
 .history li p { width: 150px; display: inline-block; margin: 0 25px 0 0; }
 .history li .error { display: block; color: #666; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -1,8 +1,12 @@
 body { width: 800px; margin: 1em auto; font-family: sans; }
 section { margin: 5em 0; }
 
-#program { background: #ddd; padding: 1em; }
-#program .arrow { text-align: center; }
+#program { background: #ddd; padding: 1em; text-align: center; font-size: 24px; }
+#program .program { display: inline-block; }
+#program .arrow { color: transparent; font-size: 0; }
+#program .arrow:after { content: "⬇"; color: black; font-size: 24px; }
+#program.horizontal .arrow { display: inline-block; }
+#program.horizontal .arrow:after { margin: 0 1em; content: "⮕" }
 
 #graphs { }
 #graphs figure { margin: 1em auto; position: relative; padding-top: 200px; width: 400px; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -74,3 +74,9 @@ pre.shell code:before { content: "$ "; font-weight: bold; }
 #backtrace th { text-align: right; }
 #backtrace td:nth-child(3), #backtrace td:nth-child(4) { text-align: right; }
 #backtrace td.procedure { font-family: monospace; }
+
+.tabbar { margin: 0; padding: 0; list-style-type: none; list-style-position: inside; text-align: left; }
+.tabbar p { display: inline-block; margin: 0 1em 0 0}
+.tabbar li { padding: .5ex; display: inline-block; margin: .1em; cursor: pointer; }
+.tabbar li:hover { background: #e4e4e4; }
+.tabbar li.selected { background: #d3d3d3; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -1,5 +1,10 @@
 body { width: 800px; margin: 1em auto; font-family: sans; }
-section { margin: 5em 0; }
+
+section { margin: 5em 0; position: relative; }
+section h1 {
+    position: absolute; width: 300px; text-align: left; right: -340px; top: -15px;
+    font-size: 24px; color: #aaa; transform: rotate(90deg); transform-origin: top left;
+}
 
 #program { background: #ddd; padding: 1em; text-align: center; font-size: 24px; }
 #program .program { display: inline-block; }
@@ -8,8 +13,7 @@ section { margin: 5em 0; }
 #program.horizontal .arrow { display: inline-block; }
 #program.horizontal .arrow:after { margin: 0 1em; content: "⮕" }
 
-#graphs { }
-#graphs figure { margin: 1em auto; position: relative; padding-top: 200px; width: 400px; }
+#graphs figure { margin: 1em auto; position: relative; padding-top: 300px; width: 800px; }
 #graphs figcaption { text-align: left; }
 #graphs figure img { position: absolute; top: 0; left: 0; }
 #graphs figcaption button {
@@ -30,18 +34,19 @@ section { margin: 5em 0; }
 a.icon { color: black; opacity: 0.5; text-decoration: none; font-weight: bold; }
 a.icon:hover { opacity: 1.0; }
 
-#process-info, #process-info ol { list-style: square; width: 800px; }
-#process-info h2 { margin-top: 3em; }
-#process-info li {margin: .5em 0;}
-#process-info .rule { text-decoration: underline; }
-#process-info .event {
-    list-style-type: none; display: block;
-    margin: 1.5em 5em; font-size: 95%; color: gray;
-}
+.history, .history ol { list-style: none inside; width: 800px; margin: 0; padding: 0; }
 
-.history li { position: relative; }
-.history .error { position: absolute; right: 0; top: 0; color: #666; }
-.history .error:after { content: " bits"; }
+.history li { position: relative; overflow-x: auto; }
+.history li p { width: 150px; display: inline-block; margin: 0 25px 0 0; }
+.history li .error { display: block; color: #666; }
+.history li > div { display: inline-block; margin: 0; width: 600px; vertical-align: top; }
+.history li > div > div { margin: 0; display: inline-block; text-align: right !important; }
+
+.history h2 { margin-top: 3em; }
+.history li {margin: .5em 0; border-bottom: 1px solid #ddd; padding-bottom: .5em; }
+.history li:last-child { border-bottom: none; padding-bottom: 0; }
+.history .rule { text-decoration: underline; }
+.history .event { display: block; margin: .5em 0; }
 
 .timeline { height: 2em; }
 .timeline-phase { height: 2em; display: inline-block; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -59,7 +59,7 @@ a.icon:hover { opacity: 1.0; }
 #process-info { background: #ddd; }
 #process-info p.header { font-size: 110%; padding: 1em 1em .5em; margin: 0; }
 #process-info p.header .attachment { float: right; margin: 0 0 0 1em; }
-#process-info pre { padding: 1em; margin: 0; font-family: monospace; }
+#process-info pre { padding: 1em; margin: 0; font-family: monospace; overflow-x: auto; }
 #process-info p { margin: 1em .75em 0; }
 pre.shell code:before { content: "$ "; font-weight: bold; }
 

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -29,6 +29,8 @@ section h1 {
 #graphs figcaption button.Input { border-color: red; background: pink; }
 #graphs figcaption button.inactive { background: white; }
 
+h1 { margin: .67em .33em; text-align: center; vertical-align: top; font-size: 3em; font-weight: normal; }
+
 #large { margin: 2em 0; text-align: center; }
 #large div { margin: 0 1em; display: inline-block; vertical-align: top; }
 #large .number { font-size: 3em; display: block; }
@@ -54,7 +56,7 @@ a.icon:hover { opacity: 1.0; }
 #process-info p.header { font-size: 110%; padding: 1em 1em .5em; margin: 0; }
 #process-info p.header .attachment { float: right; margin: 0 0 0 1em; }
 #process-info pre { padding: 1em; margin: 0; font-family: monospace; }
-
+#process-info p { margin: 1em .75em 0; }
 pre.shell code:before { content: "$ "; font-weight: bold; }
 
 .timeline { height: 2em; border-top: 1px solid #888; border-bottom: 1px solid #888; }
@@ -68,3 +70,8 @@ pre.shell code:before { content: "$ "; font-weight: bold; }
 .timeline-phase.prune    { background: #ad7fa8; }
 .timeline-phase.regimes  { background: #a40000; }
 
+#backtrace table { width: 100%; }
+#backtrace th[colspan] { text-align: left; }
+#backtrace th { text-align: right; }
+#backtrace td:nth-child(3), #backtrace td:nth-child(4) { text-align: right; }
+#backtrace td.procedure { font-family: monospace; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -50,7 +50,7 @@ a.icon:hover { opacity: 1.0; }
 .history li > div { display: inline-block; margin: 0; width: 600px; vertical-align: middle; }
 .history li > div > div { margin: 0; display: inline-block; text-align: right !important; }
 
-.history h2 { margin-top: 3em; }
+.history h2 { margin: 1.333em 0 .333em; }
 .history li {margin: .5em 0; border-top: 1px solid #ddd; padding-top: .5em; }
 .history li:first-child { border-top: none; padding-top: 0; }
 .history .rule { text-decoration: underline; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -1,4 +1,6 @@
 body { width: 800px; margin: 1em auto; font-family: sans; }
+a {color: #2A6496; text-decoration: none}
+a:hover {text-decoration: underline; color: #295785}
 
 section { margin: 5em 0; position: relative; }
 section h1 {
@@ -39,7 +41,7 @@ a.icon:hover { opacity: 1.0; }
 .history li { position: relative; overflow-x: auto; }
 .history li p { width: 150px; display: inline-block; margin: 0 25px 0 0; }
 .history li .error { display: block; color: #666; }
-.history li > div { display: inline-block; margin: 0; width: 600px; vertical-align: top; }
+.history li > div { display: inline-block; margin: 0; width: 600px; vertical-align: middle; }
 .history li > div > div { margin: 0; display: inline-block; text-align: right !important; }
 
 .history h2 { margin-top: 3em; }
@@ -48,7 +50,14 @@ a.icon:hover { opacity: 1.0; }
 .history .rule { text-decoration: underline; }
 .history .event { display: block; margin: .5em 0; }
 
-.timeline { height: 2em; }
+#process-info { background: #ddd; }
+#process-info p.header { font-size: 110%; padding: 1em 1em .5em; margin: 0; }
+#process-info p.header .attachment { float: right; margin: 0 0 0 1em; }
+#process-info pre { padding: 1em; margin: 0; font-family: monospace; }
+
+pre.shell code:before { content: "$ "; font-weight: bold; }
+
+.timeline { height: 2em; border-top: 1px solid #888; border-bottom: 1px solid #888; }
 .timeline-phase { height: 2em; display: inline-block; }
 .timeline-phase.start    { background: #d3d7cf; }
 .timeline-phase.setup    { background: #edd400; }
@@ -58,7 +67,4 @@ a.icon:hover { opacity: 1.0; }
 .timeline-phase.simplify { background: #8ae234; }
 .timeline-phase.prune    { background: #ad7fa8; }
 .timeline-phase.regimes  { background: #a40000; }
-#runtime .attachment { float: right; margin: 0 0 0 1em; }
-#reproduce pre code:before { content: "$ "; font-weight: bold; }
-a {color: #2A6496; text-decoration: none}
-a:hover {text-decoration: underline; color: #295785}
+

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -40,7 +40,6 @@ a.icon:hover { opacity: 1.0; }
 
 .history, .history ol { list-style: none inside; width: 800px; margin: 0; padding: 0; }
 
-.history li { position: relative; overflow-x: auto; }
 .history li p { width: 150px; display: inline-block; margin: 0 25px 0 0; }
 .history li .error { display: block; color: #666; }
 .history li > div { display: inline-block; margin: 0; width: 600px; vertical-align: middle; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -63,6 +63,11 @@ a.icon:hover { opacity: 1.0; }
 #process-info p { margin: 1em .75em 0; }
 pre.shell code:before { content: "$ "; font-weight: bold; }
 
+#comparison table { width: 300px; display: inline-table; vertical-align: top; }
+#comparison table th { text-align: left; }
+#comparison table td { text-align: right; }
+#comparison div { display: inline-block; width: 500px; }
+
 .timeline { height: 2em; border-top: 1px solid #888; border-bottom: 1px solid #888; }
 .timeline-phase { height: 2em; display: inline-block; }
 .timeline-phase.start    { background: #d3d7cf; }

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -47,8 +47,8 @@ a.icon:hover { opacity: 1.0; }
 .history li > div > div { margin: 0; display: inline-block; text-align: right !important; }
 
 .history h2 { margin-top: 3em; }
-.history li {margin: .5em 0; border-bottom: 1px solid #ddd; padding-bottom: .5em; }
-.history li:last-child { border-bottom: none; padding-bottom: 0; }
+.history li {margin: .5em 0; border-top: 1px solid #ddd; padding-top: .5em; }
+.history li:first-child { border-top: none; padding-top: 0; }
 .history .rule { text-decoration: underline; }
 .history .event { display: block; margin: .5em 0; }
 

--- a/src/reports/graph.css
+++ b/src/reports/graph.css
@@ -1,8 +1,11 @@
-body { width: 1200px; margin: 1em auto; font-family: sans; }
+body { width: 800px; margin: 1em auto; font-family: sans; }
+section { margin: 5em 0; }
 
-#about { float: left; width: 400px; }
-#graphs { width: 400px; }
-#graphs figure { margin: 1em 0; position: relative; padding-top: 200px; }
+#program { background: #ddd; padding: 1em; }
+#program .arrow { text-align: center; }
+
+#graphs { }
+#graphs figure { margin: 1em auto; position: relative; padding-top: 200px; width: 400px; }
 #graphs figcaption { text-align: left; }
 #graphs figure img { position: absolute; top: 0; left: 0; }
 #graphs figcaption button {
@@ -16,17 +19,12 @@ body { width: 1200px; margin: 1em auto; font-family: sans; }
 #graphs figcaption button.Input { border-color: red; background: pink; }
 #graphs figcaption button.inactive { background: white; }
 
-#details { width: 800px; float: right; }
-#output { margin: 2em 0; text-align: center; }
-
 #large { margin: 2em 0; text-align: center; }
 #large div { margin: 0 1em; display: inline-block; vertical-align: top; }
 #large .number { font-size: 3em; display: block; }
 #large .icon { font-size: 3em; display: block; }
 a.icon { color: black; opacity: 0.5; text-decoration: none; font-weight: bold; }
 a.icon:hover { opacity: 1.0; }
-
-dt { font-weight: bold; float: left; width: 7em; }
 
 #process-info, #process-info ol { list-style: square; width: 800px; }
 #process-info h2 { margin-top: 3em; }
@@ -37,9 +35,9 @@ dt { font-weight: bold; float: left; width: 7em; }
     margin: 1.5em 5em; font-size: 95%; color: gray;
 }
 
-li { position: relative; }
-.error { position: absolute; right: 0; top: 0; color: #666; }
-.error:after { content: " bits"; }
+.history li { position: relative; }
+.history .error { position: absolute; right: 0; top: 0; color: #666; }
+.history .error:after { content: " bits"; }
 
 .timeline { height: 2em; }
 .timeline-phase { height: 2em; display: inline-block; }
@@ -51,3 +49,7 @@ li { position: relative; }
 .timeline-phase.simplify { background: #8ae234; }
 .timeline-phase.prune    { background: #ad7fa8; }
 .timeline-phase.regimes  { background: #a40000; }
+#runtime .attachment { float: right; margin: 0 0 0 1em; }
+#reproduce pre code:before { content: "$ "; font-weight: bold; }
+a {color: #2A6496; text-decoration: none}
+a:hover {text-decoration: underline; color: #295785}

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -60,9 +60,20 @@
     (printf "<p>Please <a href='https://github.com/uwplse/herbie/issues'>report a bug</a> with the following info:</p>\n"))
   (printf "<pre class='shell'><code>")
   (printf "herbie --seed '~a'\n" (get-seed))
-  (printf "(FPCore ~a\n  :name ~s\n  ~a~a)"
-       (test-vars test) (test-name test)
-       (if (test-output test) (format "\n  :target\n  ~a" (test-output test)) "") (test-input test))
+
+  (printf "(FPCore ~a\n" (test-vars test))
+  (printf "  :name ~s\n" (test-name test))
+  (unless (equal? (test-precondition test) 'TRUE)
+    (printf "  :pre ~a\n" (test-precondition test)))
+  (unless (andmap (curry equal? 'default) (test-sampling-expr test))
+    (printf "  :herbie-samplers ~a\n"
+            (for/list ([var (test-vars test)] [samp (test-sampling-expr test)]
+                       #:unless (equal? samp 'default))
+              (list var samp))))
+  (unless (equal? (test-expected test) #t)
+    (printf "  :herbie-expected ~a\n" (test-expected test)))
+  (when (test-output test) (printf "\n  :target\n  ~a\n\n" (test-output test)))
+  (printf "  ~a)" (test-input test))
   (printf "</code></pre>\n")
   (printf "</section>\n"))
 

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -84,6 +84,7 @@
 
      (printf "<section id='graphs'>\n")
      (printf "<h1>Error</h1>\n")
+     (printf "<div>\n")
      (for ([var (test-vars test)] [idx (in-naturals)])
        (when (> (length (remove-duplicates (map (curryr list-ref idx) newpoints))) 1)
          (define title "The X axis may use a short exponential scale")
@@ -95,7 +96,7 @@
                       #:out (build-path rdir (format "plot-~ag.png" idx))))
          (make-plot end-error newpoints #:axis idx #:color *blue-theme*
                     #:out (build-path rdir (format "plot-~ab.png" idx)))
-         (printf "<figure>")
+         (printf "<figure id='fig-~a'>" idx)
          (printf "<img width='800' height='300' src='plot-~a.png' title='~a'/>" idx title)
          (printf "<img width='800' height='300' src='plot-~ar.png' title='~a' data-name='Input'/>" idx title)
          (when target-error
@@ -103,6 +104,7 @@
          (printf "<img width='800' height='300' src='plot-~ab.png' title='~a' data-name='Result'/>" idx title)
          (printf "<figcaption>Bits error versus <var>~a</var></figcaption>" var)
          (printf "</figure>\n")))
+     (printf "</div>\n")
      (printf "</section>\n")
 
 

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -236,6 +236,7 @@
      (printf "<body>\n")
      
      (printf "<h1>Timeout in ~a</h1>\n" (format-time time))
+     (printf "<p>Use the <code>--timeout</code> flag to change the timeout.</p>\n")
 
      (render-process-info time timeline profile? test)
 

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -96,7 +96,9 @@
 
      ; Big bold numbers
      (printf "<section id='large'>\n")
-     (printf "<div>Error: <span class='number'>~a → ~a</span></div>\n"
+     (printf "<div>Average Error: <span class='number' title='Maximum error: ~a → ~a'>~a → ~a</span></div>\n"
+             (format-bits (apply max (map ulps->bits start-error)) #:unit #f)
+             (format-bits (apply max (map ulps->bits end-error)) #:unit #f)
              (format-bits (errors-score start-error) #:unit #f)
              (format-bits (errors-score end-error) #:unit #f))
      (printf "<div>Time: <span class='number'>~a</span></div>\n" (format-time time))
@@ -140,6 +142,21 @@
          (printf "</figure>\n")))
      (printf "</div>\n")
      (printf "</section>\n")
+
+     (when (test-output test)
+       (printf "<section id='comparison'>\n")
+       (printf "<h1>Target</h1>")
+       (printf "<table>\n")
+       (printf "<tr><th>Original</th><td>~a</td></tr>\n"
+               (format-bits (errors-score start-error)))
+       (printf "<tr><th>Comparison</th><td>~a</td></tr>\n"
+               (format-bits (errors-score target-error)))
+       (printf "<tr><th>Herbie</th><td>~a</td></tr>\n"
+               (format-bits (errors-score end-error)))
+       (printf "</table>\n")
+       (printf "<div>\\[ ~a \\]</div>\n"
+               (texify-prog `(λ ,(test-vars test) ,(test-output test))))
+       (printf "</section>\n"))
 
 
      (printf "<section id='history'>\n")

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -57,7 +57,7 @@
   (printf "</p>")
   (output-timeline timeline)
   (when bug?
-    (printf "<p>Please <a href='https://github.com/uwplse/herbie/issues'>report a bug</a> with the following info:</p>\n"))
+    (printf "<p>Please include this information when filing a <a href='https://github.com/uwplse/herbie/issues'>bug report</a>:</p>\n"))
   (printf "<pre class='shell'><code>")
   (printf "herbie --seed '~a'" (get-seed))
   (for ([rec (changed-flags)])

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -125,7 +125,7 @@
          (when target-error
            (printf "<img width='800' height='300' src='plot-~ag.png' title='~a' data-name='Target'/>" idx title))
          (printf "<img width='800' height='300' src='plot-~ab.png' title='~a' data-name='Result'/>" idx title)
-         (printf "<figcaption>Bits error versus <var>~a</var></figcaption>" var)
+         (printf "<figcaption><p>Bits error versus <var>~a</var></p></figcaption>" var)
          (printf "</figure>\n")))
      (printf "</div>\n")
      (printf "</section>\n")

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -269,6 +269,8 @@
                  (if (ordinary-float? (interval-end-point ival))
                      (format " &lt; ~a" (interval-end-point ival))
                      ""))))])
+       (printf "<li class='event'>Split input into ~a regimes.</li>\n" (length prevs))
+       (printf "<li>\n")
        (for ([entry prevs] [entry-idx (range (length prevs))] [pred preds])
          (let* ([entry-ivals
                  (filter (λ (intrvl) (= (interval-alt-idx intrvl) entry-idx)) intervals)]
@@ -290,7 +292,10 @@
              (if (null? ivalpoints) (*pcontext*) (mk-pcontext ivalpoints ivalexacts)))
            (parameterize ([*pcontext* new-pcontext])
              (output-history entry))
-           (printf "</ol>\n"))))]
+           (printf "</ol>\n")))
+       (printf "</li>\n")
+       (printf "<li class='event'>Recombined ~a regimes into one program.</li>\n"
+               (length prevs)))]
 
     [(alt-event prog `(taylor ,pt ,loc) `(,prev))
      (output-history prev)

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -59,7 +59,12 @@
   (when bug?
     (printf "<p>Please <a href='https://github.com/uwplse/herbie/issues'>report a bug</a> with the following info:</p>\n"))
   (printf "<pre class='shell'><code>")
-  (printf "herbie --seed '~a'\n" (get-seed))
+  (printf "herbie --seed '~a'" (get-seed))
+  (for ([rec (changed-flags)])
+    (match rec
+      [(list 'enabled class flag) (printf " +o ~a:~a" class flag)]
+      [(list 'disabled class flag) (printf " -o ~a:~a" class flag)]))
+  (printf "\n")
 
   (printf "(FPCore ~a\n" (test-vars test))
   (printf "  :name ~s\n" (test-name test))

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -76,11 +76,11 @@
          (make-plot end-error newpoints #:axis idx #:color *blue-theme*
                     #:out (build-path rdir (format "plot-~ab.png" idx)))
          (printf "<figure>")
-         (printf "<img width='800' height='300' src='plot-~a.png'/>" idx)
-         (printf "<img width='800' height='300' src='plot-~ar.png' data-name='Input'/>" idx)
+         (printf "<img width='800' height='300' src='plot-~a.png' title='The X axis may use a short exponential scale'/>" idx)
+         (printf "<img width='800' height='300' src='plot-~ar.png' title='The X axis may use a short exponential scale' data-name='Input'/>" idx)
          (when target-error
-           (printf "<img width='800' height='300' src='plot-~ag.png' data-name='Target'/>" idx))
-         (printf "<img width='800' height='300' src='plot-~ab.png' data-name='Result'/>" idx)
+           (printf "<img width='800' height='300' src='plot-~ag.png' title='The X axis may use a short exponential scale' data-name='Target'/>" idx))
+         (printf "<img width='800' height='300' src='plot-~ab.png' title='The X axis may use a short exponential scale' data-name='Result'/>" idx)
          (printf "<figcaption>Bits error versus <var>~a</var></figcaption>" var)
          (printf "</figure>\n")))
      (printf "</section>\n")
@@ -98,20 +98,19 @@
 
      (printf "<section id='process-info'>\n")
      (printf "<h1>Runtime</h1>\n")
-     (printf "<div id='runtime'>\n")
+     (printf "<p class='header'>")
      (printf "Total time: <span class='number'>~a</span>\n" (format-time time))
      (printf "<a class='attachment' href='debug.txt'>Debug log</a>")
      (when profile?
-       (printf "<a class='attachment' href='profile.txt'>Profile</a></div>"))
+       (printf "<a class='attachment' href='profile.txt'>Profile</a>"))
+     (printf "</p>")
      (output-timeline timeline)
-     (printf "<div id='reproduce'>\n")
-     (printf "<pre><code>")
+     (printf "<pre class='shell'><code>")
      (printf "herbie --seed '~a'\n" (get-seed))
      (printf "(FPCore ~a\n  :name ~s\n  ~a~a)"
           (test-vars test) (test-name test)
           (if (test-output test) (format "\n  :target\n  ~a" (test-output test)) "") (test-input test))
      (printf "</code></pre>\n")
-     (printf "</div>\n")
      (printf "</section>\n")
 
 

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -153,8 +153,8 @@
                (format-bits (errors-score target-error)))
        (printf "<tr><th>Herbie</th><td>~a</td></tr>\n"
                (format-bits (errors-score end-error)))
-       (printf "</table>\n")
-       (printf "<div>\\[ ~a \\]</div>\n"
+       (printf "</table><!--\n")
+       (printf "--><div>\\[ ~a \\]</div>\n"
                (texify-prog `(λ ,(test-vars test) ,(test-output test))))
        (printf "</section>\n"))
 

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -64,9 +64,8 @@
 
      ; Big bold numbers
      (printf "<section id='large'>\n")
-     (printf "<div>Input Error: <span class='number'>~a</span></div>\n"
-             (format-bits (errors-score start-error) #:unit #f))
-     (printf "<div>Output Error: <span class='number'>~a</span></div>\n"
+     (printf "<div>Error: <span class='number'>~a → ~a</span></div>\n"
+             (format-bits (errors-score start-error) #:unit #f)
              (format-bits (errors-score end-error) #:unit #f))
      (printf "<div>Time: <span class='number'>~a</span></div>\n" (format-time time))
      (printf "<div>Precision: <span class='number'>~a</span></div>\n" (format-bits (*bit-width*) #:unit #f))

--- a/src/reports/make-report.rkt
+++ b/src/reports/make-report.rkt
@@ -135,10 +135,19 @@
        (printf "<tr><th>Points:</th><td>~a</td></tr>\n" (*num-points*))
        (printf "<tr><th>Fuel:</th><td>~a</td></tr>\n" (*num-iterations*))
        (printf "<tr><th>Seed:</th><td>~a</td></tr>\n" seed)
-       (printf "<tr><th>Flags:</th><td id='flag-list'>")
-       (for ([rec (hash->list (*flags*))])
-         (for ([fl (cdr rec)])
-           (printf "<kbd>~a:~a</kbd>" (car rec) fl)))
+       (printf "<tr><th>Flags:</th><td id='flag-list'>\n")
+       (printf "<div id='all-flags'>")
+       (for* ([(class flags) (*flags*)] [flag flags])
+         (printf "<kbd>~a:~a</kbd>" class flag))
+       (printf "</div>\n")
+       (printf "<div id='changed-flags'>")
+       (when (null? (changed-flags))
+         (printf "default"))
+       (for ([rec (changed-flags)])
+         (match rec
+           [(list 'enabled class flag) (printf "<kbd>+o ~a:~a</kbd>")]
+           [(list 'disabled class flag) (printf "<kbd>-o ~a:~a</kbd>")]))
+       (printf "</div>\n")
        (printf "</td></tr>")
        (printf "</table>\n")
 

--- a/src/reports/make-report.rkt
+++ b/src/reports/make-report.rkt
@@ -45,7 +45,7 @@
 
      (copy-file "src/reports/report.js" (build-path dir "report.js") #t)
      (copy-file "src/reports/report.css" (build-path dir "report.css") #t)
-     ;(copy-file "src/reports/graph.css" (build-path dir "graph.css") #t)
+     (copy-file "src/reports/graph.css" (build-path dir "graph.css") #t)
      (copy-file "src/reports/arrow-chart.js" (build-path dir "arrow-chart.js") #t)
 
      (define total-time (apply + (map table-row-time tests)))

--- a/src/reports/report.css
+++ b/src/reports/report.css
@@ -43,7 +43,19 @@ li.timeout    {background-color: #8e8e93; color: #f7f7f7;}
 #about { margin: 3em auto; }
 #about th { font-weight: bold; }
 
+#flag-list { position: relative; }
 #flag-list kbd:not(:last-child):after {content: ", ";}
+#flag-list a {
+    float: right; margin: 0 .5em;
+    color: #2A6496; text-decoration: none; cursor: pointer;
+}
+#flag-list a:before { content: "("; }
+#flag-list a:after { content: ")"; }
+#flag-list a:hover { text-decoration: underline; color: #295785 }
+#flag-list #changed-flags { display: none; }
+#flag-list #all-flags { display: block; }
+#flag-list.changed-flags #changed-flags { display: block; }
+#flag-list.changed-flags #all-flags { display: none; }
 
 #results { border-collapse: collapse; width:100%; }
 #results td { text-align: right; padding: .5em; overflow: hidden; font-size: 15pt; }

--- a/src/reports/report.css
+++ b/src/reports/report.css
@@ -62,6 +62,12 @@ li.timeout    {background-color: #8e8e93; color: #f7f7f7;}
 #results td.bad-est {border-right: 5px solid #c86edf;}
 #results tbody tr:hover {background-color: #e0f8d8; cursor: pointer;}
 
+#results tr { position: relative; }
+#results a {
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0; z-index: 100;
+    padding: .5em;
+}
+
 #results td:nth-child(1) {text-align: left;}
 #results td:nth-child(7) {width: 0;}
 

--- a/src/reports/report.js
+++ b/src/reports/report.js
@@ -58,12 +58,27 @@ function setup_timeline() {
     }
 }
 
+function setup_program_arrow() {
+    var progelt = document.getElementById("program");
+    var progs = progelt.getElementsByClassName("program");
+    var arrs = progelt.getElementsByClassName("arrow");
+
+    progelt.classList.add("horizontal");
+    var progBot = progs[0].offsetTop + progs[0].offsetHeight;
+    for (var i in progs) {
+        if (progs[i].offsetTop >= progBot) {
+            return progelt.classList.remove("horizontal");
+        }
+    }
+}
+
 function load_graph() {
     var figs = document.querySelectorAll("#graphs figure");
     for (var i = 0; i < figs.length; i++) {
         setup_figure(figs[i]);
     }
     setup_timeline();
+    setup_program_arrow();
 }
 
 function report() {load_report();}

--- a/src/reports/report.js
+++ b/src/reports/report.js
@@ -33,6 +33,7 @@ function toggle_figure(figure, name) {
 
 function setup_figure(figure) {
     var names = figure_names(figure);
+    var caption_text = figure.querySelector("figcaption p");
     for (var name in names) {
         var control = document.createElement("button");
         control.className = name;
@@ -43,7 +44,7 @@ function setup_figure(figure) {
                 toggle_figure(figure, name);
             });
         })(name);
-        figure.querySelector("figcaption").appendChild(control);
+        figure.querySelector("figcaption").insertBefore(control, caption_text);
     }
 }
 
@@ -72,15 +73,16 @@ function setup_figure_tabs(figure_container) {
         if (figures[i].classList.contains("default")) default_figure = idx;
         figure_array[idx] = { elt: figures[i], name: variable };
         figures[i].style.display = "none";
+        figures[i].querySelector("figcaption > p").style.display = "none";
     }
     if (default_figure === null) default_figure = figures[0].id;
 
     var tab_bar = document.createElement("ul");
     tab_bar.classList.add("tabbar");
     var p = document.createElement("p");
-    p.innerText = "Variable:"
+    p.innerText = "Bits error vs value of"
     tab_bar.appendChild(p)
-    figure_container.insertBefore(tab_bar, figures[0]);
+    figure_container.appendChild(tab_bar);
     for (var idx in figure_array) {
         var tab_button = document.createElement("li");
         tab_button.id = "tab-" + idx;

--- a/src/reports/report.js
+++ b/src/reports/report.js
@@ -47,6 +47,53 @@ function setup_figure(figure) {
     }
 }
 
+function select_tab(id) {
+    var tab = document.getElementById("tab-" + id);
+    var pane = document.getElementById(id);
+
+    var old_tab = tab.parentNode.getElementsByClassName("selected");
+    if (old_tab.length > 0) {
+        var old_pane = document.getElementById(old_tab[0].id.substr(4));
+        old_pane.style.display = "none";
+        old_tab[0].classList.remove("selected")
+    }
+
+    tab.classList.add("selected");
+    pane.style.display = "block";
+}
+
+function setup_figure_tabs(figure_container) {
+    var figures = figure_container.getElementsByTagName("figure");
+    var figure_array = {};
+    var default_figure = null;
+    for (var i = 0; i < figures.length; i++) {
+        var idx = figures[i].id;
+        var variable = figures[i].getElementsByTagName("var")[0].innerText;
+        if (figures[i].classList.contains("default")) default_figure = idx;
+        figure_array[idx] = { elt: figures[i], name: variable };
+        figures[i].style.display = "none";
+    }
+    if (default_figure === null) default_figure = figures[0].id;
+
+    var tab_bar = document.createElement("ul");
+    tab_bar.classList.add("tabbar");
+    var p = document.createElement("p");
+    p.innerText = "Variable:"
+    tab_bar.appendChild(p)
+    figure_container.insertBefore(tab_bar, figures[0]);
+    for (var idx in figure_array) {
+        var tab_button = document.createElement("li");
+        tab_button.id = "tab-" + idx;
+        tab_button.innerText = figure_array[idx].name;
+        tab_button.addEventListener("click", function() {
+            select_tab(this.id.substr(4));
+        });
+        tab_bar.appendChild(tab_button);
+    }
+
+    select_tab(default_figure);
+}
+
 function setup_timeline() {
     var ts = document.getElementsByClassName("timeline-phase");
     var total_time = 0;
@@ -78,6 +125,7 @@ function load_graph() {
     for (var i = 0; i < figs.length; i++) {
         setup_figure(figs[i]);
     }
+    setup_figure_tabs(document.querySelector("#graphs div"));
     setup_timeline();
     // Run the program_arrow after rendering happens
     MathJax.Hub.Queue(setup_program_arrow);

--- a/src/reports/report.js
+++ b/src/reports/report.js
@@ -78,7 +78,8 @@ function load_graph() {
         setup_figure(figs[i]);
     }
     setup_timeline();
-    setup_program_arrow();
+    // Run the program_arrow after rendering happens
+    MathJax.Hub.Queue(setup_program_arrow);
 }
 
 function report() {load_report();}

--- a/src/reports/report.js
+++ b/src/reports/report.js
@@ -11,7 +11,6 @@ function clickable_rows(elt) {
 
 function toggle_flag_list() {
     var flags = document.getElementById("flag-list");
-    console.log(flags);
     flags.classList.toggle("changed-flags");
     var changed_only = flags.classList.contains("changed-flags");
     var button = document.getElementById("flag-list-toggle");

--- a/src/reports/report.js
+++ b/src/reports/report.js
@@ -2,11 +2,30 @@ function tr_click() {
     this.querySelector("td a").click();
 }
 
-function load_report() {
-    var trs = document.querySelectorAll("tbody tr");
+function clickable_rows(elt) {
+    var trs = elt.querySelectorAll("tbody tr");
     for (var i = 0; i < trs.length; i++) {
         trs[i].addEventListener("click", tr_click);
     }
+}
+
+function toggle_flag_list() {
+    var flags = document.getElementById("flag-list");
+    console.log(flags);
+    flags.classList.toggle("changed-flags");
+    var changed_only = flags.classList.contains("changed-flags");
+    var button = document.getElementById("flag-list-toggle");
+    button.innerText = changed_only ? "see all" : "see diff";
+}
+
+function togglable_flags() {
+    var flags = document.getElementById("flag-list");
+    flags.classList.add("changed-flags");
+    var button = document.createElement("a");
+    button.setAttribute("id", "flag-list-toggle");
+    button.innerText = "see all";
+    button.addEventListener("click", toggle_flag_list);
+    flags.insertBefore(button, flags.children[0]);
 }
 
 function figure_names(figure) {
@@ -133,6 +152,15 @@ function load_graph() {
     MathJax.Hub.Queue(setup_program_arrow);
 }
 
+function load_report() {
+    clickable_rows(document.getElementById("results"));
+    togglable_flags();
+}
+
+function load_index() {
+    clickable_rows(document.getElementById("reports"));
+}
+
 function report() {load_report();}
 function graph() {load_graph();}
-function index() {load_report();}
+function index() {load_index();}

--- a/src/reports/report.js
+++ b/src/reports/report.js
@@ -1,14 +1,3 @@
-function tr_click() {
-    this.querySelector("td a").click();
-}
-
-function clickable_rows(elt) {
-    var trs = elt.querySelectorAll("tbody tr");
-    for (var i = 0; i < trs.length; i++) {
-        trs[i].addEventListener("click", tr_click);
-    }
-}
-
 function toggle_flag_list() {
     var flags = document.getElementById("flag-list");
     flags.classList.toggle("changed-flags");
@@ -152,12 +141,11 @@ function load_graph() {
 }
 
 function load_report() {
-    clickable_rows(document.getElementById("results"));
     togglable_flags();
 }
 
 function load_index() {
-    clickable_rows(document.getElementById("reports"));
+    // Nothing
 }
 
 function report() {load_report();}

--- a/src/reports/report.js
+++ b/src/reports/report.js
@@ -37,6 +37,7 @@ function setup_figure(figure) {
         var control = document.createElement("button");
         control.className = name;
         control.textContent = name;
+        control.title = ("Click to toggle " + name.toLowerCase() + " graph");
         (function(name){
             control.addEventListener("click", function() {
                 toggle_figure(figure, name);


### PR DESCRIPTION
Totally reworks the details pages generated by the reports script for every input.

+ Bigger graphs, with tabs for different variables
+ Larger and clearer design
+ More compact derivations
+ Easier reproduction
+ Mark regimes on plot
+ Saner tick marks on plot
+ Nicer error and timeout pages
+ Python-style, not math-style, TeX for `if` statements

This feature is intended for the 1.1 release.