### PR TITLE
Syntax check info

### DIFF
--- a/bench/numerics/fma.fpcore
+++ b/bench/numerics/fma.fpcore
@@ -1,0 +1,21 @@
+; -*- mode: scheme -*-
+
+(FPCore (t)
+ :name "fma_test1"
+ :herbie-samplers ([t (uniform 0.9 1.1)])
+ :target
+ (let ([x (+ 1 (* t 2e-16))]
+       [z (- -1 (* 2 (* t 2e-16)))])
+   (fma x x z))
+ (let ([x (+ 1 (* t 2e-16))]
+       [z (- -1 (* 2 (* t 2e-16)))])
+   (+ (* x x) z)))
+
+(FPCore (t)
+ :name "fma_test2"
+ :herbie-samplers ([t (uniform 1.9 2.1)])
+ :target
+ (let ([x 1.7e308])
+   (fma x t (- x)))
+ (let ([x 1.7e308])
+   (- (* x t) x)))

--- a/infra/index.css
+++ b/infra/index.css
@@ -37,12 +37,10 @@ figure a { color: black; text-decoration: none; display: block; }
 #reports td:nth-child(2), #reports th:nth-child(2) { text-align: center; display: none; }
 #reports td:nth-child(3) { text-align: center; }
 #reports thead { border-bottom: 1px solid black; height: 5em; vertical-align: bottom; }
-#results tr { position: relative; }
-#results a {
-    position: absolute; top: 0; left: 0; right: 0; bottom: 0; z-index: 100;
-    padding: .5em;
+#reports a {
+    position: absolute; left: 0; right: 0; z-index: 100;
+    padding: .5em; margin-top: -1.25em;
 }
-
 #reports thead:after {
     position: absolute; width: 300px; text-align: left; right: -325px;
     font-size: 32px; color: #888; content: attr(data-branch);

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -44,7 +44,7 @@
                      (parameterize ([*flags* default-flags]) (has-flag? class flag)))
               [(#t #t) #f]
               [(#f #f) #f]
-              [(#t #f) (list 'enabled class flags)]
+              [(#t #f) (list 'enabled class flag)]
               [(#f #t) (list 'disabled class flag)]))))
 
 (define ((flag type f) a b)

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -73,4 +73,4 @@
 
 (define *binary-search-test-points* (make-parameter 16))
 
-(define *herbie-version* "1.0")
+(define *herbie-version* "1.1")

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -34,7 +34,8 @@
 (define (has-flag? class flag)
   (set-member? (dict-ref (*flags*) class) flag))
 
-(define *flags* (make-parameter (hash-copy default-flags)))
+; `hash-copy` returns a mutable hash, which makes `dict-update` invalid
+(define *flags* (make-parameter (make-immutable-hash (hash->list default-flags))))
 
 (define (changed-flags)
   (filter identity

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -2,7 +2,8 @@
 (require "config.rkt")
 (provide raise-herbie-error raise-herbie-syntax-error
          herbie-error->string 
-         (struct-out exn:fail:user:herbie))
+         (struct-out exn:fail:user:herbie)
+         (struct-out exn:fail:user:herbie:syntax))
 
 (struct exn:fail:user:herbie exn:fail:user (url)
         #:extra-constructor-name make-exn:fail:user:herbie)

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -7,7 +7,7 @@
 (struct exn:fail:user:herbie exn:fail:user (url)
         #:extra-constructor-name make-exn:fail:user:herbie)
 
-(struct exn:fail:user:herbie:syntax exn:fail:user:herbie (locations messages)
+(struct exn:fail:user:herbie:syntax exn:fail:user:herbie (locations)
         #:extra-constructor-name make-exn:fail:user:herbie:syntax)
 
 (define (raise-herbie-error message #:url [url #f] . args)
@@ -22,10 +22,6 @@
   (with-output-to-string
     (λ ()
       (match err
-        [(exn:fail:user:herbie message marks url)
-         (eprintf "~a\n" message)
-         (when url
-           (eprintf "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url))]
         [(exn:fail:user:herbie:syntax message marks url locations)
          (eprintf "~a\n" message)
          (for ([(stx message) (in-dict locations)])
@@ -37,7 +33,11 @@
            (eprintf "  ~a:~a:~a: ~a\n" file (or (syntax-line stx) "")
                     (or (syntax-column stx) (syntax-position stx)) message))
          (when url
-           (eprintf "See <https://herbie.uwplse.org/doc/~a/~a\n" *herbie-version* url)])))))
+           (eprintf "See <https://herbie.uwplse.org/doc/~a/~a\n" *herbie-version* url))]
+        [(exn:fail:user:herbie message marks url)
+         (eprintf "~a\n" message)
+         (when url
+           (eprintf "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url))]))))
 
 (define old-error-display-handler (error-display-handler))
 (error-display-handler

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -1,24 +1,43 @@
 #lang racket
 (require "config.rkt")
-(provide raise-herbie-error herbie-error->string
+(provide raise-herbie-error raise-herbie-syntax-error
+         herbie-error->string 
          (struct-out exn:fail:user:herbie))
 
-(struct exn:fail:user:herbie exn:fail:user (url location)
+(struct exn:fail:user:herbie exn:fail:user (url)
         #:extra-constructor-name make-exn:fail:user:herbie)
 
-(define (raise-herbie-error message #:location [location #f] #:url [url #f] . args)
+(struct exn:fail:user:herbie:syntax exn:fail:user:herbie (locations messages)
+        #:extra-constructor-name make-exn:fail:user:herbie:syntax)
+
+(define (raise-herbie-error message #:url [url #f] . args)
   (raise (make-exn:fail:user:herbie
-          (apply format message args) (current-continuation-marks) url location)))
+          (apply format message args) (current-continuation-marks) url)))
+
+(define (raise-herbie-syntax-error message #:url [url "faq.html#invalid-syntax"] #:locations [locations '()] . args)
+  (raise (make-exn:fail:user:herbie:syntax
+          (apply format message args) (current-continuation-marks) url locations)))
 
 (define (herbie-error->string err)
-  (match-define (exn:fail:user:herbie message marks url location) err)
   (with-output-to-string
     (λ ()
-      (when location
-        (eprintf "~a: " (string-join (map ~a location))))
-      (eprintf "~a\n" message)
-      (when url
-        (eprintf "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url)))))
+      (match err
+        [(exn:fail:user:herbie message marks url)
+         (eprintf "~a\n" message)
+         (when url
+           (eprintf "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url))]
+        [(exn:fail:user:herbie:syntax message marks url locations)
+         (eprintf "~a\n" message)
+         (for ([(stx message) (in-dict locations)])
+           (define file
+             (if (path? (syntax-source stx))
+                 (let-values ([(base name dir?) (split-path (syntax-source stx))])
+                   (path->string name))
+                 (syntax-source stx)))
+           (eprintf "  ~a:~a:~a: ~a\n" file (or (syntax-line stx) "")
+                    (or (syntax-column stx) (syntax-position stx)) message))
+         (when url
+           (eprintf "See <https://herbie.uwplse.org/doc/~a/~a\n" *herbie-version* url)])))))
 
 (define old-error-display-handler (error-display-handler))
 (error-display-handler

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -7,7 +7,6 @@
         #:extra-constructor-name make-exn:fail:user:herbie)
 
 (define (raise-herbie-error message #:location [location #f] #:url [url #f] . args)
-  
   (raise (make-exn:fail:user:herbie
           (apply format message args) (current-continuation-marks) url location)))
 
@@ -24,6 +23,11 @@
 (define old-error-display-handler (error-display-handler))
 (error-display-handler
  (λ (message err)
-   (if (exn:fail:user:herbie? err)
-       (display (herbie-error->string err) (current-error-port))
-       (old-error-display-handler message err))))
+   (cond
+    [(exn:fail:user:herbie? err)
+     (display (herbie-error->string err) (current-error-port))]
+    [(exn:fail:read? err)
+     (printf "~a in ~a.\nSee <https://herbie.uwplse.org/doc/~a/input.html> for more.\n"
+             (exn-message err) (srcloc-source (car (exn:fail:read-srclocs err))) *herbie-version*)]
+    [else
+     (old-error-display-handler message err)])))

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -19,7 +19,7 @@
         (eprintf "~a: " (string-join (map ~a location))))
       (eprintf "~a\n" message)
       (when url
-        (eprintf "See <https://herbie.uwplse.org/~a/~a> for more.\n" *herbie-version* url)))))
+        (eprintf "See <https://herbie.uwplse.org/doc/~a/~a> for more.\n" *herbie-version* url)))))
 
 (define old-error-display-handler (error-display-handler))
 (error-display-handler

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -47,7 +47,7 @@
     [(exn:fail:user:herbie? err)
      (display (herbie-error->string err) (current-error-port))]
     [(exn:fail:read? err)
-     (printf "~a in ~a.\nSee <https://herbie.uwplse.org/doc/~a/input.html> for more.\n"
-             (exn-message err) (srcloc-source (car (exn:fail:read-srclocs err))) *herbie-version*)]
+     (printf "Invalid syntax\n  ~a\nSee <https://herbie.uwplse.org/doc/~a/input.html> for more.\n"
+             (exn-message err) *herbie-version*)]
     [else
      (old-error-display-handler message err)])))

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -41,20 +41,7 @@
      (define samps (map (lambda (x) (car (dict-ref samp-dict x '(default)))) args))
 
      (define body* (desugar-program body))
-
-     (match (check-expression (last (syntax->list stx)) args)
-       [(list) (void)]
-       [(list (cons stxs msgs) ...)
-        (define err-lines
-          (for/list ([stx stxs] [msg msgs])
-            (define file
-              (if (path? (syntax-source stx))
-                  (let-values ([(base name dir?) (split-path (syntax-source stx))])
-                    (path->string name))
-                  (syntax-source stx)))
-            (format "  ~a:~a:~a: ~a" file (or (syntax-line stx) "") (or (syntax-column stx) (syntax-position stx)) msg)))
-        (raise-herbie-error (format "Invalid syntax in ~a.\n~a" (syntax-source stx) (string-join err-lines "\n"))
-                            #:url "faq.html#invalid-syntax")])
+     (assert-expression! (last (syntax->list stx)) args)
 
      (test (~a (dict-ref prop-dict ':name body))
            args samps

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -91,7 +91,7 @@
     (load-file fname)))
 
 (define (load-tests [path benchmark-path])
-  (define path* (if (string? path) (path->string path) path))
+  (define path* (if (string? path) (string->path path) path))
   (if (directory-exists? path*)
       (load-directory path*)
       (load-file path*)))

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -65,9 +65,6 @@
     (λ (port)
       (define tests (for/list ([test (in-port (curry read-syntax file) port)])
                       (parse-test test)))
-      (let ([duplicate-name (check-duplicates tests #:key test-name)])
-        (assert (not duplicate-name)
-                #:extra-info (λ () (format "Two tests with the same name ~a" duplicate-name))))
       tests)))
 
 (define (is-racket-file? f)

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -54,7 +54,7 @@
                   (syntax-source stx)))
             (format "  ~a:~a:~a: ~a" file (or (syntax-line stx) "") (or (syntax-column stx) (syntax-position stx)) msg)))
         (raise-herbie-error (format "Invalid syntax in ~a.\n~a" (syntax-source stx) (string-join err-lines "\n"))
-                            #:url "faq.html#invalid-program")])
+                            #:url "faq.html#invalid-syntax")])
 
      (test (~a (dict-ref prop-dict ':name body))
            args samps

--- a/src/plot.rkt
+++ b/src/plot.rkt
@@ -94,7 +94,7 @@
      (if (<= min 1.0 max) (list (pre-tick 1.0 #t)) '())
      (if (<= min 0.0 max) (pre-tick 0.0 #t) '())
      (if (<= min -1.0 max) (pre-tick -1.0 #t) '())
-     ((ticks-layout (ticks-scale (linear-ticks #:number 10 #:base 10 #:divisors '(1 2 5)) double-transform))))]
+     ((ticks-layout (ticks-scale (linear-ticks #:number 10 #:base 10 #:divisors '(1 2 5)) double-transform)) min max))]
    [else
     (define necessary (filter identity (map (curry index-of possible) '(1.0 0.0 -1.0))))
     (define major-indices (pick-spaced-indices necessary (length possible) 12))

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -198,7 +198,7 @@
       [(exn:fail:user:herbie? exn)
        (printf "<section id='user-error'>\n")
        (printf "<h2>~a <a href='https://herbie.uwplse.org/~a/~a'>(more)</a></h2>\n"
-               (exn-message) *herbie-version* (exn:fail:user:herbie-url url))
+               (exn-message exn) *herbie-version* (exn:fail:user:herbie-url exn))
 
        (when (exn:fail:user:herbie:syntax? exn)
          (printf "<table>\n")
@@ -208,7 +208,7 @@
          (for ([(stx msg) (in-dict (exn:fail:user:herbie:syntax-locations exn))])
            (printf "<tr><td class='procedure'>~a</td><td>~a</td><td>~a</td><td>~a</td></tr>\n"
                    msg (syntax-source stx) (or (syntax-line stx) "")
-                   (or (syntax-column col) (syntax-position stx))))
+                   (or (syntax-column stx) (syntax-position stx))))
          (printf "</table>\n"))
 
        (printf "</section>")]

--- a/src/reports/make-report.rkt
+++ b/src/reports/make-report.rkt
@@ -145,8 +145,8 @@
          (printf "default"))
        (for ([rec (changed-flags)])
          (match rec
-           [(list 'enabled class flag) (printf "<kbd>+o ~a:~a</kbd>")]
-           [(list 'disabled class flag) (printf "<kbd>-o ~a:~a</kbd>")]))
+           [(list 'enabled class flag) (printf "<kbd>+o ~a:~a</kbd>" class flag)]
+           [(list 'disabled class flag) (printf "<kbd>-o ~a:~a</kbd>" class flag)]))
        (printf "</div>\n")
        (printf "</td></tr>")
        (printf "</table>\n")

--- a/src/reports/report.css
+++ b/src/reports/report.css
@@ -62,10 +62,9 @@ li.timeout    {background-color: #8e8e93; color: #f7f7f7;}
 #results td.bad-est {border-right: 5px solid #c86edf;}
 #results tbody tr:hover {background-color: #e0f8d8; cursor: pointer;}
 
-#results tr { position: relative; }
 #results a {
-    position: absolute; top: 0; left: 0; right: 0; bottom: 0; z-index: 100;
-    padding: .5em;
+    position: absolute; left: 0; right: 0; z-index: 100;
+    padding: .5em; margin-top: -1.25em;
 }
 
 #results td:nth-child(1) {text-align: left;}

--- a/src/reports/rerun.rkt
+++ b/src/reports/rerun.rkt
@@ -28,7 +28,7 @@
   (define tests
     (for/list ([row (report-info-tests data)])
       (test (table-row-name row) (table-row-vars row)
-            (table-row-samplers row) (table-row-input row) (table-row-output row) #t 'TRUE)))
+            (table-row-samplers row) (table-row-input row) (table-row-output row) #f #t 'TRUE)))
   (*flags* (report-info-flags data))
   (set-seed! (report-info-seed data))
   (*num-points* (report-info-points data))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -134,13 +134,13 @@
                    link)))]
    [(test-failure? result)
     (define link (path-element->string (last (explode-path rdir))))
-    (match-define (test name vars sampling-expr input output _ pre) (test-failure-test result))
-    (table-row (test-name (test-failure-test result)) "crash"
-               #f #f #f #f #f #f vars sampling-expr input #f
+    (define test (test-failure-test result))
+    (table-row (test-name test) "crash"
+               #f #f #f #f #f #f (test-sampling-expr test) (test-input test) #f
                (test-failure-time result) (test-failure-bits result) link)]
    [(test-timeout? result)
     (define link (path-element->string (last (explode-path rdir))))
-    (match-define (test name vars sampling-expr input output _ pre) (test-timeout-test result))
+    (define test (test-failure-test result))
     (table-row (test-name (test-timeout-test result)) "timeout"
-               #f #f #f #f #f #f vars sampling-expr input #f
+               #f #f #f #f #f #f (test-sampling-expr test) (test-input test) #f
                (test-timeout-time result) (test-timeout-bits result) link)]))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -400,7 +400,8 @@
   [expm1-log1p (expm1 (log1p x))          x]
   [hypot-def   (sqrt (+ (sqr x) (sqr y))) (hypot x y)]
   [hypot-1-def (sqrt (+ 1 (sqr y)))       (hypot 1 y)]
-  [fma-def     (+ (* x y) z)              (fma x y z)])
+  [fma-def     (+ (* x y) z)              (fma x y z)]
+  [fma-neg     (- (* x y) z)              (fma x y (- z))])
 
 (define-ruleset special-numerical-expand (numerics)
   [expm1-udef    (expm1 x)      (- (exp x) 1)]

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -88,7 +88,7 @@
                      #:seed *fixed-seed*
                      #:setup! (λ () (set-debug-level! 'progress '(3 4)))
                      #:debug p
-                     (test name vars (map (const 'default) vars) body #f #f 'TRUE))))))
+                     (test name vars (map (const 'default) vars) body #f #f #f 'TRUE))))))
 
           (define make-page
             (cond [(test-result? result) make-graph]

--- a/www/doc/1.1/faq.html
+++ b/www/doc/1.1/faq.html
@@ -25,7 +25,7 @@
     information and debugging tips.
   </p>
   
-  <h3 id="invalid-syntax">“Invalid synatx” error</h3>
+  <h3 id="invalid-syntax">“Invalid syntax” error</h3>
 
   <p>
     This error means you mis-formatted Herbie's input. Common errors

--- a/www/doc/1.1/faq.html
+++ b/www/doc/1.1/faq.html
@@ -25,17 +25,16 @@
     information and debugging tips.
   </p>
   
-  <h3 id="invalid-program">“Invalid program” error</h3>
+  <h3 id="invalid-syntax">“Invalid synatx” error</h3>
 
   <p>
-    This error is most likely due to an error in preparing the input
-    to Herbie. Common errors include misspelling function names and
-    parenthesizing expressions that must not be parenthesized. The
-    stack trace will contain additional information. For example, in
-    the expression <code>(- (exp (x)) 1)</code>, the use
-    of <code>x</code> as invalid because <code>x</code> is a variable,
-    so cannot be parenthesized. <code>(- (exp x) 1)</code> would
-    be the correct way of describing that expression.
+    This error means you mis-formatted Herbie's input. Common errors
+    include misspelling function names and parenthesizing expressions
+    that must not be parenthesized. For example, in 
+    <code>(- (exp (x)) 1)</code>, <code>(x)</code> is incorrect:
+    <code>x</code> is a variable so isn't parenthesized. <code>(- (exp
+    x) 1)</code> would be the correct way of writing that expression.
+    The error message will contain additional information.
   </p>
   
   <h3 id="sample-valid-points">“Cannot sample enough valid points” error</h3>


### PR DESCRIPTION
Print error messages for invalid syntax with line and column info, and with more-detailed error messages.

This should make it much easier to fix FPCore syntax bugs. Note that bad parenthisation still triggers a not-too-user-friendly error message, unfortunately.