### PR TITLE
Teach series expansion about function definitions

### DIFF
--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -87,8 +87,12 @@
         (cons (pattern-substitute (rule-output rule) bindings) bindings)
         #f)))
 
-(define (rule-rewrite rule prog loc)
-  (location-do loc prog (compose car (curry rule-apply rule))))
+(define (rule-rewrite rule prog [loc '()])
+  (let/ec return
+    (location-do loc prog
+                 (λ (x) (match (rule-apply rule x)
+                          [(cons out bindings) out]
+                          [#f (return #f)])))))
 
 (define (rule-apply-force-destructs rule expr)
   (and (not (symbol? (rule-input rule))) (rule-apply rule expr)))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -1,10 +1,7 @@
 #lang racket
 
-(require "../common.rkt")
-(require "../programs.rkt")
-(require "matcher.rkt")
-(require "../syntax/rules.rkt")
-(require "../syntax/syntax.rkt")
+(require "../common.rkt" "../programs.rkt" "matcher.rkt"
+         "../function-definitions.rkt" "../syntax/rules.rkt" "../syntax/syntax.rkt")
 
 (provide simplify)
 
@@ -20,7 +17,8 @@
     (debug #:from 'backup-simplify "Simplify" expr "into" simpl)
     simpl))
 
-(define (simplify* expr)
+(define (simplify* expr*)
+  (define expr ((get-evaluator) expr*))
   (match expr
     [(? constant?) expr]
     [(? variable?) expr]

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -2,6 +2,7 @@
 
 (require math/number-theory)
 (require "../common.rkt")
+(require "../function-definitions.rkt")
 (require "../programs.rkt")
 (require "reduce.rkt")
 (require "matcher.rkt")
@@ -154,17 +155,24 @@
           (loop (- i (length seg)) (+ sum 1))
           (list-ref seg i)))))
 
-(define (taylor var expr)
+(define taylor-expansion-known
+  '(+ - * / sqr sqrt exp sin cos log pow))
+
+(define (taylor var expr*)
   "Return a pair (e, n), such that expr ~= e var^n"
-  (debug #:from 'taylor "Taking taylor expansion of" expr "in" var)
+  (debug #:from 'taylor "Taking taylor expansion of" expr* "in" var)
+  (define expr
+    (if (and (list? expr*) (not (set-member? taylor-expansion-known (car expr*))))
+        ((get-expander taylor-expansion-known) expr*)
+        expr*))
+  (unless (equal? expr expr*)
+    (debug #:from 'taylor "Rewrote expression to" expr))
   (match expr
     [(? (curry equal? var))
      (taylor-exact 0 1)]
     [(? constant?)
      (taylor-exact expr)]
     [(? variable?)
-     (taylor-exact expr)]
-    [`(fabs ,arg)
      (taylor-exact expr)]
     [`(+ ,args ...)
      (apply taylor-add (map (curry taylor var) args))]
@@ -180,10 +188,6 @@
      (taylor-invert (taylor var arg))]
     [`(/ ,num ,den)
      (taylor-quotient (taylor var num) (taylor var den))]
-    [`(if ,cond ,btrue ,bfalse)
-     (taylor-exact expr)]
-    [`(fmod ,a ,b)
-     (taylor-exact expr)]
     [`(sqr ,a)
      (let ([ta (taylor var a)])
        (taylor-mult ta ta))]
@@ -238,8 +242,6 @@
      (cons (- power) (λ (n) (if (= n 0) 1 0)))]
     [`(pow ,base ,power)
      (taylor var `(exp (* ,power (log ,base))))]
-    [`(tan ,arg)
-     (taylor var `(/ (sin ,arg) (cos ,arg)))]
     [_
      (taylor-exact expr)]))
 

--- a/src/function-definitions.rkt
+++ b/src/function-definitions.rkt
@@ -1,0 +1,62 @@
+#lang racket
+
+(require "config.rkt" "syntax/syntax.rkt" "syntax/rules.rkt" "core/matcher.rkt" "programs.rkt")
+(provide get-expander get-evaluator)
+
+(define (evaluation-rule? rule)
+  (and (list? (rule-input rule))
+       (null? (free-variables (rule-input rule)))))
+
+(define (definition-rule? rule)
+  (and (list? (rule-input rule))
+       (andmap variable? (cdr (rule-input rule)))))
+
+(define (all-ops expr good?)
+  (match expr
+    [(? constant?) #t]
+    [(? variable?) #t]
+    [(list f args ...)
+     (and (good? f) (andmap (curryr all-ops good?) args))]))
+
+(define expanders (make-hash))
+(define evaluators (make-hash))
+
+(define (make-expander primitives)
+  (define known-functions (make-hash))
+  (for ([op primitives])
+    (dict-set! known-functions op #f))
+  (define known-function? (curry dict-has-key? known-functions))
+
+  (define definition-rules (filter definition-rule? (*rules*)))
+
+  (let loop ()
+    (define continue? #f)
+    (for ([rule definition-rules])
+      (define op (car (rule-input rule)))
+      (when (and (not (known-function? op))
+                 (all-ops (rule-output rule) known-function?))
+        (dict-set! known-functions op rule)
+        (set! continue? #t))))
+
+  (define (simplify expr)
+    (and (list? expr)
+         (dict-ref known-functions (car expr) #f)
+         (rule-rewrite (dict-ref known-functions (car expr)) expr)))
+
+  (λ (expr)
+    (let loop ([expr expr])
+      (let ([expr* (simplify expr)])
+        (if expr* (loop expr*) expr)))))
+
+(define (make-evaluator)
+  (define evaluation-rules
+    (for/hash ([rule (*rules*)] #:when (evaluation-rule? rule))
+      (values (rule-input rule) (rule-output rule))))
+
+  (λ (expr) (dict-ref evaluation-rules expr expr)))
+
+(define (get-expander primitives)
+  (hash-ref! expanders (cons primitives (*flags*)) (λ () (make-expander primitives))))
+
+(define (get-evaluator)
+  (hash-ref! evaluators (*flags*) (λ () (make-evaluator))))


### PR DESCRIPTION
When one function is an alias for simpler functions, such as `(tan x)` for `(/ (sin x) (cos x))`, we normally have rules expanding on this definition. With this change, series expansion can now use those rules for series-expansion automatically.