### PR TITLE
Pin Racket version in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM jackfirth/racket:6.8
 MAINTAINER Pavel Panchekha <me@pavpanchekha.com>
+RUN apt-get update \
+ && apt-get install -y libcairo2-dev libjpeg62 libpango1.0-dev \
+ && rm -rf /var/lib/apt/lists/*
 ADD src /src/herbie
 RUN raco pkg install --auto /src/herbie
 ENTRYPOINT ["raco", "herbie"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jackfirth/racket
+FROM jackfirth/racket:6.8
 MAINTAINER Pavel Panchekha <me@pavpanchekha.com>
 RUN apt-get update \
  && apt-get install -y libcairo2-dev libjpeg62 libpango1.0-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM jackfirth/racket:6.8
 MAINTAINER Pavel Panchekha <me@pavpanchekha.com>
-RUN apt-get update \
- && apt-get install -y libcairo2-dev libjpeg62 libpango1.0-dev \
- && rm -rf /var/lib/apt/lists/*
 ADD src /src/herbie
 RUN raco pkg install --auto /src/herbie
 ENTRYPOINT ["raco", "herbie"]


### PR DESCRIPTION
This pins the Racket version in Docker to Racket 6.8.

I also removed a line which installed a bunch of packages. @jackfirth, do you know why that line is in there?