### PR TITLE
Support zero-argument expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
       HERBIE_SEED="#f"
 matrix:
   allow_failures:
-    - env: RACKET_VERSION="6.5"
+    - env: RACKET_VERSION="6.7"
            HERBIE_SEED="#f"
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -17,10 +17,10 @@
 (provide infer-splitpoints (struct-out sp) splitpoints->point-preds)
 
 (define (infer-splitpoints alts [axis #f])
-  (cond
-   [(null? (program-variables (*start-prog*)))
-    (list (list (sp 0 0 +inf.0)) (list (argmin (compose errors-score alt-errors) alts)))]
-   [else
+  (match alts
+   [(list alt)
+    (list (list (sp 0 0 +inf.0)) (list alt))]
+   [_
     (debug "Finding splitpoints for:" alts #:from 'regime-changes #:depth 2)
     (define options
       (map (curry option-on-expr alts)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -17,19 +17,23 @@
 (provide infer-splitpoints (struct-out sp) splitpoints->point-preds)
 
 (define (infer-splitpoints alts [axis #f])
-  (debug "Finding splitpoints for:" alts #:from 'regime-changes #:depth 2)
-  (define options
-    (map (curry option-on-expr alts)
-         (if axis (list axis) (exprs-to-branch-on alts))))
-  (define options*
-    (for/list ([option options] #:unless (check-duplicates (map sp-point (option-splitpoints option))))
-      option))
-  (define best-option (argmin (compose errors-score option-errors) options*))
-  (define splitpoints (option-splitpoints best-option))
-  (define altns (used-alts splitpoints alts))
-  (define splitpoints* (coerce-indices splitpoints))
-  (debug #:from 'regimes "Found splitpoints:" splitpoints* ", with alts" altns)
-  (list splitpoints* altns))
+  (cond
+   [(null? (program-variables (*start-prog*)))
+    (list (list (sp 0 0 +inf.0)) (list (argmin (compose errors-score alt-errors) alts)))]
+   [else
+    (debug "Finding splitpoints for:" alts #:from 'regime-changes #:depth 2)
+    (define options
+      (map (curry option-on-expr alts)
+           (if axis (list axis) (exprs-to-branch-on alts))))
+    (define options*
+      (for/list ([option options] #:unless (check-duplicates (map sp-point (option-splitpoints option))))
+        option))
+    (define best-option (argmin (compose errors-score option-errors) options*))
+    (define splitpoints (option-splitpoints best-option))
+    (define altns (used-alts splitpoints alts))
+    (define splitpoints* (coerce-indices splitpoints))
+    (debug #:from 'regimes "Found splitpoints:" splitpoints* ", with alts" altns)
+    (list splitpoints* altns)]))
 
 (struct option (splitpoints errors) #:transparent
 	#:methods gen:custom-write


### PR DESCRIPTION
For zero-argument expressions, inferring a split-point just chooses the
best alternative. This is the correctly handled by the rest of the code.