### PR TITLE
Add variary comparators

### DIFF
--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -116,7 +116,7 @@
     [(list f args ...)
      (if (hash-has-key? (*operations*) (syntax->datum f))
          (let ([num-args (list-ref (hash-ref (*operations*) (syntax->datum f)) mode:args)])
-           (unless (set-member? num-args (length args))
+           (unless (or (set-member? num-args (length args)) (set-member? num-args '*))
              (error! stx "Operator ~a given ~a arguments (expects ~a)"
                                  (syntax->datum f) (length args) (string-join (map ~a num-args) " or "))))
          (error! stx "Unknown operator ~a" (syntax->datum f)))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -129,6 +129,16 @@
 (define (and-fn . as) (andmap identity as))
 (define (or-fn  . as) (ormap identity as))
 
+(define (!=-fn . args)
+  (not (check-duplicates args =)))
+
+(define (bf!=-fn . args)
+  (not (check-duplicates args bf=)))
+
+(define ((comparator test) . args)
+  (for/and ([left args] [right (cdr args)])
+    (test left right)))
+
 ; Table defining costs and translations to bigfloat and regular float
 ; See "costs.c" for details of how these costs were determined
 (define-table operations
@@ -190,21 +200,22 @@
   [y1        '(1)  bfbesy1      _fly1          55]
 
   ; TODO : These are different and should be treated differently
-  [if       '(3)      if-fn     if-fn      65]
-  [=        '(2)      bf=       =          65]
-  [>        '(2)      bf>       >          65]
-  [<        '(2)      bf<       <          65]
-  [>=       '(2)      bf>=      >=         65]
-  [<=       '(2)      bf<=      <=         65]
-  [not      '(1)      not       not        65]
-  [and      '(2)      and-fn    and-fn     55]
-  [or       '(2)      or-fn     or-fn      55])
+  [if       '(3)      if-fn                  if-fn                   65]
+  [==       '(*)      (comparator bf=)       (comparator =)          65]
+  [!=       '(*)      bf!=-fn                !=-fn                   65]
+  [>        '(*)      (comparator bf>)       (comparator >)          65]
+  [<        '(*)      (comparator bf<)       (comparator <)          65]
+  [>=       '(*)      (comparator bf>=)      (comparator >=)         65]
+  [<=       '(*)      (comparator bf<=)      (comparator <=)         65]
+  [not      '(1)      not                    not                     65]
+  [and      '(2)      and-fn                 and-fn                  55]
+  [or       '(2)      or-fn                  or-fn                   55])
 
 (define *operations* (make-parameter operations))
 
 (define constants '(PI E TRUE FALSE))
 
-(define predicates '(or and < > <= >= =))
+(define predicates '(or and < > <= >= == !=))
 
 (define mode:args 0)
 (define mode:bf 1)


### PR DESCRIPTION
Operators can list '* as a valid number of arguments (which means any number).

This used to mostly work; then stopped when we added syntax checking; but now works again and furthermore according to FPBench spec.