### PR TITLE
Faster pre sampling

### DIFF
--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -28,7 +28,11 @@
 (define (test-samplers test)
   (define range-table (condition->range-table (test-precondition test)))
   (for/list ([var (test-vars test)] [samp (test-sampling-expr test)])
-    (cons var (eval-sampler samp (range-table-ref range-table var)))))
+    (define intvl (range-table-ref range-table var))
+    (unless intvl
+     (raise-herbie-error "No valid values of variable ~a" var
+                         #:url "faq.html#no-valid-values"))
+    (cons var (eval-sampler samp intvl))))
 
 (define (parse-test expr)
   (match expr

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -4,6 +4,7 @@
 (require "../errors.rkt")
 (require "../alternative.rkt")
 (require "../programs.rkt")
+(require "../range-analysis.rkt")
 (require "../syntax/distributions.rkt")
 
 (provide (struct-out test) test-program test-samplers
@@ -25,8 +26,9 @@
 (struct test (name vars sampling-expr input output expected precondition) #:prefab)
 
 (define (test-samplers test)
+  (define range-table (condition->range-table (test-precondition test)))
   (for/list ([var (test-vars test)] [samp (test-sampling-expr test)])
-    (cons var (eval-sampler samp))))
+    (cons var (eval-sampler samp (range-table-ref range-table var)))))
 
 (define (parse-test expr)
   (match expr

--- a/src/range-analysis.rkt
+++ b/src/range-analysis.rkt
@@ -87,6 +87,20 @@
  ;; Disjoint intervals
  (check-equal? (interval-union (interval 0 1 #t #f) (interval 2 3 #f #t)) (interval 0 3 #t #t)))
 
+(define (interval-invert intvl)
+  (match intvl
+    [(interval -inf.0 +inf.0 _ _) #f]
+    [(interval -inf.0 u _ u?) (interval u +inf.0 (not u?) #f)]
+    [(interval l +inf.0 l? _) (interval -inf.0 l #f (not l?))]
+    [_ (interval -inf.0 +inf.0 #f #f)])) ; somehow (interval -inf.0 -inf.0 #f #f) will be matched to this case
+
+(module+ test
+  (check-equal? (interval-invert (interval -inf.0 +inf.0 #f #f)) #f)
+  (check-equal? (interval-invert (interval -inf.0 1 #f #f)) (interval 1 +inf.0 #t #f))
+  (check-equal? (interval-invert (interval 1 +inf.0 #t #f)) (interval -inf.0 1 #f #f))
+  (check-equal? (interval-invert (interval 1 2 #t #f)) (interval -inf.0 +inf.0 #f #f))
+  (check-equal? (interval-invert #f) (interval -inf.0 +inf.0 #f #f)))
+
 (define (make-range-table x intvl)
   (make-hash (list (cons x intvl))))
 

--- a/src/range-analysis.rkt
+++ b/src/range-analysis.rkt
@@ -1,0 +1,78 @@
+#lang racket
+
+(module+ test
+ (require rackunit))
+
+;; NOTE: an interval can also be #f for an empty interval
+(struct interval (l u l? u?) #:transparent)
+
+(define (interval-intersect interval1 interval2)
+  (cond
+   [(and interval1 interval2)
+    (match-define (interval l1 u1 l1? u1?) interval1)
+    (match-define (interval l2 u2 l2? u2?) interval2)
+
+    (define l? 
+     (cond [(< l1 l2) l2?]
+           [(= l1 l2) (and l1? l2?)]
+           [(> l1 l2) l1?]))
+    (define u?
+     (cond [(< u1 u2) u1?]
+           [(= u1 u2) (and u1? u2?)]
+           [(> u1 u2) u2?]))
+    (define l (max l1 l2))
+    (define u (min u1 u2))
+
+    (if (or (< u1 l2) (< u2 l1) (and (= l u) (not (and l? u?))))
+        #f
+        (interval l u l? u?))]
+   [else #f]))
+
+(module+ test
+ ;; Overlapping on a range
+ (check-equal? (interval-intersect (interval 0 2 #t #t) (interval 1 3 #t #t)) (interval 1 2 #t #t))
+ (check-equal? (interval-intersect (interval 0 2 #t #t) (interval 1 3 #f #t)) (interval 1 2 #f #t))
+ (check-equal? (interval-intersect (interval 0 2 #t #f) (interval 1 3 #t #t)) (interval 1 2 #t #f))
+ (check-equal? (interval-intersect (interval 0 2 #t #f) (interval 1 3 #f #t)) (interval 1 2 #f #f))
+ ;; Overlapping on a point
+ (check-equal? (interval-intersect (interval 0 2 #t #t) (interval 2 3 #t #t)) (interval 2 2 #t #t))
+ (check-equal? (interval-intersect (interval 0 2 #t #f) (interval 2 3 #t #t)) #f)
+ ;; No overlap
+ (check-equal? (interval-intersect (interval 0 1 #t #t) (interval 2 3 #t #t)) #f)
+ ;; Single point intervals
+ (check-equal? (interval-intersect (interval 1 1 #t #t) (interval 0 2 #f #f)) (interval 1 1 #t #t))
+ (check-equal? (interval-intersect (interval 1 1 #t #t) (interval 1 2 #f #f)) #f))
+
+(define (interval-union interval1 interval2)
+  (cond
+   [(and interval1 interval2)
+    (match-define (interval l1 u1 l1? u1?) interval1)
+    (match-define (interval l2 u2 l2? u2?) interval2)
+
+    (define l? 
+     (cond [(< l1 l2) l1?]
+           [(= l1 l2) (or l1? l2?)]
+           [(> l1 l2) l2?]))
+    (define u?
+     (cond [(< u1 u2) u2?]
+           [(= u1 u2) (or u1? u2?)]
+           [(> u1 u2) u1?]))
+    (define l (min l1 l2))
+    (define u (max u1 u2))
+
+    (interval l u l? u?)]
+   [interval1 interval1]
+   [else interval2]))
+
+(module+ test
+ ;; Overlapping on a range
+ (check-equal? (interval-union (interval 0 2 #t #t) (interval 1 3 #t #t)) (interval 0 3 #t #t))
+ (check-equal? (interval-union (interval 0 2 #t #f) (interval 1 3 #f #f)) (interval 0 3 #t #f))
+ (check-equal? (interval-union (interval 0 2 #f #t) (interval 1 3 #f #f)) (interval 0 3 #f #f))
+ ;; Single point intervals
+ (check-equal? (interval-union (interval 0 0 #t #t) (interval 1 3 #f #f)) (interval 0 3 #t #f))
+ (check-equal? (interval-union (interval 2 2 #t #t) (interval 2 3 #f #f)) (interval 2 3 #t #f))
+ (check-equal? (interval-union (interval 0 0 #t #t) (interval 3 3 #t #t)) (interval 0 3 #t #t))
+ ;; Disjoint intervals
+ (check-equal? (interval-union (interval 0 1 #t #f) (interval 2 3 #f #t)) (interval 0 3 #t #t)))
+

--- a/src/syntax/distributions.rkt
+++ b/src/syntax/distributions.rkt
@@ -21,29 +21,34 @@
 (define (sample-int)
   (- (random-exp 32) (expt 2 31)))
 
-(define (sample-bounded lo hi [left-closed #t] [right-closed #t])
-  (cond [(> lo hi) #f]
-        [(and (equal? (exact->inexact hi) (exact->inexact lo)) (or (not left-closed) (not right-closed))) #f]
-        [(equal? (exact->inexact hi) (exact->inexact lo)) (exact->inexact lo)]
-        [else
-          (let* ([ordinal (- (flonum->ordinal (exact->inexact hi)) (flonum->ordinal (exact->inexact lo)))]
-                 [num-bits (ceiling (/ (log ordinal) (log 2)))]
-                 [random-num (random-exp (inexact->exact num-bits))])
-            (if (or (and (not left-closed) (equal? 0 random-num))
-                    (and (not right-closed) (equal? ordinal random-num))
-                    (> random-num ordinal))
-              (sample-bounded lo left-closed hi right-closed)
-              (ordinal->flonum (+ (flonum->ordinal (exact->inexact lo)) random-num))))]))
+(define (sample-bounded lo hi #:left-closed? [left-closed? #t] #:right-closed? [right-closed? #t])
+  (define lo* (exact->inexact lo))
+  (define hi* (exact->inexact hi))
+  (cond
+   [(> lo* hi*) #f]
+   [(= lo* hi*)
+    (if (and left-closed? right-closed?) lo* #f)]
+   [(< lo* hi*)
+    (define ordinal (- (flonum->ordinal hi*) (flonum->ordinal lo*)))
+    (define num-bits (ceiling (/ (log ordinal) (log 2))))
+    (define random-num (random-exp (inexact->exact num-bits)))
+    (if (or (and (not left-closed?) (equal? 0 random-num))
+            (and (not right-closed?) (equal? ordinal random-num))
+            (> random-num ordinal))
+      ;; Happens with p < .5 so will not loop forever
+      (sample-bounded lo hi #:left-closed? left-closed? #:right-closed? right-closed?)
+      (ordinal->flonum (+ (flonum->ordinal lo*) random-num)))]))
 
 (module+ test
   (check-true (<= 1.0 (sample-bounded 1 2) 2.0))
-  (let ([a (sample-bounded 1 2 #f)])
+  (let ([a (sample-bounded 1 2 #:left-closed? #f)])
     (check-true (< 1 a))
     (check-true (<= a 2)))
-  (check-false (sample-bounded 1 1.0 #f) "Empty interval due to left openness")
-  (check-false (sample-bounded 1 1.0 #t #f) "Empty interval due to right openness")
-  (check-false (sample-bounded 1 1.0 #f #f) "Empty interval due to both-openness")
-  (check-false (sample-bounded 2.0 1.0 "Interval bounds flipped")))
+  (check-false (sample-bounded 1 1.0 #:left-closed? #f) "Empty interval due to left openness")
+  (check-false (sample-bounded 1 1.0 #:right-closed? #f) "Empty interval due to right openness")
+  (check-false (sample-bounded 1 1.0 #:left-closed? #f #:right-closed? #f)
+               "Empty interval due to both-openness")
+  (check-false (sample-bounded 2.0 1.0) "Interval bounds flipped"))
 
 (define (eval-op op)
   (match op ['> >] ['< <] ['>= >=] ['<= <=]))

--- a/src/syntax/distributions.rkt
+++ b/src/syntax/distributions.rkt
@@ -1,5 +1,5 @@
 #lang racket
-(require "../common.rkt")
+(require "../common.rkt" "../range-analysis.rkt")
 (require math/flonum)
 (provide eval-sampler)
 
@@ -59,11 +59,12 @@
       [(_ val)
        #'(and (or '< '> '>= '<=) (app eval-op val))])))
 
-(define (eval-sampler expr)
+(define (eval-sampler expr intval)
+  (match-define (interval lo hi lo? hi?) intval)
   (match expr
-    ['default sample-default]
+    ['default (λ () (sample-bounded lo hi #:left-closed? lo? #:right-closed? hi?))]
     [(? number? x) (const x)]
-    [`(uniform ,(? number? a) ,(? number? b)) (λ () (sample-uniform a b))]
+    [`(uniform ,(? number? a) ,(? number? b)) (λ () (sample-uniform (max a lo) (min b hi)))]
     ['int sample-int]
     [(list (op op) (? number? lb) sub)
      (define sub* (eval-sampler sub))


### PR DESCRIPTION
Implement range table to store information about preconditions. A range table contains at most one interval for one variable. This enables earlier failure if the precondition entered by the client is not valid.