### PR TITLE
Simplify bug

### DIFF
--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -138,16 +138,19 @@
                  ;; invalidate any change in bindings, it seems like
                  ;; the right thing to do for now.
                  [en (pack-leader en)]
-                 [bindings* (match-e (rule-input rl) en)])
+                 [bindings* (match-e (rule-input rl) en)]
+                 [applied #f])
           ;; Apply the match for each binding.
           (for ([binding bindings]
                 #:when (set-member? bindings* binding))
-            (merge-egraph-nodes! eg en (substitute-e eg (rule-output rl) binding)))
-          ;; Prune the enode if we can.
-          (try-prune-enode en)
-          ;; Mark this node as having this rule applied so that we don't try
-          ;; to apply it again.
-          (rule-applied! en rl)))
+            (merge-egraph-nodes! eg en (substitute-e eg (rule-output rl) binding))
+            (set! applied #t))
+          (when applied
+            ;; Prune the enode if we can.
+            (try-prune-enode en)
+            ;; Mark this node as having this rule applied so that we don't try
+            ;; to apply it again.
+            (rule-applied! en rl))))
   (define (try-prune-enode en)
     ;; If one of the variations of the enode is a single variable or
     ;; constant, reduce to that.

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -137,16 +137,17 @@
                  ;; changed. While it may be aggressive to
                  ;; invalidate any change in bindings, it seems like
                  ;; the right thing to do for now.
-                 [en (pack-leader en)])
-	(when (equal? (match-e (rule-input rl) en) bindings)
+                 [en (pack-leader en)]
+                 [bindings* (match-e (rule-input rl) en)])
           ;; Apply the match for each binding.
-          (for ([binding bindings])
+          (for ([binding bindings]
+                #:when (set-member? bindings* binding))
             (merge-egraph-nodes! eg en (substitute-e eg (rule-output rl) binding)))
           ;; Prune the enode if we can.
           (try-prune-enode en)
           ;; Mark this node as having this rule applied so that we don't try
           ;; to apply it again.
-          (rule-applied! en rl))))
+          (rule-applied! en rl)))
   (define (try-prune-enode en)
     ;; If one of the variations of the enode is a single variable or
     ;; constant, reduce to that.


### PR DESCRIPTION
This fixes a subtle but pervasive and pernicious bug in simplification.

Simplification proceeds by estimating a number of iterations (of egraph rewriting) necessary to simplify a term, then doing that many (with a bound on both nodes and iters). The estimated number of iterations is simple: for every binary operator, a commutation and an associativity can be necessary (so 2 iterations) and for other operators we estimate 1. The maximum through any branch should give a nice bound.

The bug in question causes us not to do some rewriting steps on some iterations, even if they are valid. As a result, outputs are often "undersimplified".

The issue is that the simplifier *first* computes the set of valid rewrites, *then* executes them one after another. But one rewrite can invalidate another, due to pruning, so we check that a rewrite is still valid before executing. However, rewrites come batched (by rewrite rule & enode), and we were checking batches for equality before applying them. This means that if the batch grew strictly larger (so all previous rewrites are valid, plus new ones are too) we would skip the rule application. This could cause us to skip applying rules until that part of the tree had "settled down", which could take many iterations.

This fix changes the strict equality check by separating out the batches of rewrites and checking that each individual one is valid; that fixes the strict-superset case above as well as some cases where the batches simply intersect.