### PR TITLE
Windows Support

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -8,7 +8,7 @@
   (require rackunit))
 
 (provide *start-prog*
-         reap define-table table-ref table-set!
+         reap define-table table-ref table-set! table-remove!
          first-value assert for/append
          ordinary-float? =-or-nan? log2 </total
          take-up-to flip-lists argmins argmaxs setfindf index-of set-disjoint?
@@ -64,6 +64,13 @@
   (match-let ([(cons header rows) tbl])
     (define row (for/list ([(hkey htype) (in-dict header)]) (dict-ref fields hkey)))
     (dict-set! rows key row)))
+
+(define/contract (table-remove! tbl key)
+  (-> (cons/c (listof (cons/c symbol? contract?)) (hash/c symbol? (listof any/c)))
+      symbol?
+      any)
+  (match-let ([(cons header rows) tbl])
+    (dict-remove! rows key)))
 
 ;; More various helpful values
 

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -8,14 +8,16 @@
 ;; Flag Stuff
 
 (define all-flags
-  #hash([precision . (double)]
+  #hash([precision . (double fallback)]
+        [fn . (cbrt)]
         [setup . (simplify early-exit)]
         [generate . (rr taylor simplify)]
         [reduce . (regimes taylor simplify avg-error post-process binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics)]))
 
 (define default-flags
-  #hash([precision . (double)]
+  #hash([precision . (double fallback)]
+        [fn . (cbrt)]
         [setup . (simplify)]
         [generate . (rr taylor simplify)]
         [reduce . (regimes taylor simplify avg-error binary-search branch-expressions)]

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -4,7 +4,8 @@
 (require "config.rkt")
 (require "common.rkt")
 
-(provide ulp-difference *bit-width* ulps->bits bit-difference sample-float sample-double)
+(provide ulp-difference *bit-width* ulps->bits bit-difference sample-float sample-double
+         single-flonum->bit-field)
 
 (define (single-flonum->bit-field x)
   (integer-bytes->integer (real->floating-point-bytes x 4) #f))

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require racket/lazy-require)
-(require "common.rkt" "multi-command-line.rkt" "sandbox.rkt" "errors.rkt")
+(require "common.rkt" "multi-command-line.rkt" "sandbox.rkt" "errors.rkt" "syntax/syntax.rkt")
 
 (lazy-require
  ["web/demo.rkt" (run-demo)]
@@ -24,6 +24,12 @@
   (define report-profile? #f)
   (define report-note #f)
 
+  (unless (if (flag-set? 'precision 'double) (null? (*unknown-d-ops*)) (null? (*unknown-f-ops*)))
+    (eprintf "Warning: native ~a not supported on your system; fallbacks will be used.\n"
+             (string-join (map ~a (if (flag-set? 'precision 'double) (*unknown-d-ops*) (*unknown-f-ops*)))
+                          ", "))
+    (eprintf "See <https://herbie.uwplse.org/doc/~a/faq.html#native-ops> for more info.\n"
+             *herbie-version*))
 
   (multi-command-line
    #:program "herbie"

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -3,6 +3,7 @@
 ;; Arithmetic identities for rewriting programs.
 
 (require "../common.rkt")
+(require "syntax.rkt")
 
 (provide (struct-out rule) *rules* *simplify-rules* *fp-safe-simplify-rules*)
 
@@ -15,9 +16,22 @@
 
 (define *rulesets* (make-parameter '()))
 
+(define (rule-ops-supported? rule)
+  (define (ops-in-expr expr)
+    (cond
+      [(list? expr) (if (member (car expr) (*loaded-ops*))
+                        (for/and ([subexpr (cdr expr)])
+                          (ops-in-expr subexpr))
+                        #f)]
+      [else #t]))
+  (and (ops-in-expr (rule-input rule)) (ops-in-expr (rule-output rule))))
+
 (define-syntax-rule (define-ruleset name groups [rname input output] ...)
-  (begin (define name (list (rule 'rname 'input 'output) ...))
-	 (*rulesets* (cons (cons name 'groups) (*rulesets*)))))
+  (begin
+    (define name (for/list ([r (list (rule 'rname 'input 'output) ...)]
+                                 #:when (rule-ops-supported? r))
+                        r))
+	  (*rulesets* (cons (cons name 'groups) (*rulesets*)))))
 
 ; Commutativity
 (define-ruleset commutativity (arithmetic simplify fp-safe)

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -5,7 +5,7 @@
 (require "../common.rkt")
 (require "syntax.rkt")
 
-(provide (struct-out rule) *rules* *simplify-rules* *fp-safe-simplify-rules*)
+(provide (struct-out rule) *rules* *simplify-rules* *fp-safe-simplify-rules* prune-rules!)
 
 (struct rule (name input output) ; Input and output are patterns
         #:methods gen:custom-write
@@ -26,11 +26,16 @@
       [else #t]))
   (and (ops-in-expr (rule-input rule)) (ops-in-expr (rule-output rule))))
 
+(define (prune-rules!)
+  (*rulesets* (for/list ([ruleset (*rulesets*)])
+                (cons (for/list ([rule (car ruleset)]
+                                 #:when (rule-ops-supported? rule))
+                        rule)
+                      (cdr ruleset)))))
+
 (define-syntax-rule (define-ruleset name groups [rname input output] ...)
   (begin
-    (define name (for/list ([r (list (rule 'rname 'input 'output) ...)]
-                                 #:when (rule-ops-supported? r))
-                        r))
+    (define name (for/list ([r (list (rule 'rname 'input 'output) ...)]) r))
 	  (*rulesets* (cons (cons name 'groups) (*rulesets*)))))
 
 ; Commutativity

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -77,11 +77,12 @@
 (define-syntax-rule (define-operator (operator atypes ...) rtype [key value] ...)
   (let ([type (hash (length '(atypes ...)) (list '(atypes ...) 'rtype))]
         [args (list (length '(atypes ...)))]
-        [racketfl (if (findf (λ (x) (equal? (car x) 'racketfl)) (list '(atypes ...)))
+        ;;TODO: This is a temporary default value. FIX THIS!
+        [racketfl (if (findf (λ (x) (equal? (car x) 'racketfl)) '([key value] ...))
                       '()
-                      (cons 'racketfl (λ args 0.0)))]) ;;TODO: This is a temporary default value. FIX THIS!
+                      (list (cons 'racketfl (λ args 0.0))))])
     (table-set! operators 'operator
-                (make-hash (list (cons 'type type) (cons 'args args) (cons 'key value) ... racketfl)))))
+                (make-hash (append (list (cons 'type type) (cons 'args args) (cons 'key value) ...) racketfl)))))
 
 (define-operator (+ real real) real
   [fl +] [bf bf+] [cost 40]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -392,7 +392,7 @@
   [->c/double (curry format "logb(~a)")]
   [->c/mpfr (curry format "mpfr_set_si(~a, mpfr_get_exp(~a), MPFR_RNDN)")]
   [->tex (curry format "\\log^{*}_{b} ~a")]
-  [nonffi (match-lambda [(list x) (writeln "test") (flfloor (fllog2 (flabs (fl x))))])])
+  [nonffi (match-lambda [(list x) (flfloor (fllog2 (flabs (fl x))))])])
 
 (define-operator/libm (pow real real) real
   [libm pow powf] [bf bfexpt] [cost 210]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -134,11 +134,11 @@
        #`(begin
            (define-libm id_d (_fun #,@(build-list num-args (λ (_) #'_double)) -> _double)
                         #:fail (lambda ()
-                                 (*unknown-d-ops* (cons 'id_d (*unknown-d-ops*)))
+                                 (*unknown-d-ops* (cons 'operator (*unknown-d-ops*)))
                                  (λ args ((operator-info 'operator 'nonffi) args))))
            (define-libm id_f (_fun #,@(build-list num-args (λ (_) #'_float)) -> _float)
                         #:fail (lambda ()
-                                 (*unknown-f-ops* (cons 'id_f (*unknown-f-ops*)))
+                                 (*unknown-f-ops* (cons 'operator (*unknown-f-ops*)))
                                  (λ args ((operator-info 'operator 'nonffi) args))))
            (define-operator (operator #,@(build-list num-args (λ (_) #'real))) real
              [fl (λ args (apply (if (flag-set? 'precision 'double) id_d id_f) args))]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -7,10 +7,12 @@
 (require "../float.rkt")
 
 (provide constant? variable? operator? operator-info constant-info
-         *unknown-d-ops* *unknown-f-ops*)
+         *unknown-d-ops* *unknown-f-ops* *loaded-ops*)
 
 (define *unknown-d-ops* (make-parameter '()))
 (define *unknown-f-ops* (make-parameter '()))
+
+(define *loaded-ops* (make-parameter '()))
 
 (define (type? x) (or (equal? x 'real) (equal? x 'bool)))
 
@@ -87,6 +89,9 @@
                                                     (format "couldn't find ~a and no default implementation defined" 'operator)
                                                     (current-continuation-marks)) 
                                              0.0))))])
+    ;; TODO: If we don't find the op in nonffi mode and we want to remove it,
+    ;; then don't add it to the list of loaded-ops
+    (*loaded-ops* (cons 'operator (*loaded-ops*)))
     (table-set! operators 'operator
                 (make-hash (append (list (cons 'type type) (cons 'args args) (cons 'key value) ...) nonffi)))))
 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -2,9 +2,12 @@
 
 (require math/flonum)
 (require math/bigfloat)
+(require math/special-functions)
 (require "../common.rkt")
+(require "../float.rkt")
 
-(provide constant? variable? operator? operator-info constant-info)
+(provide constant? variable? operator? operator-info constant-info
+         *unknown-d-ops* *unknown-f-ops*)
 
 (define *unknown-d-ops* (make-parameter '()))
 (define *unknown-f-ops* (make-parameter '()))
@@ -65,7 +68,7 @@
   [args  (listof (or/c '* natural-number/c))]
   [bf    (unconstrained-argument-number-> (or/c bigfloat? boolean?) (or/c bigfloat? boolean?))]
   [fl    (unconstrained-argument-number-> (or/c flonum? boolean?) (or/c flonum? boolean?))]
-  [racketfl (unconstrained-argument-number-> (or/c bigfloat? flonum? boolean?) (or/c bigfloat? flonum? boolean?))]
+  [nonffi (unconstrained-argument-number-> (or/c bigfloat? flonum? boolean?) (or/c bigfloat? flonum? boolean?))]
   [cost  natural-number/c]
   [type  (hash/c (or/c '* natural-number/c) (list/c (or/c (listof type?) (list/c '* type?)) type?))]
   [->c/double (unconstrained-argument-number-> string? string?)]
@@ -78,17 +81,22 @@
   (let ([type (hash (length '(atypes ...)) (list '(atypes ...) 'rtype))]
         [args (list (length '(atypes ...)))]
         ;;TODO: This is a temporary default value. FIX THIS!
-        [racketfl (if (findf (λ (x) (equal? (car x) 'racketfl)) '([key value] ...))
+        [nonffi (if (findf (λ (x) (equal? (car x) 'nonffi)) '([key value] ...))
                       '()
-                      (list (cons 'racketfl (λ args 0.0))))])
+                      (list (cons 'nonffi (λ args 
+                                             (raise exn:fail:unsupported 
+                                                    (format "couldn't find ~a and no default implementation defined" 'operator)
+                                                    (current-continuation-marks)) 
+                                             0.0))))])
     (table-set! operators 'operator
-                (make-hash (append (list (cons 'type type) (cons 'args args) (cons 'key value) ...) racketfl)))))
+                (make-hash (append (list (cons 'type type) (cons 'args args) (cons 'key value) ...) nonffi)))))
 
 (define-operator (+ real real) real
   [fl +] [bf bf+] [cost 40]
   [->c/double (curry format "~a + ~a")]
   [->c/mpfr (curry format "mpfr_add(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "~a + ~a")])
+  [->tex (curry format "~a + ~a")]
+  [nonffi +])
 
 (define-operator (- real [real]) real
   ;; Override the normal argument handling because - can be unary
@@ -96,19 +104,22 @@
   [fl -] [bf bf-] [cost 40]
   [->c/double (λ (x [y #f]) (if y (format "~a - ~a" x y) (format "-~a" x)))]
   [->c/mpfr (λ (out x [y #f]) (if y (format "mpfr_sub(~a, ~a, ~a, MPFR_RNDN)" out x y) (format "mpfr_neg(~a, ~a, MPFR_RNDN)" out x)))]
-  [->tex (λ (x [y #f]) (if y (format "~a - ~a" x y) (format "-~a" x)))])
+  [->tex (λ (x [y #f]) (if y (format "~a - ~a" x y) (format "-~a" x)))]
+  [nonffi -])
 
 (define-operator (* real real) real
   [fl *] [bf bf*] [cost 40]
   [->c/double (curry format "~a * ~a")]
   [->c/mpfr (curry format "mpfr_mul(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "~a \\cdot ~a")])
+  [->tex (curry format "~a \\cdot ~a")]
+  [nonffi *])
 
 (define-operator (/ real real) real
   [fl /] [bf bf/] [cost 40]
   [->c/double (curry format "~a / ~a")]
   [->c/mpfr (curry format "mpfr_div(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\frac{~a}{~a}")])
+  [->tex (curry format "\\frac{~a}{~a}")]
+  [nonffi /])
 
 ; Use C ffi to get numerical ops from libm
 (require ffi/unsafe ffi/unsafe/define)
@@ -122,11 +133,11 @@
            (define-libm id_d (_fun #,@(build-list num-args (λ (_) #'_double)) -> _double)
                         #:fail (lambda ()
                                  (*unknown-d-ops* (cons 'id_d (*unknown-d-ops*)))
-                                 (λ args ((operator-info 'operator 'racketfl) args))))
+                                 (λ args ((operator-info 'operator 'nonffi) args))))
            (define-libm id_f (_fun #,@(build-list num-args (λ (_) #'_float)) -> _float)
                         #:fail (lambda ()
                                  (*unknown-f-ops* (cons 'id_f (*unknown-f-ops*)))
-                                 (λ args ((operator-info 'operator 'racketfl) args))))
+                                 (λ args ((operator-info 'operator 'nonffi) args))))
            (define-operator (operator #,@(build-list num-args (λ (_) #'real))) real
              [fl (λ args (apply (if (flag-set? 'precision 'double) id_d id_f) args))]
              [key value] ...)))]))
@@ -135,55 +146,64 @@
   [libm acos acosf] [bf bfacos] [cost 90]
   [->c/double (curry format "acos(~a)")]
   [->c/mpfr (curry format "mpfr_acos(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\cos^{-1} ~a")])
+  [->tex (curry format "\\cos^{-1} ~a")]
+  [nonffi acos])
 
 (define-operator/libm (acosh real) real
   [libm acosh acoshf] [bf bfacosh] [cost 55]
   [->c/double (curry format "acosh(~a)")]
   [->c/mpfr (curry format "mpfr_acosh(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\cosh^{-1} ~a")])
+  [->tex (curry format "\\cosh^{-1} ~a")]
+  [nonffi flacosh])
 
 (define-operator/libm (asin real) real
   [libm asin asinf] [bf bfasin] [cost 105]
   [->c/double (curry format "asin(~a)")]
   [->c/mpfr (curry format "mpfr_asin(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\sin^{-1} ~a")])
+  [->tex (curry format "\\sin^{-1} ~a")]
+  [nonffi asin])
 
 (define-operator/libm (asinh real) real
   [libm asinh asinhf] [bf bfasinh] [cost 55]
   [->c/double (curry format "asinh(~a)")]
   [->c/mpfr (curry format "mpfr_asinh(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\sinh^{-1} ~a")])
+  [->tex (curry format "\\sinh^{-1} ~a")]
+  [nonffi flasinh])
 
 (define-operator/libm (atan real) real
   [libm atan atanf] [bf bfatan] [cost 105]
   [->c/double (curry format "atan(~a)")]
   [->c/mpfr (curry format "mpfr_atan(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\tan^{-1} ~a")])
+  [->tex (curry format "\\tan^{-1} ~a")]
+  [nonffi atan])
 
 (define-operator/libm (atan2 real real) real
   [libm atan2 atan2f] [bf bfatan2] [cost 140]
   [->c/double (curry format "atan2(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_atan2(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\tan^{-1}_* \\frac{~a}{~a}")])
+  [->tex (curry format "\\tan^{-1}_* \\frac{~a}{~a}")]
+  [nonffi atan])
 
 (define-operator/libm (atanh real) real
   [libm atanh atanhf] [bf bfatanh] [cost 55]
   [->c/double (curry format "atanh(~a)")]
   [->c/mpfr (curry format "mpfr_atanh(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\tanh^{-1} ~a")])
+  [->tex (curry format "\\tanh^{-1} ~a")]
+  [nonffi flatanh])
 
 (define-operator/libm (cbrt real) real
   [libm cbrt cbrtf] [bf bfcbrt] [cost 80]
   [->c/double (curry format "cbrt(~a)")]
   [->c/mpfr (curry format "mpfr_cbrt(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\sqrt[3]{~a}")])
+  [->tex (curry format "\\sqrt[3]{~a}")]
+  [nonffi (λ (x) (expt x (/ 1 3)))])
 
 (define-operator/libm (ceil real) real
   [libm ceil ceilf] [bf bfceiling] [cost 80]
   [->c/double (curry format "ceil(~a)")]
   [->c/mpfr (curry format "mpfr_ceil(~a, ~a)")]
-  [->tex (curry format "\\left\\lceil~a\\right\\rceil")])
+  [->tex (curry format "\\left\\lceil~a\\right\\rceil")]
+  [nonffi ceiling])
 
 (define (bfcopysign x y)
   (bf* (bfabs x) (bf (expt -1 (bigfloat-signbit y)))))
@@ -192,55 +212,64 @@
   [libm copysign copysignf] [bf bfcopysign] [cost 80]
   [->c/double (curry format "copysign(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_copysign(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{copysign}\\left(~a, ~a\\right)")])
+  [->tex (curry format "\\mathsf{copysign}\\left(~a, ~a\\right)")]
+  [nonffi (λ (x y) (if (>= y 0) (abs x) (- (abs x))))])
 
 (define-operator/libm (cos real) real
   [libm cos cosf] [bf bfcos] [cost 60]
   [->c/double (curry format "cos(~a)")]
   [->c/mpfr (curry format "mpfr_cos(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\cos ~a")])
+  [->tex (curry format "\\cos ~a")]
+  [nonffi cos])
 
 (define-operator/libm (cosh real) real
   [libm cosh coshf] [bf bfcosh] [cost 55]
   [->c/double (curry format "cosh(~a)")]
   [->c/mpfr (curry format "mpfr_cosh(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\cosh ~a")])
+  [->tex (curry format "\\cosh ~a")]
+  [nonffi cosh])
 
 (define-operator/libm (erf real) real
   [libm erf erff] [bf bferf] [cost 70]
   [->c/double (curry format "erf(~a)")]
   [->c/mpfr (curry format "mpfr_erf(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{erf} ~a")])
+  [->tex (curry format "\\mathsf{erf} ~a")]
+  [nonffi flerf])
 
 (define-operator/libm (erfc real) real
   [libm erfc erfcf] [bf bferfc] [cost 70]
   [->c/double (curry format "erfc(~a)")]
   [->c/mpfr (curry format "mpfr_erfc(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{erfc} ~a")])
+  [->tex (curry format "\\mathsf{erfc} ~a")]
+  [nonffi flerfc])
 
 (define-operator/libm (exp real) real
   [libm exp expf] [bf bfexp] [cost 70]
   [->c/double (curry format "exp(~a)")]
   [->c/mpfr (curry format "mpfr_exp(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "e^{~a}")])
+  [->tex (curry format "e^{~a}")]
+  [nonffi exp])
 
 (define-operator/libm (exp2 real) real
   [libm exp2 exp2f] [bf bfexp2] [cost 70]
   [->c/double (curry format "exp2(~a)")]
   [->c/mpfr (curry format "mpfr_exp2(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "2^{~a}")])
+  [->tex (curry format "2^{~a}")]
+  [nonffi (λ (x) (expt 2.0 x))])
 
 (define-operator/libm (expm1 real) real
   [libm expm1 expm1f] [bf bfexpm1] [cost 70]
   [->c/double (curry format "expm1(~a)")]
   [->c/mpfr (curry format "mpfr_expm1(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "(e^{~a} - 1)^*")])
+  [->tex (curry format "(e^{~a} - 1)^*")]
+  [nonffi flexpm1])
 
 (define-operator/libm (fabs real) real
   [libm fabs fabsf] [bf bfabs] [cost 40]
   [->c/double (curry format "fabs(~a)")]
   [->c/mpfr (curry format "mpfr_abs(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\left|~a\\right|")])
+  [->tex (curry format "\\left|~a\\right|")]
+  [nonffi abs])
 
 (define (bffdim x y)
   (if (bf> x y)
@@ -251,13 +280,15 @@
   [libm fdim fdimf] [bf bffdim] [cost 55]
   [->c/double (curry format "fdim(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_dim(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{fdim}\\left(~a, ~a\\right)")])
+  [->tex (curry format "\\mathsf{fdim}\\left(~a, ~a\\right)")]
+  [nonffi (λ (x y) (max (- x y) 0))])
 
 (define-operator/libm (floor real) real
   [libm floor floorf] [bf bffloor] [cost 55]
   [->c/double (curry format "floor(~a)")]
   [->c/mpfr (curry format "mpfr_floor(~a, ~a)")]
-  [->tex (curry format "\\left\\lfloor~a\\right\\rfloor")])
+  [->tex (curry format "\\left\\lfloor~a\\right\\rfloor")]
+  [nonffi floor])
 
 (define (bffma x y z)
   (bf+ (bf* x y) z))
@@ -266,19 +297,22 @@
   [libm fma fmaf] [bf bffma] [cost 55]
   [->c/double (curry format "fma(~a, ~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fma(~a, ~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "(~a \\cdot ~a + ~a)_*")])
+  [->tex (curry format "(~a \\cdot ~a + ~a)_*")]
+  [nonffi (λ (x y z) (bigfloat->flonum (bf+ (bf* (bf x) (bf y)) (bf z))))])
 
 (define-operator/libm (fmax real real) real
   [libm fmax fmaxf] [bf bfmax] [cost 55]
   [->c/double (curry format "fmax(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fmax(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{fmax}\\left(~a, ~a\\right)")])
+  [->tex (curry format "\\mathsf{fmax}\\left(~a, ~a\\right)")]
+  [nonffi (λ (x y) (cond  [(nan? x) y] [(nan? y) x] [else (max x y)]))])
 
 (define-operator/libm (fmin real real) real
   [libm fmin fminf] [bf bfmin] [cost 55]
   [->c/double (curry format "fmin(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fmin(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{fmin}\\left(~a, ~a\\right)")])
+  [->tex (curry format "\\mathsf{fmin}\\left(~a, ~a\\right)")]
+  [nonffi (λ (x y) (cond  [(nan? x) y] [(nan? y) x] [else (min x y)]))])
 
 (define (bffmod x mod)
   (bf- x (bf* mod (bffloor (bf/ x mod)))))
@@ -287,55 +321,64 @@
   [libm fmod fmodf] [bf bffmod] [cost 70]
   [->c/double (curry format "fmod(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fmod(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "~a \\bmod ~a")])
+  [->tex (curry format "~a \\bmod ~a")]
+  [nonffi (λ (x) (bigfloat->flonum (bffmod x)))])
 
 (define-operator/libm (hypot real real) real
   [libm hypot hypotf] [bf bfhypot] [cost 55]
   [->c/double (curry format "hypot(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_hypot(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\sqrt{~a^2 + ~a^2}^*")])
+  [->tex (curry format "\\sqrt{~a^2 + ~a^2}^*")]
+  [nonffi flhypot])
 
 (define-operator/libm (j0 real) real
   [libm j0 j0f] [bf bfbesj0] [cost 55]
   [->c/double (curry format "j0(~a)")]
   [->c/mpfr (curry format "mpfr_j0(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{j0} ~a")])
+  [->tex (curry format "\\mathsf{j0} ~a")]
+  [nonffi (λ (x) (bigfloat->flonum (bfbesj0 (bf x))))])
 
 (define-operator/libm (j1 real) real
   [libm j1 j1f] [bf bfbesj1] [cost 55]
   [->c/double (curry format "j1(~a)")]
   [->c/mpfr (curry format "mpfr_j1(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{j1} ~a")])
+  [->tex (curry format "\\mathsf{j1} ~a")]
+  [nonffi (λ (x) (bigfloat->flonum (bfbesj1 (bf x))))])
 
 (define-operator/libm (lgamma real) real
   [libm lgamma lgammaf] [bf bflog-gamma] [cost 55]
   [->c/double (curry format "lgamma(~a)")]
   [->c/mpfr (curry format "mpfr_lngamma(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\log_* \\left( \\mathsf{gamma} ~a \\right)")])
+  [->tex (curry format "\\log_* \\left( \\mathsf{gamma} ~a \\right)")]
+  [nonffi log-gamma])
 
 (define-operator/libm (log real) real
   [libm log logf] [bf bflog] [cost 70]
   [->c/double (curry format "log(~a)")]
   [->c/mpfr (curry format "mpfr_log(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\log ~a")])
+  [->tex (curry format "\\log ~a")]
+  [nonffi log])
 
 (define-operator/libm (log10 real) real
   [libm log10 log10f] [bf bflog10] [cost 70]
   [->c/double (curry format "log10(~a)")]
   [->c/mpfr (curry format "mpfr_log10(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\log_{10} ~a")])
+  [->tex (curry format "\\log_{10} ~a")]
+  [nonffi (λ (x) (log x 10))])
 
 (define-operator/libm (log1p real) real
   [libm log1p log1pf] [bf bflog1p] [cost 90]
   [->c/double (curry format "log1p(~a)")]
   [->c/mpfr (curry format "mpfr_log1p(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\log_* (1 + ~a)")])
+  [->tex (curry format "\\log_* (1 + ~a)")]
+  [nonffi fllog1p])
 
 (define-operator/libm (log2 real) real
   [libm log2 log2f] [bf bflog2] [cost 70]
   [->c/double (curry format "log2(~a)")]
   [->c/mpfr (curry format "mpfr_log2(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\log_{2} ~a")])
+  [->tex (curry format "\\log_{2} ~a")]
+  [nonffi fllog2])
 
 (define (bflogb x)
   (bigfloat-exponent x))
@@ -344,85 +387,112 @@
   [libm logb logbf] [bf bflogb] [cost 70]
   [->c/double (curry format "logb(~a)")]
   [->c/mpfr (curry format "mpfr_set_si(~a, mpfr_get_exp(~a), MPFR_RNDN)")]
-  [->tex (curry format "\\log^{*}_{b} ~a")])
+  [->tex (curry format "\\log^{*}_{b} ~a")]
+  [nonffi (λ (x) (cond 
+                    [(or (= x +inf.0) (= x -inf.0)) +inf.0]
+                    [(nan? x) x]
+                    [(= x 0) -inf.0]
+                    ;; Manually extract exponent from double or float
+                    [else (if (flag-set? 'precision 'double)
+                              (- (arithmetic-shift (bitwise-and #x7ff0000000000000
+                                                                (flonum->bit-field x))
+                                                   -52)
+                                 (1023))
+                              (- (arithmetic-shift (bitwise-and #x7f800000 ;; TODO: This doesn't work
+                                                                (single-flonum->bit-field (real->single-flonum x)))
+                                                   -23)
+                                 (127)))]))])
 
 (define-operator/libm (pow real real) real
   [libm pow powf] [bf bfexpt] [cost 210]
   [->c/double (curry format "pow(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_pow(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "{~a}^{~a}")])
+  [->tex (curry format "{~a}^{~a}")]
+  [nonffi (λ (x y) (expt x y))])
 
 (define-operator/libm (remainder real real) real
   [libm remainder remainderf] [bf bfremainder] [cost 70]
   [->c/double (curry format "remainder(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_remainder(~a, ~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "~a \\mathsf{rem} ~a")])
+  [->tex (curry format "~a \\mathsf{rem} ~a")]
+  [nonffi (λ (x y) (bigfloat->flonum (bfremainder (bf x) (bf y))))])
 
 (define-operator/libm (rint real) real
   [libm rint rintf] [bf bfrint] [cost 70]
   [->c/double (curry format "rint(~a)")]
   [->c/mpfr (curry format "mpfr_rint(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{rint} ~a")])
+  [->tex (curry format "\\mathsf{rint} ~a")]
+  [nonffi flround])
 
 (define-operator/libm (round real) real
   [libm round roundf] [bf bfround] [cost 70]
   [->c/double (curry format "round(~a)")]
   [->c/mpfr (curry format "mpfr_round(~a, ~a)")]
-  [->tex (curry format "\\mathsf{round} ~a")])
+  [->tex (curry format "\\mathsf{round} ~a")]
+  [nonffi flround])
 
 (define-operator/libm (sin real) real
   [libm sin sinf] [bf bfsin] [cost 60]
   [->c/double (curry format "sin(~a)")]
   [->c/mpfr (curry format "mpfr_sin(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\sin ~a")])
+  [->tex (curry format "\\sin ~a")]
+  [nonffi sin])
 
 (define-operator/libm (sinh real) real
   [libm sinh sinhf] [bf bfsinh] [cost 55]
   [->c/double (curry format "sinh(~a)")]
   [->c/mpfr (curry format "mpfr_sinh(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\sinh ~a")])
+  [->tex (curry format "\\sinh ~a")]
+  [nonffi sinh])
 
 (define-operator/libm (sqrt real) real
   [libm sqrt sqrtf] [bf bfsqrt] [cost 40]
   [->c/double (curry format "sqrt(~a)")]
   [->c/mpfr (curry format "mpfr_sqrt(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\sqrt{~a}")])
+  [->tex (curry format "\\sqrt{~a}")]
+  [nonffi sqrt])
 
 (define-operator/libm (tan real) real
   [libm tan tanf] [bf bftan] [cost 95]
   [->c/double (curry format "tan(~a)")]
   [->c/mpfr (curry format "mpfr_tan(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\tan ~a")])
+  [->tex (curry format "\\tan ~a")]
+  [nonffi tan])
 
 (define-operator/libm (tanh real) real
   [libm tanh tanhf] [bf bftanh] [cost 55]
   [->c/double (curry format "tanh(~a)")]
   [->c/mpfr (curry format "mpfr_tanh(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\tanh ~a")])
+  [->tex (curry format "\\tanh ~a")]
+  [nonffi tanh])
 
 (define-operator/libm (tgamma real) real
   [libm tgamma tgammaf] [bf bfgamma] [cost 55]
   [->c/double (curry format "tgamma(~a)")]
   [->c/mpfr (curry format "mpfr_gamma(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{gamma} ~a")])
+  [->tex (curry format "\\mathsf{gamma} ~a")]
+  [nonffi gamma])
 
 (define-operator/libm (trunc real) real
   [libm trunc truncf] [bf bftruncate] [cost 55]
   [->c/double (curry format "trunc(~a)")]
   [->c/mpfr (curry format "mpfr_trunc(~a, ~a)")]
-  [->tex (curry format "\\mathsf{trunc} ~a")])
+  [->tex (curry format "\\mathsf{trunc} ~a")]
+  [nonffi truncate])
 
 (define-operator/libm (y0 real) real
   [libm y0 y0f] [bf bfbesy0] [cost 55]
   [->c/double (curry format "y0(~a)")]
   [->c/mpfr (curry format "mpfr_y0(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{y0} ~a")])
+  [->tex (curry format "\\mathsf{y0} ~a")]
+  [nonffi (λ (x) (bigfloat->flonum (bfbesy0 (bf x))))])
 
 (define-operator/libm (y1 real) real
   [libm y1 y1f] [bf bfbesy1] [cost 55]
   [->c/double (curry format "y1(~a)")]
   [->c/mpfr (curry format "mpfr_y1(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{y1} ~a")])
+  [->tex (curry format "\\mathsf{y1} ~a")]
+  [nonffi (λ (x) (bigfloat->flonum (bfbesy1 (bf x))))])
 
 ;; DEPRECATED
 
@@ -430,13 +500,15 @@
   [fl sqr] [bf bfsqr] [cost 40]
   [->c/double (λ (x) (format "~a * ~a" x x))]
   [->c/mpfr (curry format "mpfr_sqr(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "{~a}^2")])
+  [->tex (curry format "{~a}^2")]
+  [nonffi (λ (x) (* x x))])
 
 (define-operator (cube real) real
   [fl (λ (x) (* x (* x x)))] [bf (λ (x) (bf* x (bf* x x)))] [cost 80]
   [->c/double (λ (x) (format "~a * (~a * ~a)" x x x))]
   [->c/mpfr (λ (out x) (format "mpfr_sqr(~a, ~a, MPFR_RNDN); mpfr_mul(~a, ~a, ~a, MPFR_RNDN)" out x out out x))]
-  [->tex (curry format "{~a}^3")])
+  [->tex (curry format "{~a}^3")]
+  [nonffi (λ (x) (* x x x))])
 
 (define (if-fn test if-true if-false) (if test if-true if-false))
 (define (and-fn . as) (andmap identity as))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -388,20 +388,7 @@
   [->c/double (curry format "logb(~a)")]
   [->c/mpfr (curry format "mpfr_set_si(~a, mpfr_get_exp(~a), MPFR_RNDN)")]
   [->tex (curry format "\\log^{*}_{b} ~a")]
-  [nonffi (match-lambda [(list x) (cond 
-    [(or (= x +inf.0) (= x -inf.0)) +inf.0]
-    [(nan? x) x]
-    [(= x 0) -inf.0]
-    ;; Manually extract exponent from double or float
-    [else (if (flag-set? 'precision 'double)
-              (- (arithmetic-shift (bitwise-and #x7ff0000000000000
-                                                (flonum->bit-field x))
-                                   -52)
-                 (1023))
-              (- (arithmetic-shift (bitwise-and #x7f800000 ;; TODO: This doesn't work
-                                                (single-flonum->bit-field (real->single-flonum x)))
-                                   -23)
-                 (127)))])])])
+  [nonffi (match-lambda [(list x) (writeln "test") (flfloor (fllog2 (flabs (fl x))))])])
 
 (define-operator/libm (pow real real) real
   [libm pow powf] [bf bfexpt] [cost 210]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -147,7 +147,7 @@
   [->c/double (curry format "acos(~a)")]
   [->c/mpfr (curry format "mpfr_acos(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\cos^{-1} ~a")]
-  [nonffi (match-lambda [(list x) (acos x)])])
+  [nonffi (match-lambda [(list x) (flacos x)])])
 
 (define-operator/libm (acosh real) real
   [libm acosh acoshf] [bf bfacosh] [cost 55]
@@ -161,7 +161,7 @@
   [->c/double (curry format "asin(~a)")]
   [->c/mpfr (curry format "mpfr_asin(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sin^{-1} ~a")]
-  [nonffi (match-lambda [(list x) (asin x)])])
+  [nonffi (match-lambda [(list x) (flasin x)])])
 
 (define-operator/libm (asinh real) real
   [libm asinh asinhf] [bf bfasinh] [cost 55]
@@ -175,14 +175,14 @@
   [->c/double (curry format "atan(~a)")]
   [->c/mpfr (curry format "mpfr_atan(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tan^{-1} ~a")]
-  [nonffi (match-lambda [(list x) (atan x)])])
+  [nonffi (match-lambda [(list x) (flatan x)])])
 
 (define-operator/libm (atan2 real real) real
   [libm atan2 atan2f] [bf bfatan2] [cost 140]
   [->c/double (curry format "atan2(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_atan2(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tan^{-1}_* \\frac{~a}{~a}")]
-  [nonffi (match-lambda [(list x y) (atan x y)])])
+  [nonffi (match-lambda [(list x y) (flatan x y)])])
 
 (define-operator/libm (atanh real) real
   [libm atanh atanhf] [bf bfatanh] [cost 55]
@@ -196,14 +196,14 @@
   [->c/double (curry format "cbrt(~a)")]
   [->c/mpfr (curry format "mpfr_cbrt(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sqrt[3]{~a}")]
-  [nonffi (match-lambda [(list x) (expt x (/ 1 3))])])
+  [nonffi (match-lambda [(list x) (flexpt x (fl (/ 1 3)))])])
 
 (define-operator/libm (ceil real) real
   [libm ceil ceilf] [bf bfceiling] [cost 80]
   [->c/double (curry format "ceil(~a)")]
   [->c/mpfr (curry format "mpfr_ceil(~a, ~a)")]
   [->tex (curry format "\\left\\lceil~a\\right\\rceil")]
-  [nonffi (match-lambda [(list x) (ceiling x)])])
+  [nonffi (match-lambda [(list x) (flceiling x)])])
 
 (define (bfcopysign x y)
   (bf* (bfabs x) (bf (expt -1 (bigfloat-signbit y)))))
@@ -213,21 +213,21 @@
   [->c/double (curry format "copysign(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_copysign(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{copysign}\\left(~a, ~a\\right)")]
-  [nonffi (match-lambda [(list x y) (if (>= y 0) (abs x) (- (abs x)))])])
+  [nonffi (match-lambda [(list x y) (if (>= y 0) (flabs x) (- (flabs x)))])])
 
 (define-operator/libm (cos real) real
   [libm cos cosf] [bf bfcos] [cost 60]
   [->c/double (curry format "cos(~a)")]
   [->c/mpfr (curry format "mpfr_cos(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\cos ~a")]
-  [nonffi (match-lambda [(list x) (cos x)])])
+  [nonffi (match-lambda [(list x) (flcos x)])])
 
 (define-operator/libm (cosh real) real
   [libm cosh coshf] [bf bfcosh] [cost 55]
   [->c/double (curry format "cosh(~a)")]
   [->c/mpfr (curry format "mpfr_cosh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\cosh ~a")]
-  [nonffi (match-lambda [(list x) (cosh x)])])
+  [nonffi (match-lambda [(list x) (flcosh x)])])
 
 (define-operator/libm (erf real) real
   [libm erf erff] [bf bferf] [cost 70]
@@ -248,14 +248,14 @@
   [->c/double (curry format "exp(~a)")]
   [->c/mpfr (curry format "mpfr_exp(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "e^{~a}")]
-  [nonffi (match-lambda [(list x) (exp x)])])
+  [nonffi (match-lambda [(list x) (flexp x)])])
 
 (define-operator/libm (exp2 real) real
   [libm exp2 exp2f] [bf bfexp2] [cost 70]
   [->c/double (curry format "exp2(~a)")]
   [->c/mpfr (curry format "mpfr_exp2(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "2^{~a}")]
-  [nonffi (match-lambda [(list x) (expt 2.0 x)])])
+  [nonffi (match-lambda [(list x) (flexpt 2.0 x)])])
 
 (define-operator/libm (expm1 real) real
   [libm expm1 expm1f] [bf bfexpm1] [cost 70]
@@ -269,7 +269,7 @@
   [->c/double (curry format "fabs(~a)")]
   [->c/mpfr (curry format "mpfr_abs(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\left|~a\\right|")]
-  [nonffi (match-lambda [(list x) (abs x)])])
+  [nonffi (match-lambda [(list x) (flabs x)])])
 
 (define (bffdim x y)
   (if (bf> x y)
@@ -281,14 +281,14 @@
   [->c/double (curry format "fdim(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_dim(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{fdim}\\left(~a, ~a\\right)")]
-  [nonffi (match-lambda [(list x y) (max (- x y) 0)])])
+  [nonffi (match-lambda [(list x y) (flmax (- x y) 0)])])
 
 (define-operator/libm (floor real) real
   [libm floor floorf] [bf bffloor] [cost 55]
   [->c/double (curry format "floor(~a)")]
   [->c/mpfr (curry format "mpfr_floor(~a, ~a)")]
   [->tex (curry format "\\left\\lfloor~a\\right\\rfloor")]
-  [nonffi (match-lambda [(list x) (floor x)])])
+  [nonffi (match-lambda [(list x) (flfloor x)])])
 
 (define (bffma x y z)
   (bf+ (bf* x y) z))
@@ -305,14 +305,14 @@
   [->c/double (curry format "fmax(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fmax(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{fmax}\\left(~a, ~a\\right)")]
-  [nonffi (match-lambda [(list x y) (cond  [(nan? x) y] [(nan? y) x] [else (max x y)])])])
+  [nonffi (match-lambda [(list x y) (cond  [(nan? x) y] [(nan? y) x] [else (flmax x y)])])])
 
 (define-operator/libm (fmin real real) real
   [libm fmin fminf] [bf bfmin] [cost 55]
   [->c/double (curry format "fmin(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fmin(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{fmin}\\left(~a, ~a\\right)")]
-  [nonffi (match-lambda [(list x y) (cond  [(nan? x) y] [(nan? y) x] [else (min x y)])])])
+  [nonffi (match-lambda [(list x y) (cond  [(nan? x) y] [(nan? y) x] [else (flmin x y)])])])
 
 (define (bffmod x mod)
   (bf- x (bf* mod (bffloor (bf/ x mod)))))
@@ -350,21 +350,21 @@
   [->c/double (curry format "lgamma(~a)")]
   [->c/mpfr (curry format "mpfr_lngamma(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\log_* \\left( \\mathsf{gamma} ~a \\right)")]
-  [nonffi (match-lambda [(list x) (log-gamma x)])])
+  [nonffi (match-lambda [(list x) (fllog-gamma x)])])
 
 (define-operator/libm (log real) real
   [libm log logf] [bf bflog] [cost 70]
   [->c/double (curry format "log(~a)")]
   [->c/mpfr (curry format "mpfr_log(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\log ~a")]
-  [nonffi (match-lambda [(list x) (log x)])])
+  [nonffi (match-lambda [(list x) (fllog x)])])
 
 (define-operator/libm (log10 real) real
   [libm log10 log10f] [bf bflog10] [cost 70]
   [->c/double (curry format "log10(~a)")]
   [->c/mpfr (curry format "mpfr_log10(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\log_{10} ~a")]
-  [nonffi (match-lambda [(list x) (log x 10)])])
+  [nonffi (match-lambda [(list x) (fllog x (fl 10))])])
 
 (define-operator/libm (log1p real) real
   [libm log1p log1pf] [bf bflog1p] [cost 90]
@@ -408,7 +408,7 @@
   [->c/double (curry format "pow(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_pow(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "{~a}^{~a}")]
-  [nonffi (match-lambda [(list x y) (expt x y)])])
+  [nonffi (match-lambda [(list x y) (flexpt x y)])])
 
 (define-operator/libm (remainder real real) real
   [libm remainder remainderf] [bf bfremainder] [cost 70]
@@ -436,49 +436,49 @@
   [->c/double (curry format "sin(~a)")]
   [->c/mpfr (curry format "mpfr_sin(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sin ~a")]
-  [nonffi (match-lambda [(list x) (sin x)])])
+  [nonffi (match-lambda [(list x) (flsin x)])])
 
 (define-operator/libm (sinh real) real
   [libm sinh sinhf] [bf bfsinh] [cost 55]
   [->c/double (curry format "sinh(~a)")]
   [->c/mpfr (curry format "mpfr_sinh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sinh ~a")]
-  [nonffi (match-lambda [(list x) (sinh x)])])
+  [nonffi (match-lambda [(list x) (flsinh x)])])
 
 (define-operator/libm (sqrt real) real
   [libm sqrt sqrtf] [bf bfsqrt] [cost 40]
   [->c/double (curry format "sqrt(~a)")]
   [->c/mpfr (curry format "mpfr_sqrt(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sqrt{~a}")]
-  [nonffi (match-lambda [(list x) (sqrt x)])])
+  [nonffi (match-lambda [(list x) (flsqrt x)])])
 
 (define-operator/libm (tan real) real
   [libm tan tanf] [bf bftan] [cost 95]
   [->c/double (curry format "tan(~a)")]
   [->c/mpfr (curry format "mpfr_tan(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tan ~a")]
-  [nonffi (match-lambda [(list x) (tan x)])])
+  [nonffi (match-lambda [(list x) (fltan x)])])
 
 (define-operator/libm (tanh real) real
   [libm tanh tanhf] [bf bftanh] [cost 55]
   [->c/double (curry format "tanh(~a)")]
   [->c/mpfr (curry format "mpfr_tanh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tanh ~a")]
-  [nonffi (match-lambda [(list x) (tanh x)])])
+  [nonffi (match-lambda [(list x) (fltanh x)])])
 
 (define-operator/libm (tgamma real) real
   [libm tgamma tgammaf] [bf bfgamma] [cost 55]
   [->c/double (curry format "tgamma(~a)")]
   [->c/mpfr (curry format "mpfr_gamma(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{gamma} ~a")]
-  [nonffi (match-lambda [(list x) (gamma x)])])
+  [nonffi (match-lambda [(list x) (flgamma x)])])
 
 (define-operator/libm (trunc real) real
   [libm trunc truncf] [bf bftruncate] [cost 55]
   [->c/double (curry format "trunc(~a)")]
   [->c/mpfr (curry format "mpfr_trunc(~a, ~a)")]
   [->tex (curry format "\\mathsf{trunc} ~a")]
-  [nonffi (match-lambda [(list x) (truncate x)])])
+  [nonffi (match-lambda [(list x) (fltruncate x)])])
 
 (define-operator/libm (y0 real) real
   [libm y0 y0f] [bf bfbesy0] [cost 55]
@@ -492,7 +492,7 @@
   [->c/double (curry format "y1(~a)")]
   [->c/mpfr (curry format "mpfr_y1(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{y1} ~a")]
-  [nonffi (match-lambda [(list x) (bigfloat->flonum (bfbesy1 (bf (car x))))])])
+  [nonffi (match-lambda [(list x) (bigfloat->flonum (bfbesy1 (bf x)))])])
 
 ;; DEPRECATED
 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -6,7 +6,7 @@
 (require "../common.rkt")
 (require "../float.rkt")
 
-(provide constant? variable? operator? operator-info constant-info
+(provide constant? variable? operator? operator-info constant-info prune-operators!
          *unknown-d-ops* *unknown-f-ops* *loaded-ops*)
 
 (define *unknown-d-ops* (make-parameter '()))
@@ -78,6 +78,17 @@
   [->tex      (unconstrained-argument-number-> string? string?)])
 
 (define (operator-info operator field) (table-ref operators operator field))
+
+(define (operator-remove! operator)
+  (table-remove! operators operator)
+  (*loaded-ops* (remove operator (*loaded-ops*))))
+
+(define (prune-operators!)
+  (unless (flag-set? 'precision 'fallback)
+    (for ([op (if (flag-set? 'precision 'double) (*unknown-d-ops*) (*unknown-f-ops*))])
+      (operator-remove! op)))
+
+  (unless (flag-set? 'fn 'cbrt) (operator-remove! 'cbrt)))
 
 (define-syntax-rule (define-operator (operator atypes ...) rtype [key value] ...)
   (let ([type (hash (length '(atypes ...)) (list '(atypes ...) 'rtype))]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -84,13 +84,11 @@
         [args (list (length '(atypes ...)))]
         [nonffi (if (findf (λ (x) (equal? (car x) 'nonffi)) '([key value] ...))
                       '()
-                      (list (cons 'nonffi (λ args 
-                                             (raise exn:fail:unsupported 
+                      (list (cons 'nonffi (λ args
+                                             (raise exn:fail:unsupported
                                                     (format "couldn't find ~a and no default implementation defined" 'operator)
-                                                    (current-continuation-marks)) 
+                                                    (current-continuation-marks))
                                              0.0))))])
-    ;; TODO: If we don't find the op in nonffi mode and we want to remove it,
-    ;; then don't add it to the list of loaded-ops
     (*loaded-ops* (cons 'operator (*loaded-ops*)))
     (table-set! operators 'operator
                 (make-hash (append (list (cons 'type type) (cons 'args args) (cons 'key value) ...) nonffi)))))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -80,7 +80,6 @@
 (define-syntax-rule (define-operator (operator atypes ...) rtype [key value] ...)
   (let ([type (hash (length '(atypes ...)) (list '(atypes ...) 'rtype))]
         [args (list (length '(atypes ...)))]
-        ;;TODO: This is a temporary default value. FIX THIS!
         [nonffi (if (findf (λ (x) (equal? (car x) 'nonffi)) '([key value] ...))
                       '()
                       (list (cons 'nonffi (λ args 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -147,63 +147,63 @@
   [->c/double (curry format "acos(~a)")]
   [->c/mpfr (curry format "mpfr_acos(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\cos^{-1} ~a")]
-  [nonffi acos])
+  [nonffi (match-lambda [(list x) (acos x)])])
 
 (define-operator/libm (acosh real) real
   [libm acosh acoshf] [bf bfacosh] [cost 55]
   [->c/double (curry format "acosh(~a)")]
   [->c/mpfr (curry format "mpfr_acosh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\cosh^{-1} ~a")]
-  [nonffi flacosh])
+  [nonffi (match-lambda [(list x) (flacosh x)])])
 
 (define-operator/libm (asin real) real
   [libm asin asinf] [bf bfasin] [cost 105]
   [->c/double (curry format "asin(~a)")]
   [->c/mpfr (curry format "mpfr_asin(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sin^{-1} ~a")]
-  [nonffi asin])
+  [nonffi (match-lambda [(list x) (asin x)])])
 
 (define-operator/libm (asinh real) real
   [libm asinh asinhf] [bf bfasinh] [cost 55]
   [->c/double (curry format "asinh(~a)")]
   [->c/mpfr (curry format "mpfr_asinh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sinh^{-1} ~a")]
-  [nonffi flasinh])
+  [nonffi (match-lambda [(list x) (flasinh x)])])
 
 (define-operator/libm (atan real) real
   [libm atan atanf] [bf bfatan] [cost 105]
   [->c/double (curry format "atan(~a)")]
   [->c/mpfr (curry format "mpfr_atan(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tan^{-1} ~a")]
-  [nonffi atan])
+  [nonffi (match-lambda [(list x) (atan x)])])
 
 (define-operator/libm (atan2 real real) real
   [libm atan2 atan2f] [bf bfatan2] [cost 140]
   [->c/double (curry format "atan2(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_atan2(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tan^{-1}_* \\frac{~a}{~a}")]
-  [nonffi atan])
+  [nonffi (match-lambda [(list x y) (atan x y)])])
 
 (define-operator/libm (atanh real) real
   [libm atanh atanhf] [bf bfatanh] [cost 55]
   [->c/double (curry format "atanh(~a)")]
   [->c/mpfr (curry format "mpfr_atanh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tanh^{-1} ~a")]
-  [nonffi flatanh])
+  [nonffi (match-lambda [(list x) (flatanh x)])])
 
 (define-operator/libm (cbrt real) real
   [libm cbrt cbrtf] [bf bfcbrt] [cost 80]
   [->c/double (curry format "cbrt(~a)")]
   [->c/mpfr (curry format "mpfr_cbrt(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sqrt[3]{~a}")]
-  [nonffi (λ (x) (expt x (/ 1 3)))])
+  [nonffi (match-lambda [(list x) (expt x (/ 1 3))])])
 
 (define-operator/libm (ceil real) real
   [libm ceil ceilf] [bf bfceiling] [cost 80]
   [->c/double (curry format "ceil(~a)")]
   [->c/mpfr (curry format "mpfr_ceil(~a, ~a)")]
   [->tex (curry format "\\left\\lceil~a\\right\\rceil")]
-  [nonffi ceiling])
+  [nonffi (match-lambda [(list x) (ceiling x)])])
 
 (define (bfcopysign x y)
   (bf* (bfabs x) (bf (expt -1 (bigfloat-signbit y)))))
@@ -213,63 +213,63 @@
   [->c/double (curry format "copysign(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_copysign(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{copysign}\\left(~a, ~a\\right)")]
-  [nonffi (λ (x y) (if (>= y 0) (abs x) (- (abs x))))])
+  [nonffi (match-lambda [(list x y) (if (>= y 0) (abs x) (- (abs x)))])])
 
 (define-operator/libm (cos real) real
   [libm cos cosf] [bf bfcos] [cost 60]
   [->c/double (curry format "cos(~a)")]
   [->c/mpfr (curry format "mpfr_cos(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\cos ~a")]
-  [nonffi cos])
+  [nonffi (match-lambda [(list x) (cos x)])])
 
 (define-operator/libm (cosh real) real
   [libm cosh coshf] [bf bfcosh] [cost 55]
   [->c/double (curry format "cosh(~a)")]
   [->c/mpfr (curry format "mpfr_cosh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\cosh ~a")]
-  [nonffi cosh])
+  [nonffi (match-lambda [(list x) (cosh x)])])
 
 (define-operator/libm (erf real) real
   [libm erf erff] [bf bferf] [cost 70]
   [->c/double (curry format "erf(~a)")]
   [->c/mpfr (curry format "mpfr_erf(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{erf} ~a")]
-  [nonffi flerf])
+  [nonffi (match-lambda [(list x) (flerf x)])])
 
 (define-operator/libm (erfc real) real
   [libm erfc erfcf] [bf bferfc] [cost 70]
   [->c/double (curry format "erfc(~a)")]
   [->c/mpfr (curry format "mpfr_erfc(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{erfc} ~a")]
-  [nonffi flerfc])
+  [nonffi (match-lambda [(list x) (flerfc x)])])
 
 (define-operator/libm (exp real) real
   [libm exp expf] [bf bfexp] [cost 70]
   [->c/double (curry format "exp(~a)")]
   [->c/mpfr (curry format "mpfr_exp(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "e^{~a}")]
-  [nonffi exp])
+  [nonffi (match-lambda [(list x) (exp x)])])
 
 (define-operator/libm (exp2 real) real
   [libm exp2 exp2f] [bf bfexp2] [cost 70]
   [->c/double (curry format "exp2(~a)")]
   [->c/mpfr (curry format "mpfr_exp2(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "2^{~a}")]
-  [nonffi (λ (x) (expt 2.0 x))])
+  [nonffi (match-lambda [(list x) (expt 2.0 x)])])
 
 (define-operator/libm (expm1 real) real
   [libm expm1 expm1f] [bf bfexpm1] [cost 70]
   [->c/double (curry format "expm1(~a)")]
   [->c/mpfr (curry format "mpfr_expm1(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "(e^{~a} - 1)^*")]
-  [nonffi flexpm1])
+  [nonffi (match-lambda [(list x) (flexpm1 x)])])
 
 (define-operator/libm (fabs real) real
   [libm fabs fabsf] [bf bfabs] [cost 40]
   [->c/double (curry format "fabs(~a)")]
   [->c/mpfr (curry format "mpfr_abs(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\left|~a\\right|")]
-  [nonffi abs])
+  [nonffi (match-lambda [(list x) (abs x)])])
 
 (define (bffdim x y)
   (if (bf> x y)
@@ -281,14 +281,14 @@
   [->c/double (curry format "fdim(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_dim(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{fdim}\\left(~a, ~a\\right)")]
-  [nonffi (λ (x y) (max (- x y) 0))])
+  [nonffi (match-lambda [(list x y) (max (- x y) 0)])])
 
 (define-operator/libm (floor real) real
   [libm floor floorf] [bf bffloor] [cost 55]
   [->c/double (curry format "floor(~a)")]
   [->c/mpfr (curry format "mpfr_floor(~a, ~a)")]
   [->tex (curry format "\\left\\lfloor~a\\right\\rfloor")]
-  [nonffi floor])
+  [nonffi (match-lambda [(list x) (floor x)])])
 
 (define (bffma x y z)
   (bf+ (bf* x y) z))
@@ -298,21 +298,21 @@
   [->c/double (curry format "fma(~a, ~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fma(~a, ~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "(~a \\cdot ~a + ~a)_*")]
-  [nonffi (λ (x y z) (bigfloat->flonum (bf+ (bf* (bf x) (bf y)) (bf z))))])
+  [nonffi (match-lambda [(list x y z) (bigfloat->flonum (bf+ (bf* (bf x) (bf y)) (bf z)))])])
 
 (define-operator/libm (fmax real real) real
   [libm fmax fmaxf] [bf bfmax] [cost 55]
   [->c/double (curry format "fmax(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fmax(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{fmax}\\left(~a, ~a\\right)")]
-  [nonffi (λ (x y) (cond  [(nan? x) y] [(nan? y) x] [else (max x y)]))])
+  [nonffi (match-lambda [(list x y) (cond  [(nan? x) y] [(nan? y) x] [else (max x y)])])])
 
 (define-operator/libm (fmin real real) real
   [libm fmin fminf] [bf bfmin] [cost 55]
   [->c/double (curry format "fmin(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fmin(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{fmin}\\left(~a, ~a\\right)")]
-  [nonffi (λ (x y) (cond  [(nan? x) y] [(nan? y) x] [else (min x y)]))])
+  [nonffi (match-lambda [(list x y) (cond  [(nan? x) y] [(nan? y) x] [else (min x y)])])])
 
 (define (bffmod x mod)
   (bf- x (bf* mod (bffloor (bf/ x mod)))))
@@ -322,63 +322,63 @@
   [->c/double (curry format "fmod(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_fmod(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "~a \\bmod ~a")]
-  [nonffi (λ (x) (bigfloat->flonum (bffmod x)))])
+  [nonffi (match-lambda [(list x y) (bigfloat->flonum (bffmod (bf x) (bf y)))])])
 
 (define-operator/libm (hypot real real) real
   [libm hypot hypotf] [bf bfhypot] [cost 55]
   [->c/double (curry format "hypot(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_hypot(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sqrt{~a^2 + ~a^2}^*")]
-  [nonffi flhypot])
+  [nonffi (match-lambda [(list x y) (flhypot x y)])])
 
 (define-operator/libm (j0 real) real
   [libm j0 j0f] [bf bfbesj0] [cost 55]
   [->c/double (curry format "j0(~a)")]
   [->c/mpfr (curry format "mpfr_j0(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{j0} ~a")]
-  [nonffi (λ (x) (bigfloat->flonum (bfbesj0 (bf x))))])
+  [nonffi (match-lambda [(list x) (bigfloat->flonum (bfbesj0 (bf x)))])])
 
 (define-operator/libm (j1 real) real
   [libm j1 j1f] [bf bfbesj1] [cost 55]
   [->c/double (curry format "j1(~a)")]
   [->c/mpfr (curry format "mpfr_j1(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{j1} ~a")]
-  [nonffi (λ (x) (bigfloat->flonum (bfbesj1 (bf x))))])
+  [nonffi (match-lambda [(list x) (bigfloat->flonum (bfbesj1 (bf x)))])])
 
 (define-operator/libm (lgamma real) real
   [libm lgamma lgammaf] [bf bflog-gamma] [cost 55]
   [->c/double (curry format "lgamma(~a)")]
   [->c/mpfr (curry format "mpfr_lngamma(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\log_* \\left( \\mathsf{gamma} ~a \\right)")]
-  [nonffi log-gamma])
+  [nonffi (match-lambda [(list x) (log-gamma x)])])
 
 (define-operator/libm (log real) real
   [libm log logf] [bf bflog] [cost 70]
   [->c/double (curry format "log(~a)")]
   [->c/mpfr (curry format "mpfr_log(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\log ~a")]
-  [nonffi log])
+  [nonffi (match-lambda [(list x) (log x)])])
 
 (define-operator/libm (log10 real) real
   [libm log10 log10f] [bf bflog10] [cost 70]
   [->c/double (curry format "log10(~a)")]
   [->c/mpfr (curry format "mpfr_log10(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\log_{10} ~a")]
-  [nonffi (λ (x) (log x 10))])
+  [nonffi (match-lambda [(list x) (log x 10)])])
 
 (define-operator/libm (log1p real) real
   [libm log1p log1pf] [bf bflog1p] [cost 90]
   [->c/double (curry format "log1p(~a)")]
   [->c/mpfr (curry format "mpfr_log1p(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\log_* (1 + ~a)")]
-  [nonffi fllog1p])
+  [nonffi (match-lambda [(list x) (fllog1p x)])])
 
 (define-operator/libm (log2 real) real
   [libm log2 log2f] [bf bflog2] [cost 70]
   [->c/double (curry format "log2(~a)")]
   [->c/mpfr (curry format "mpfr_log2(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\log_{2} ~a")]
-  [nonffi fllog2])
+  [nonffi (match-lambda [(list x) (fllog2 x)])])
 
 (define (bflogb x)
   (bigfloat-exponent x))
@@ -388,111 +388,111 @@
   [->c/double (curry format "logb(~a)")]
   [->c/mpfr (curry format "mpfr_set_si(~a, mpfr_get_exp(~a), MPFR_RNDN)")]
   [->tex (curry format "\\log^{*}_{b} ~a")]
-  [nonffi (λ (x) (cond 
-                    [(or (= x +inf.0) (= x -inf.0)) +inf.0]
-                    [(nan? x) x]
-                    [(= x 0) -inf.0]
-                    ;; Manually extract exponent from double or float
-                    [else (if (flag-set? 'precision 'double)
-                              (- (arithmetic-shift (bitwise-and #x7ff0000000000000
-                                                                (flonum->bit-field x))
-                                                   -52)
-                                 (1023))
-                              (- (arithmetic-shift (bitwise-and #x7f800000 ;; TODO: This doesn't work
-                                                                (single-flonum->bit-field (real->single-flonum x)))
-                                                   -23)
-                                 (127)))]))])
+  [nonffi (match-lambda [(list x) (cond 
+    [(or (= x +inf.0) (= x -inf.0)) +inf.0]
+    [(nan? x) x]
+    [(= x 0) -inf.0]
+    ;; Manually extract exponent from double or float
+    [else (if (flag-set? 'precision 'double)
+              (- (arithmetic-shift (bitwise-and #x7ff0000000000000
+                                                (flonum->bit-field x))
+                                   -52)
+                 (1023))
+              (- (arithmetic-shift (bitwise-and #x7f800000 ;; TODO: This doesn't work
+                                                (single-flonum->bit-field (real->single-flonum x)))
+                                   -23)
+                 (127)))])])])
 
 (define-operator/libm (pow real real) real
   [libm pow powf] [bf bfexpt] [cost 210]
   [->c/double (curry format "pow(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_pow(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "{~a}^{~a}")]
-  [nonffi (λ (x y) (expt x y))])
+  [nonffi (match-lambda [(list x y) (expt x y)])])
 
 (define-operator/libm (remainder real real) real
   [libm remainder remainderf] [bf bfremainder] [cost 70]
   [->c/double (curry format "remainder(~a, ~a)")]
   [->c/mpfr (curry format "mpfr_remainder(~a, ~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "~a \\mathsf{rem} ~a")]
-  [nonffi (λ (x y) (bigfloat->flonum (bfremainder (bf x) (bf y))))])
+  [nonffi (match-lambda [(list x y) (bigfloat->flonum (bfremainder (bf x) (bf y)))])])
 
 (define-operator/libm (rint real) real
   [libm rint rintf] [bf bfrint] [cost 70]
   [->c/double (curry format "rint(~a)")]
   [->c/mpfr (curry format "mpfr_rint(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{rint} ~a")]
-  [nonffi flround])
+  [nonffi (match-lambda [(list x) (flround x)])])
 
 (define-operator/libm (round real) real
   [libm round roundf] [bf bfround] [cost 70]
   [->c/double (curry format "round(~a)")]
   [->c/mpfr (curry format "mpfr_round(~a, ~a)")]
   [->tex (curry format "\\mathsf{round} ~a")]
-  [nonffi flround])
+  [nonffi (match-lambda [(list x) (flround x)])])
 
 (define-operator/libm (sin real) real
   [libm sin sinf] [bf bfsin] [cost 60]
   [->c/double (curry format "sin(~a)")]
   [->c/mpfr (curry format "mpfr_sin(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sin ~a")]
-  [nonffi sin])
+  [nonffi (match-lambda [(list x) (sin x)])])
 
 (define-operator/libm (sinh real) real
   [libm sinh sinhf] [bf bfsinh] [cost 55]
   [->c/double (curry format "sinh(~a)")]
   [->c/mpfr (curry format "mpfr_sinh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sinh ~a")]
-  [nonffi sinh])
+  [nonffi (match-lambda [(list x) (sinh x)])])
 
 (define-operator/libm (sqrt real) real
   [libm sqrt sqrtf] [bf bfsqrt] [cost 40]
   [->c/double (curry format "sqrt(~a)")]
   [->c/mpfr (curry format "mpfr_sqrt(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\sqrt{~a}")]
-  [nonffi sqrt])
+  [nonffi (match-lambda [(list x) (sqrt x)])])
 
 (define-operator/libm (tan real) real
   [libm tan tanf] [bf bftan] [cost 95]
   [->c/double (curry format "tan(~a)")]
   [->c/mpfr (curry format "mpfr_tan(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tan ~a")]
-  [nonffi tan])
+  [nonffi (match-lambda [(list x) (tan x)])])
 
 (define-operator/libm (tanh real) real
   [libm tanh tanhf] [bf bftanh] [cost 55]
   [->c/double (curry format "tanh(~a)")]
   [->c/mpfr (curry format "mpfr_tanh(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\tanh ~a")]
-  [nonffi tanh])
+  [nonffi (match-lambda [(list x) (tanh x)])])
 
 (define-operator/libm (tgamma real) real
   [libm tgamma tgammaf] [bf bfgamma] [cost 55]
   [->c/double (curry format "tgamma(~a)")]
   [->c/mpfr (curry format "mpfr_gamma(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{gamma} ~a")]
-  [nonffi gamma])
+  [nonffi (match-lambda [(list x) (gamma x)])])
 
 (define-operator/libm (trunc real) real
   [libm trunc truncf] [bf bftruncate] [cost 55]
   [->c/double (curry format "trunc(~a)")]
   [->c/mpfr (curry format "mpfr_trunc(~a, ~a)")]
   [->tex (curry format "\\mathsf{trunc} ~a")]
-  [nonffi truncate])
+  [nonffi (match-lambda [(list x) (truncate x)])])
 
 (define-operator/libm (y0 real) real
   [libm y0 y0f] [bf bfbesy0] [cost 55]
   [->c/double (curry format "y0(~a)")]
   [->c/mpfr (curry format "mpfr_y0(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{y0} ~a")]
-  [nonffi (λ (x) (bigfloat->flonum (bfbesy0 (bf x))))])
+  [nonffi (match-lambda [(list x) (bigfloat->flonum (bfbesy0 (bf x)))])])
 
 (define-operator/libm (y1 real) real
   [libm y1 y1f] [bf bfbesy1] [cost 55]
   [->c/double (curry format "y1(~a)")]
   [->c/mpfr (curry format "mpfr_y1(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "\\mathsf{y1} ~a")]
-  [nonffi (λ (x) (bigfloat->flonum (bfbesy1 (bf x))))])
+  [nonffi (match-lambda [(list x) (bigfloat->flonum (bfbesy1 (bf (car x))))])])
 
 ;; DEPRECATED
 
@@ -501,14 +501,14 @@
   [->c/double (λ (x) (format "~a * ~a" x x))]
   [->c/mpfr (curry format "mpfr_sqr(~a, ~a, MPFR_RNDN)")]
   [->tex (curry format "{~a}^2")]
-  [nonffi (λ (x) (* x x))])
+  [nonffi (match-lambda [(list x) (* x x)])])
 
 (define-operator (cube real) real
   [fl (λ (x) (* x (* x x)))] [bf (λ (x) (bf* x (bf* x x)))] [cost 80]
   [->c/double (λ (x) (format "~a * (~a * ~a)" x x x))]
   [->c/mpfr (λ (out x) (format "mpfr_sqr(~a, ~a, MPFR_RNDN); mpfr_mul(~a, ~a, ~a, MPFR_RNDN)" out x out out x))]
   [->tex (curry format "{~a}^3")]
-  [nonffi (λ (x) (* x x x))])
+  [nonffi (match-lambda [(list x) (* x x x)])])
 
 (define (if-fn test if-true if-false) (if test if-true if-false))
 (define (and-fn . as) (andmap identity as))

--- a/www/doc/1.2/faq.html
+++ b/www/doc/1.2/faq.html
@@ -75,6 +75,16 @@
     with <code>--allow-file-access-from-files</code> to fix this error.
   </p>
 
+  <h3 id="native-ops">"Warning: native <i>operation</i> not supported on your system"</h3>
+
+  <p>
+    Some systems may not support a native implementation for all
+    operations that Herbie uses. Herbie provides a default fallback
+    implementation which is used by default for functions whose
+    native implementation is not found. You can disable this fallback
+    functionality with <code>--disable precision:fallback</code>.
+  </p>
+
   <h2>Reported but unreproduced errors</h2>
 
   <p>

--- a/www/doc/1.2/options.html
+++ b/www/doc/1.2/options.html
@@ -180,6 +180,14 @@
       double-precision calculations. If turned off, Herbie treats its
       input as a single-precision calculation.</dd>
 
+    <dt><code>precision:fallback</code></dt>
+    <dd>This option, on by default, tells Herbie to use fallback
+      functions if a native implementation is not found for any
+      operations. If turned off, operations with no native
+      implementation will be disabled from use in the input or output.
+      You will want to turn this option off if you are concerned with
+      the specific behavior of libm functions.</dd>
+
     <dt><code>setup:simplify</code></dt>
     <dd>This option, on by default, simplifies the expression before
       passing it to Herbie. If turned off, Herbie will not simplify


### PR DESCRIPTION
This change adds full support for Windows. Operations that can't find a native implementation will now use a default fallback function specified by Herbie. By default, this fallback implementation will be used, but the behavior can be disabled with the new flag `precision:fallback`. Disabling this flag will disable any operations that don't have an associated native implementation, making them unusable for input, and unable to show up in the output.