### PR TITLE
Teach regimes not to split equal points

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -111,6 +111,23 @@
   (define split-points (sindices->spoints pts expr alts split-indices))
   (option split-points (pick-errors split-points pts err-lsts)))
 
+(module+ test
+  (parameterize ([*start-prog* '(λ (x) 1)]
+                 [*pcontext* (mk-pcontext '((0.5) (4.0)) '(1.0 1.0))])
+    (define alts (map (λ (body) (make-alt `(λ (x) ,body))) (list '(fmin x 1) '(fmax x 1))))
+
+    ;; This is a basic sanity test
+    (check (λ (x y) (equal? (map sp-cidx (option-splitpoints x)) y))
+           (option-on-expr alts 'x)
+           '(1 0))
+
+    ;; This test ensures we handle equal points correctly. All points
+    ;; are equal along the `1` axis, so we should only get one
+    ;; splitpoint (the second, since it is better at the further point).
+    (check (λ (x y) (equal? (map sp-cidx (option-splitpoints x)) y))
+           (option-on-expr alts '1)
+           '(1))))
+
 ;; Accepts a list of sindices in one indexed form and returns the
 ;; proper splitpoints in float form.
 (define (sindices->spoints points expr alts sindices)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -25,20 +25,7 @@
     (define options
       (map (curry option-on-expr alts)
            (if axis (list axis) (exprs-to-branch-on alts))))
-    (define options*
-      ;; This is a hack. If the bexpr evaluates to the same value for
-      ;; several points, we need to avoid placing a split point
-      ;; between them. We don't do that. Instead, we (implicitly) move
-      ;; the splitpoint to the right until all points with the same
-      ;; value are grouped. Perhaps this will ruin a promising option,
-      ;; but oh well. But this can cause the problem with having two
-      ;; split points in the same place! Right now, we just avoid
-      ;; those options totally, but really, they could be good, and we
-      ;; shouldn't just drop them.
-      (for/list ([option options]
-                 #:unless (check-duplicates (map sp-point (option-splitpoints option))))
-        option))
-    (define best-option (argmin (compose errors-score option-errors) options*))
+    (define best-option (argmin (compose errors-score option-errors) options))
     (define splitpoints (option-splitpoints best-option))
     (define altns (used-alts splitpoints alts))
     (define splitpoints* (coerce-indices splitpoints))


### PR DESCRIPTION
Fixes a bug in regimes wherein regimes may attempt to put a branch between two points even if those points evaluate to the same value under the branch expression. The fix is to pass in an array of true/false values that determine where branches are allowed, and not to consider branches where they are not allowed.

Also some new unit tests are added to test that this functionality works. The commit is unlikely to affect the accuracy of Herbie in most cases.