### PR TITLE
Simplify conditions

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -110,7 +110,9 @@
     [(? real?)
      (not (or (infinite? x) (nan? x)))]
     [(? complex?)
-     (and (ordinary-value? (real-part x)) (ordinary-value? (imag-part x)))]))
+     (and (ordinary-value? (real-part x)) (ordinary-value? (imag-part x)))]
+    [(? boolean?)
+     true]))
 
 (module+ test
   (check-true (ordinary-value? 2.5))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -13,7 +13,7 @@
         [setup . (simplify early-exit)]
         [generate . (rr taylor simplify)]
         [reduce . (regimes taylor simplify avg-error post-process binary-search branch-expressions)]
-        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics complex)]))
+        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics complex branches)]))
 
 (define default-flags
   #hash([precision . (double fallback)]
@@ -21,7 +21,7 @@
         [setup . (simplify)]
         [generate . (rr taylor simplify)]
         [reduce . (regimes taylor simplify avg-error binary-search branch-expressions)]
-        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic complex)]))
+        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic complex branches)]))
 
 (define (enable-flag! category flag)
   (define (update cat-flags) (set-add cat-flags flag))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -13,7 +13,7 @@
         [setup . (simplify early-exit)]
         [generate . (rr taylor simplify)]
         [reduce . (regimes taylor simplify avg-error post-process binary-search branch-expressions)]
-        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics complex branches)]))
+        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics complex bools branches)]))
 
 (define default-flags
   #hash([precision . (double fallback)]
@@ -21,7 +21,7 @@
         [setup . (simplify)]
         [generate . (rr taylor simplify)]
         [reduce . (regimes taylor simplify avg-error binary-search branch-expressions)]
-        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic complex branches)]))
+        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic complex bools branches)]))
 
 (define (enable-flag! category flag)
   (define (update cat-flags) (set-add cat-flags flag))

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -22,7 +22,9 @@
      (if (flag-set? 'precision 'double) (flonums-between x y) (single-flonums-between x y))]
     [((? complex?) (? complex?))
      (+ (ulp-difference (real-part x) (real-part y))
-        (ulp-difference (imag-part x) (imag-part y)))]))
+        (ulp-difference (imag-part x) (imag-part y)))]
+    [((? boolean?) (? boolean?))
+     (if (equal? x y) 0 64)]))
 
 (define (*bit-width*) (if (flag-set? 'precision 'double) 64 32))
 

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -37,15 +37,17 @@
 (define/contract (->flonum x)
   (-> any/c (or/c flonum? complex? boolean?))
   (define convert
-    (if (flag-set? 'precision 'double) real->double-flonum real->single-flonum))
-
+    (if (flag-set? 'precision 'double)
+        real->double-flonum
+        real->single-flonum))
   (cond
    [(real? x) (convert x)]
    [(bigfloat? x) (convert (bigfloat->flonum x))]
    [(bigcomplex? x)
-    (make-rectangular (->flonum (bigcomplex-re x)) (->flonum (bigcomplex-im x)))]
+    (make-rectangular (->flonum (bigcomplex-re x))
+                      (->flonum (bigcomplex-im x)))]
    [(and (symbol? x) (constant? x))
-    (convert ((constant-info x 'fl)))]
+    (->flonum ((constant-info x 'fl)))]
    [else x]))
 
 (define (->bf x)

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -501,11 +501,13 @@
 
 (define-ruleset compare-reduce (bools simplify fp-safe)
   [lt-same      (<  x x)         FALSE]
+  [gt-same      (>  x x)         FALSE]
   [lte-same     (<= x x)         TRUE]
-  [gt-lte       (>  x y)         (<= y x)]
-  [gte-lt       (>= x y)         (<  y x)]
-  [not-lt       (not (<  x y))   (<= y x)]
-  [not-lte      (not (<= x y))   (<  y x)])
+  [gte-same     (>= x x)         TRUE]
+  [not-lt       (not (<  x y))   (>= x y)]
+  [not-gt       (not (>  x y))   (<= x y)]
+  [not-lte      (not (<= x y))   (>  x y)]
+  [not-gte      (not (>= x y))   (<  x y)])
 
 (define-ruleset branch-reduce (branches simplify fp-safe)
   [if-true        (if TRUE x y)       x]

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -651,7 +651,12 @@
         (with-handlers ([exn:fail:contract? (λ (e) (eprintf "~a: ~a\n" name (exn-message e)))])
           (define ex1 (map prog1 points))
           (define ex2 (map prog2 points))
-          ;; switch to this check instead to see failing inputs
-          ;; (for/and ([v1 ex1] [v2 ex2]) (check-equal? v1 v2)))))))
-          (define errs (for/and ([v1 ex1] [v2 ex2]) (equal? v1 v2)))
-          (check-true errs))))))
+          (define err
+            (for/first ([pt points] [v1 ex1] [v2 ex2]
+                        #:unless (equal? v1 v2))
+              (list pt v1 v2)))
+          (when err
+            (match-define (list pt v1 v2) err)
+            (with-check-info (['point (map list fv pt)] ['input-value v1] ['output-value v2])
+                             (check-false err))))))))
+;

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -505,7 +505,7 @@
   [or-false-r   (or a FALSE)     a]
   [or-same      (or a a)         a])
 
-(define-ruleset compare-reduce (bools simplify fp-safe)
+(define-ruleset compare-reduce (bools simplify fp-safe-nan)
   [lt-same      (<  x x)         FALSE]
   [gt-same      (>  x x)         FALSE]
   [lte-same     (<= x x)         TRUE]

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -472,6 +472,30 @@
   [expm1-log1p-u x              (expm1 (log1p x))]
   [hypot-udef    (hypot x y)    (sqrt (+ (* x x) (* y y)))])
 
+(define-ruleset numerics-papers (numerics)
+  ;  "Further Analysis of Kahan's Algorithm for
+  ;   the Accurate Computation of 2x2 Determinants"
+  ;  Jeannerod et al., Mathematics of Computation, 2013
+  ;
+  ;  a * b - c * d  ===> fma(a, b, -(d * c)) + fma(-d, c, d * c)
+  [prod-diff    (- (* a b) (* c d))
+                (+ (fma a b (- (* d c)))
+                   (fma (- d) c (* d c)))])
+
+;; TODO
+;; (define-ruleset bool-reduce (bools simplify)
+;;   ...)
+
+(define-ruleset branch-reduce (branches simplify)
+  [if-true        (if TRUE x y)       x]
+  [if-false       (if FALSE x y)      y]
+  [if-same        (if a x x)          x]
+  [if-not         (if (not a) x y)    (if a y x)]
+  [if-if-or       (if a x (if b x y)) (if (or a b) x y)]
+  [if-if-or-not   (if a x (if b y x)) (if (or a (not b)) x y)]
+  [if-if-and      (if a (if b x y) y) (if (and a b) x y)]
+  [if-if-and-not  (if a (if b y x) y) (if (and a (not b)) x y)])
+
 (define-ruleset complex-number-basics (complex simplify)
   [real-part     (re (complex x y))     x]
   [imag-part     (im (complex x y))     y]
@@ -485,20 +509,6 @@
   [complex-div-def  (/ (complex a b) (complex c d)) (complex (/ (+ (* a c) (* b d)) (+ (* c c) (* d d))) (/ (- (* b c) (* a d)) (+ (* c c) (* d d))))]
   [complex-conj-def (conj (complex a b)) (complex a (- b))]
   )
-
-;; TODO
-;; (define-ruleset bool-reduce (bools simplify)
-;;   ...)
-
-(define-ruleset branch-reduce (branches simplify)
-  [if-true        (if #t x y)         x]
-  [if-false       (if #f x y)         y]
-  [if-same        (if a x x)          x]
-  [if-not         (if (not a) x y)    (if a y x)]
-  [if-if-or       (if a x (if b x y)) (if (or a b) x y)]
-  [if-if-or-not   (if a x (if b y x)) (if (or a (not b)) x y)]
-  [if-if-and      (if a (if b x y) y) (if (and a b) x y)]
-  [if-if-and-not  (if a (if b y x) y) (if (and a (not b)) x y)])
 
 (define (rule-valid-at-type? rule type)
   (match type
@@ -515,15 +525,6 @@
 (define (*complex-rules*)
   (for/append ([(rules groups) (in-dict (*rulesets*))])
     (if (set-member? groups 'complex) rules '())))
-
-(define-ruleset numerics-papers (numerics)
-  ;  "Further Analysis of Kahan's Algorithm for the Accurate Computation of 2x2 Determinants"
-  ;  Jeannerod et al., Mathematics of Computation, 2013
-  ;
-  ;  a * b - c * d  ===> fma(a, b, -(d * c)) + fma(-d, c, d * c)
-  [prod-diff    (- (* a b) (* c d))
-                (+ (fma a b (- (* d c)))
-                   (fma (- d) c (* d c)))])
 
 (define (*rules*)
   (for/append ([(rules groups) (in-dict (*rulesets*))])

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -592,14 +592,15 @@
       ;; TODO these tests need to sample and compare bools (inputs and outputs are not flonums)
       '(not-true not-false not-not not-and not-or
         and-true-l and-true-r and-false-l and-false-r and-same
-        or-true-l or-true-r or-false-l or-false-r or-same)
-      ;; TODO these tests need to sample flonums (inputs) and compare bools (outputs)
-      '(lt-same lte-same gt-lte gte-lt not-lt not-lte)))
+        or-true-l or-true-r or-false-l or-false-r or-same)))
 
   (for ([test-rule (*rules*)] #:unless (set-member? *skip-tests* (rule-name test-rule)))
     (parameterize ([bf-precision 2000])
     (with-check-info (['rule test-rule])
-      (with-handlers ([exn:fail? (λ (e) (fail (exn-message e)))])
+      (with-handlers ([exn:fail? (λ (e)
+                                   ((error-display-handler)
+                                    (exn-message e) e)
+                                   (fail (exn-message e)))])
         (match-define (rule name p1 p2) test-rule)
         ;; Not using the normal prepare-points machinery for speed.
         (define fv (free-variables p1))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -486,7 +486,7 @@
 ;; (define-ruleset bool-reduce (bools simplify)
 ;;   ...)
 
-(define-ruleset branch-reduce (branches simplify)
+(define-ruleset branch-reduce (branches simplify fp-safe)
   [if-true        (if TRUE x y)       x]
   [if-false       (if FALSE x y)      y]
   [if-same        (if a x x)          x]

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -486,6 +486,20 @@
   [complex-conj-def (conj (complex a b)) (complex a (- b))]
   )
 
+;; TODO
+;; (define-ruleset bool-reduce (bools simplify)
+;;   ...)
+
+(define-ruleset branch-reduce (branches simplify)
+  [if-true        (if #t x y)         x]
+  [if-false       (if #f x y)         y]
+  [if-same        (if a x x)          x]
+  [if-not         (if (not a) x y)    (if a y x)]
+  [if-if-or       (if a x (if b x y)) (if (or a b) x y)]
+  [if-if-or-not   (if a x (if b y x)) (if (or a (not b)) x y)]
+  [if-if-and      (if a (if b x y) y) (if (and a b) x y)]
+  [if-if-and-not  (if a (if b y x) y) (if (and a (not b)) x y)])
+
 (define (rule-valid-at-type? rule type)
   (match type
     ['complex (set-member? (for/set ([r (*complex-rules*)]) (values (rule-name r))) (rule-name rule))]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -17,7 +17,8 @@
 
 (define (type? x) (or (equal? x 'real) (equal? x 'bool) (equal? x 'complex)))
 
-;; Constants's values are defined as functions to allow them to depend on (bf-precision) and (flag 'precision 'double).
+;; Constants's values are defined as functions to allow them to
+;; depend on (bf-precision) and (flag 'precision 'double).
 
 (define-table constants
   [type type?]
@@ -655,7 +656,9 @@
   (and (symbol? op) (dict-has-key? (cdr operators) op)))
 
 (define (constant? var)
-  (or (number? var) (and (symbol? var) (dict-has-key? (cdr constants) var))))
+  (or (number? var)
+      (and (symbol? var)
+           (dict-has-key? (cdr constants) var))))
 
 (define (variable? var)
   (and (symbol? var) (not (constant? var))))


### PR DESCRIPTION
This PR adds some basic rules for merging nested conditionals with related rules for simplifying boolean and comparison operators.  To support unit tests, we also added optional type annotations to rule sets (e.g., to sample boolean inputs to the boolean operator rewrites).  Finally, we extended the notion of "ulp difference" to comparing boolean outputs where unequal bools have 64 ulps of error for now.