### PR TITLE
Split complex and real operators

### DIFF
--- a/bench/libraries/mathjs/arithmetic.fpcore
+++ b/bench/libraries/mathjs/arithmetic.fpcore
@@ -11,12 +11,21 @@
 
 (FPCore (x.re x.im)
  :name "math.cube on complex, real part"
+ :herbie-target
+ (+ (* (* x.re x.re) (- x.re x.im))
+    (* (* x.re x.im) (- x.re (* 3 x.im))))
+
  (-
   (* (- (* x.re x.re) (* x.im x.im)) x.re)
   (* (+ (* x.re x.im) (* x.im x.re)) x.im)))
 
 (FPCore (x.re x.im)
  :name "math.cube on complex, imaginary part"
+ :herbie-target
+ (+
+  (* (* x.re x.im) (* 2 x.re))
+  (* (* x.im (- x.re x.im)) (+ x.re x.im)))
+
  (+
   (* (- (* x.re x.re) (* x.im x.im)) x.im)
   (* (+ (* x.re x.im) (* x.im x.re)) x.re)))
@@ -107,7 +116,7 @@
 
 (FPCore (re im)
  :name "math.sqrt on complex, imaginary part, im greater than 0 branch"
- (* 0.5 (sqrt (* 2.0 (+ (sqrt (- (* re re) (* im im))) re)))))
+ (* 0.5 (sqrt (* 2.0 (- (sqrt (+ (* re re) (* im im))) re)))))
 
 (FPCore (re im)
  :name "math.square on complex, real part"

--- a/src/bigcomplex.rkt
+++ b/src/bigcomplex.rkt
@@ -25,14 +25,12 @@
   (bigcomplex (bf+ (bigcomplex-re x) (bigcomplex-re y))
               (bf+ (bigcomplex-im x) (bigcomplex-im y))))
 
-(define (bf-complex-sub x [y #f])
-  (if y
-      (bf-complex-add x (bf-complex-neg y))
-      (bf-complex-neg x)))
+(define (bf-complex-sub x y)
+  (bf-complex-add x (bf-complex-neg y)))
 
 (define (bf-complex-mult x y)
   (bigcomplex (bf+ (bf* (bigcomplex-re x) (bigcomplex-re y)) (bf- (bf* (bigcomplex-im x) (bigcomplex-im y))))
-        (bf+ (bf* (bigcomplex-im x) (bigcomplex-re y)) (bf* (bigcomplex-re x) (bigcomplex-im y)))))
+              (bf+ (bf* (bigcomplex-im x) (bigcomplex-re y)) (bf* (bigcomplex-re x) (bigcomplex-im y)))))
 
 (define (bf-complex-conjugate x)
   (bigcomplex (bigcomplex-re x) (bf- (bigcomplex-im x))))

--- a/src/bigcomplex.rkt
+++ b/src/bigcomplex.rkt
@@ -16,19 +16,19 @@
           [bf-complex-log (-> bigcomplex? bigcomplex?)]
           [bf-complex-sqrt (-> bigcomplex? bigcomplex?)]
           [bf-complex-pow (-> bigcomplex? bigcomplex? bigcomplex?)]
-          [bf-complex-div (-> bigcomplex? bigcomplex? bigcomplex?)])
-         exact+ exact- exact* exact/ exact-sqr exact-log exact-pow exact-sqrt exact-exp)
+          [bf-complex-div (-> bigcomplex? bigcomplex? bigcomplex?)]))
+
+(define (bf-complex-neg x)
+  (bigcomplex (bf- (bigcomplex-re x)) (bf- (bigcomplex-im x))))
 
 (define (bf-complex-add x y)
-  (bigcomplex (bf+ (bigcomplex-re x) (bigcomplex-re y)) (bf+ (bigcomplex-im x) (bigcomplex-im y))))
+  (bigcomplex (bf+ (bigcomplex-re x) (bigcomplex-re y))
+              (bf+ (bigcomplex-im x) (bigcomplex-im y))))
 
 (define (bf-complex-sub x [y #f])
   (if y
       (bf-complex-add x (bf-complex-neg y))
       (bf-complex-neg x)))
-
-(define (bf-complex-neg x)
-  (bigcomplex (bf- (bigcomplex-re x)) (bf- (bigcomplex-im x))))
 
 (define (bf-complex-mult x y)
   (bigcomplex (bf+ (bf* (bigcomplex-re x) (bigcomplex-re y)) (bf- (bf* (bigcomplex-im x) (bigcomplex-im y))))
@@ -61,26 +61,6 @@
   (define numer (bf-complex-mult x (bf-complex-conjugate y)))
   (define denom (bf-complex-mult y (bf-complex-conjugate y)))
   (bigcomplex (bf/ (bigcomplex-re numer) (bigcomplex-re denom)) (bf/ (bigcomplex-im numer) (bigcomplex-re denom))))
-
-(define (make-exact-fun bf-fun bf-complex-fun)
-  (lambda args
-    (match args
-      [(list (? bigfloat?) ...)
-       (apply bf-fun args)]
-      [(list (? bigcomplex?) ...)
-       (apply bf-complex-fun args)])))
-
-(require (only-in racket/base [exp e]))
-
-(define exact+ (make-exact-fun bf+ bf-complex-add))
-(define exact- (make-exact-fun bf- bf-complex-sub))
-(define exact* (make-exact-fun bf* bf-complex-mult))
-(define exact/ (make-exact-fun bf/ bf-complex-div))
-(define exact-exp (make-exact-fun bfexp bf-complex-exp))
-(define exact-log (make-exact-fun bflog bf-complex-log))
-(define exact-pow (make-exact-fun bfexpt bf-complex-pow))
-(define exact-sqr (make-exact-fun bfsqr bf-complex-sqr))
-(define exact-sqrt (make-exact-fun bfsqrt bf-complex-sqrt))
 
 (module+ test
   (define (bf-complex-eq-approx bf1 bf2)

--- a/src/core/enode.rkt
+++ b/src/core/enode.rkt
@@ -85,7 +85,7 @@
   (check-equal? (type-of-enode-expr (enode-expr xplusy)) 'real)
   (define xc (new-enode '1+2i 1))
   (define yc (new-enode '2+3i 2))
-  (define xcplusyc (new-enode (list '+ xc yc) 3))
+  (define xcplusyc (new-enode (list '+.c xc yc) 3))
   (check-equal? (type-of-enode-expr (enode-expr xcplusyc)) 'complex))
   
        

--- a/src/core/enode.rkt
+++ b/src/core/enode.rkt
@@ -7,7 +7,7 @@
 (provide new-enode enode-merge!
 	 enode-vars refresh-vars! enode-pid
 	 enode?
-	 enode-expr
+	 enode-expr enode-type
 	 pack-leader pack-members
 	 rule-applied? rule-applied!
 	 enode-subexpr?
@@ -51,7 +51,7 @@
 ;;#
 ;;################################################################################;;
 
-(struct enode (expr id-code children parent depth cvars applied-rules)
+(struct enode (expr id-code children parent depth cvars applied-rules type)
 	#:mutable
 	#:methods gen:custom-write
 	[(define (write-proc en port mode)
@@ -64,21 +64,36 @@
 	 (define (hash2-proc en recurse-hash)
 	   (enode-id-code en))])
 
+; Get the type for an enode or an enode expr
+(define (type-of-enode-expr expr)
+  (match expr
+    [(? real?) 'real]
+    [(? complex?) 'complex]
+    [(? constant?) (constant-info expr 'type)]
+    [(? variable?) 'real] ;; TODO: assumes variable types are real
+    [(list 'if cond ift iff)
+     (enode-type ift)]
+    [(list op ens ...)
+     ;; Assumes single return type for any function
+     (second (first (first (hash-values (operator-info op 'type)))))]))
+
 (module+ test
   (require rackunit)
   (define x (new-enode '1 1))
   (define y (new-enode '2 2))
   (define xplusy (new-enode (list '+ x y) 3))
+  (check-equal? (type-of-enode-expr (enode-expr xplusy)) 'real)
   (define xc (new-enode '1+2i 1))
   (define yc (new-enode '2+3i 2))
-  (define xcplusyc (new-enode (list '+ xc yc) 3)))
+  (define xcplusyc (new-enode (list '+ xc yc) 3))
+  (check-equal? (type-of-enode-expr (enode-expr xcplusyc)) 'complex))
   
        
 ;; Creates a new enode. Keep in mind that this is egraph-blind,
 ;; and it should be wrapped in an egraph function for registering
 ;; with the egraph on creation.
 (define (new-enode expr id-code)
-  (let ([en* (enode expr id-code '() #f 1 (set expr) (mutable-set))])
+  (let ([en* (enode expr id-code '() #f 1 (set expr) (mutable-set) (type-of-enode-expr expr))])
     (check-valid-enode en* #:loc 'node-creation)
     en*))
 

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -118,7 +118,8 @@
 (define (rewrite-expression expr #:destruct [destruct? #f] #:root [root-loc '()])
   (define env (for/hash ([v (free-variables expr)]) (values v 'real)))
   (reap [sow]
-    (for ([rule (*rules*)])
+    (for ([rule (*rules*)]
+          #:when (or (not (variable? (rule-input rule))) (equal? (type-of expr env) (dict-ref (rule-itypes rule) (rule-input rule)))))
       (let* ([applyer (if destruct? rule-apply-force-destructs rule-apply)]
              [result (applyer rule expr)])
         (when result
@@ -130,7 +131,8 @@
   (define (rewriter expr ghead glen loc cdepth)
     ; expr _ _ _ _ -> (list (list change))
     (reap (sow)
-          (for ([rule (*rules*)])
+          (for ([rule (*rules*)]
+                #:when (or (not (variable? (rule-input rule))) (equal? (type-of expr env) (dict-ref (rule-itypes rule) (rule-input rule)))))
             (when (or
                     (not ghead) ; Any results work for me
                     (and

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -118,8 +118,7 @@
 (define (rewrite-expression expr #:destruct [destruct? #f] #:root [root-loc '()])
   (define env (for/hash ([v (free-variables expr)]) (values v 'real)))
   (reap [sow]
-    ; TODO: don't recompute the type of every expression
-    (for ([rule (if (equal? 'complex (type-of expr env)) (*complex-rules*) (*rules*))])
+    (for ([rule (*rules*)])
       (let* ([applyer (if destruct? rule-apply-force-destructs rule-apply)]
              [result (applyer rule expr)])
         (when result
@@ -131,7 +130,7 @@
   (define (rewriter expr ghead glen loc cdepth)
     ; expr _ _ _ _ -> (list (list change))
     (reap (sow)
-          (for ([rule (if (equal? 'complex (type-of expr env)) (*complex-rules*) (*rules*))])
+          (for ([rule (*rules*)])
             (when (or
                     (not ghead) ; Any results work for me
                     (and

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -123,9 +123,7 @@
   ;; and the enode.
   (define (find-matches ens)
     (filter (negate null?)
-	    (for*/list ([rl rls]
-			[en ens]
-                        #:when (rule-valid-at-type? rl (enode-type en)))
+	    (for*/list ([rl rls] [en ens])
 	      (if (rule-applied? en rl) '()
 		  (let ([bindings (match-e (rule-input rl) en)])
 		    (if (null? bindings) '()
@@ -172,26 +170,19 @@
     [pattern #t]
     [_ #f]))
 
-(define (exact-value? type val)
-  (match type
-    ['real (exact? val)]
-    ['complex (exact? val)]
-    ['boolean true]))
+(define (exact-value? val)
+  (match val
+    [(? real?) (exact? val)]
+    [(? complex?) (exact? val)]
+    [(? boolean?) true]))
 
-(define/match (val-of-type type val)
-  [('real    (? real?))    true]
-  [('complex (? complex?)) true]
-  [('boolean (? boolean?)) true]
-  [(_ _) false])
-
-(define (val-to-type type val)
-  (match type
-    ['real val]
-    ['complex `(complex ,(real-part val) ,(imag-part val))]
-    ['boolean (if val 'TRUE 'FALSE)]))
+(define (val-to-type val)
+  (match val
+    [(? real?) val]
+    [(? complex?) `(complex ,(real-part val) ,(imag-part val))]
+    [(? boolean?) (if val 'TRUE 'FALSE)]))
 
 (define (set-precompute! eg en)
-  (define type (enode-type en))
   (for ([var (enode-vars en)])
     (when (list? var)
       (let ([constexpr
@@ -203,8 +194,8 @@
 		   (not (matches? constexpr `(/ 0)))
 		   (andmap real? (cdr constexpr)))
 	  (let ([res (eval-const-expr constexpr)])
-	    (when (and (val-of-type type res) (exact-value? type res))
-	      (reduce-to-new! eg en (val-to-type type res)))))))))
+	    (when (and (exact-value? res))
+	      (reduce-to-new! eg en (val-to-type res)))))))))
 
 (define (hash-set*+ hash assocs)
   (for/fold ([h hash]) ([assoc assocs])

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -180,8 +180,8 @@
      (apply taylor-add (map (curry taylor var) args))]
     [`(- ,arg)
      (taylor-negate ((curry taylor var) arg))]
-    [`(- ,arg ,args ...)
-     (apply taylor-add ((curry taylor var) arg) (map (compose taylor-negate (curry taylor var)) args))]
+    [`(- ,arg1 ,arg2)
+     (taylor-add (taylor var arg1) (taylor-negate (taylor var arg2)))]
     [`(* ,left ,right)
      (taylor-mult (taylor var left) (taylor var right))]
     [`(/ 1 ,arg)

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -32,13 +32,14 @@
          (if (null? props)
              (reverse out)
              (loop (cddr props) (cons (cons (first props) (second props)) out)))))
+     (define type-ctx (map (λ (x) (cons x 'real)) args))
 
      (test (~a (dict-ref prop-dict ':name body))
            args
-           (desugar-program body)
-           (desugar-program (dict-ref prop-dict ':herbie-target #f))
+           (desugar-program body type-ctx)
+           (desugar-program (dict-ref prop-dict ':herbie-target #f) type-ctx)
            (dict-ref prop-dict ':herbie-expected #t)
-           (desugar-program (dict-ref prop-dict ':pre 'TRUE)))]
+           (desugar-program (dict-ref prop-dict ':pre 'TRUE) type-ctx))]
     [(list (or 'λ 'lambda 'define 'herbie-test) _ ...)
      (raise-herbie-error "Herbie 1.0+ no longer supports input formats other than FPCore."
                          #:url "input.html")]

--- a/src/shell.rkt
+++ b/src/shell.rkt
@@ -25,7 +25,7 @@
       (define output (get-test-result test #:seed seed))
       (match output
         [(? test-result?)
-         (printf "~a\n" (unparse-result output))]
+         (pretty-print (unparse-result output) (current-output-port) 1)]
         [(test-failure test bits exn time timeline)
          ((error-display-handler) (exn-message exn) exn)]
         [(test-timeout test bits time timeline)

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -218,11 +218,11 @@
 
 (define-ruleset fractions-transform.c (fractions complex)
   #:type ([a complex] [b complex] [c complex] [d complex])
-  [sub-div     (-.c (/.c a c) (/.c b c))  (/.c (-.c a b) c)]
-  [frac-add    (+.c (/.c a b) (/.c c d))  (/.c (+.c (*.c a d) (*.c b c)) (*.c b d))]
-  [frac-sub    (-.c (/.c a b) (/.c c d))  (/.c (-.c (*.c a d) (*.c b c)) (*.c b d))]
-  [frac-times  (*.c (/.c a b) (/.c c d))  (/.c (*.c a c) (*.c b d))]
-  [frac-2neg   (/.c a b)                  (/.c (neg.c a) (neg.c b))])
+  [sub-div.c     (-.c (/.c a c) (/.c b c))  (/.c (-.c a b) c)]
+  [frac-add.c    (+.c (/.c a b) (/.c c d))  (/.c (+.c (*.c a d) (*.c b c)) (*.c b d))]
+  [frac-sub.c    (-.c (/.c a b) (/.c c d))  (/.c (-.c (*.c a d) (*.c b c)) (*.c b d))]
+  [frac-times.c  (*.c (/.c a b) (/.c c d))  (/.c (*.c a c) (*.c b d))]
+  [frac-2neg-c   (/.c a b)                  (/.c (neg.c a) (neg.c b))])
 
 ; Square root
 (define-ruleset squares-reduce (arithmetic simplify)
@@ -703,7 +703,7 @@
 
         (define (make-point)
           (for/list ([v fv])
-            (match (dict-ref (third test-ruleset) v 'real)
+            (match (dict-ref (rule-itypes test-rule) v)
               ['real (sample-double)]
               ['bool (if (< (random) .5) false true)]
               ['complex (make-rectangular (sample-double) (sample-double))])))
@@ -745,7 +745,7 @@
         (define fv (free-variables p1))
         (define (make-point)
           (for/list ([v fv])
-            (match (dict-ref (third test-ruleset) v 'real)
+            (match (dict-ref (rule-itypes test-rule) v)
               ['real (sample-double)]
               ['bool (if (< (random) .5) false true)]
               ['complex (make-rectangular (sample-double) (sample-double))])))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -49,6 +49,7 @@
   [*-commutative     (* a b)               (* b a)])
 
 (define-ruleset commutativity.c (arithmetic simplify fp-safe complex)
+  #:type ([a complex] [b complex])
   [+.c-commutative     (+.c a b)               (+.c b a)]
   [*.c-commutative     (*.c a b)               (*.c b a)])
 
@@ -74,6 +75,7 @@
   [unsub-neg         (+ a (- b))           (- a b)])
 
 (define-ruleset associativity.c (arithmetic simplify complex)
+  #:type ([a complex] [b complex] [c complex])
   [associate-+r+.c     (+.c a (+.c b c))         (+.c (+.c a b) c)]
   [associate-+l+.c     (+.c (+.c a b) c)         (+.c a (+.c b c))]
   [associate-+r-.c     (+.c a (-.c b c))         (-.c (+.c a b) c)]
@@ -105,6 +107,7 @@
   [distribute-rgt1-in     (+ a (* c a))         (* (+ c 1) a)])
 
 (define-ruleset distributivity.c (arithmetic simplify complex)
+  #:type ([a complex] [b complex] [c complex])
   [distribute-lft-in      (*.c a (+.c b c))           (+.c (*.c a b) (*.c a c))]
   [distribute-rgt-in      (*.c a (+.c b c))           (+.c (*.c b a) (*.c c a))]
   [distribute-lft-out     (+.c (*.c a b) (*.c a c))   (*.c a (+.c b c))]
@@ -188,6 +191,7 @@
   [times-frac  (/ (* a b) (* c d))  (* (/ a c) (/ b d))])
 
 (define-ruleset fractions-distribute.c (fractions simplify complex)
+  #:type ([a complex] [b complex] [c complex] [d complex])
   [div-sub     (/.c (-.c a b) c)          (-.c (/.c a c) (/.c b c))]
   [times-frac  (/.c (*.c a b) (*.c c d))  (*.c (/.c a c) (/.c b d))])
 
@@ -199,6 +203,7 @@
   [frac-2neg   (/ a b)              (/ (- a) (- b))])
 
 (define-ruleset fractions-transform.c (fractions complex)
+  #:type ([a complex] [b complex] [c complex] [d complex])
   [sub-div     (-.c (/.c a c) (/.c b c))  (/.c (-.c a b) c)]
   [frac-add    (+.c (/.c a b) (/.c c d))  (/.c (+.c (*.c a d) (*.c b c)) (*.c b d))]
   [frac-sub    (-.c (/.c a b) (/.c c d))  (/.c (-.c (*.c a d) (*.c b c)) (*.c b d))]

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -172,7 +172,7 @@
   [mul-1-neg         (* -1 a)              (- a)])
 
 (define-ruleset id-transform (arithmetic)
-  #:type ([a real])
+  #:type ([a real] [b real])
   [div-inv           (/ a b)               (* a (/ 1 b))]
   [un-div-inv        (* a (/ 1 b))         (/ a b)]
   [clear-num         (/ a b)               (/ 1 (/ b a))])
@@ -199,7 +199,7 @@
 
 ; Dealing with fractions
 (define-ruleset fractions-distribute (fractions simplify)
-  #:type ([a real] [b real] [c real])
+  #:type ([a real] [b real] [c real] [d real])
   [div-sub     (/ (- a b) c)        (- (/ a c) (/ b c))]
   [times-frac  (/ (* a b) (* c d))  (* (/ a c) (/ b d))])
 
@@ -376,7 +376,7 @@
 
 ; Trigonometry
 (define-ruleset trig-reduce (trigonometry simplify)
-  #:type ([a real] [b real])
+  #:type ([a real] [b real] [x real])
   [cos-sin-sum (+ (* (cos a) (cos a)) (* (sin a) (sin a))) 1]
   [1-sub-cos   (- 1 (* (cos a) (cos a)))   (* (sin a) (sin a))]
   [1-sub-sin   (- 1 (* (sin a) (sin a)))   (* (cos a) (cos a))]
@@ -609,7 +609,7 @@
   [not-gte      (not (>= x y))   (<  x y)])
 
 (define-ruleset branch-reduce (branches simplify fp-safe)
-  #:type ([a bool] [b bool])
+  #:type ([a bool] [b bool] [x real] [y real])
   [if-true        (if TRUE x y)       x]
   [if-false       (if FALSE x y)      y]
   [if-same        (if a x x)          x]

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -580,14 +580,14 @@
 (define-ruleset complex-number-basics (complex simplify)
   [real-part     (re (complex x y))     x]
   [imag-part     (im (complex x y))     y]
-  [complex-add-def  (+ (complex a b) (complex c d)) (complex (+ a c) (+ b d))]
-  [complex-def-add  (complex (+ a c) (+ b d)) (+ (complex a b) (complex c d))]
-  [complex-sub-def  (- (complex a b) (complex c d)) (complex (- a c) (- b d))]
-  [complex-def-sub  (complex (- a c) (- b d)) (- (complex a b) (complex c d))]
-  [complex-neg-def  (- (complex a b)) (complex (- a) (- b))]
-  [complex-def-neg  (complex (- a) (- b)) (- (complex a b))]
-  [complex-mul-def  (* (complex a b) (complex c d)) (complex (- (* a c) (* b d)) (+ (* a d) (* b c)))]
-  [complex-div-def  (/ (complex a b) (complex c d)) (complex (/ (+ (* a c) (* b d)) (+ (* c c) (* d d))) (/ (- (* b c) (* a d)) (+ (* c c) (* d d))))]
+  [complex-add-def  (+.c (complex a b) (complex c d)) (complex (+ a c) (+ b d))]
+  [complex-def-add  (complex (+ a c) (+ b d)) (+.c (complex a b) (complex c d))]
+  [complex-sub-def  (-.c (complex a b) (complex c d)) (complex (- a c) (- b d))]
+  [complex-def-sub  (complex (- a c) (- b d)) (-.c (complex a b) (complex c d))]
+  [complex-neg-def  (neg.c (complex a b)) (complex (- a) (- b))]
+  [complex-def-neg  (complex (- a) (- b)) (neg.c (complex a b))]
+  [complex-mul-def  (*.c (complex a b) (complex c d)) (complex (- (* a c) (* b d)) (+ (* a d) (* b c)))]
+  [complex-div-def  (/.c (complex a b) (complex c d)) (complex (/ (+ (* a c) (* b d)) (+ (* c c) (* d d))) (/ (- (* b c) (* a d)) (+ (* c c) (* d d))))]
   [complex-conj-def (conj (complex a b)) (complex a (- b))]
   )
 

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -94,8 +94,8 @@
   [associate-/l*.c     (/.c (*.c b c) a)         (/.c b (/.c a c))]
   [associate-/r/.c     (/.c a (/.c b c))         (*.c (/.c a b) c)]
   [associate-/l/.c     (/.c (/.c b c) a)         (/.c b (*.c a c))]
-  [sub-neg.c           (-.c a b)                 (+.c a (-.c b))]
-  [unsub-neg.c         (+.c a (-.c b))           (-.c a b)])
+  [sub-neg.c           (-.c a b)                 (+.c a (neg.c b))]
+  [unsub-neg.c         (+.c a (neg.c b))           (-.c a b)])
 
 ; Distributivity
 (define-ruleset distributivity (arithmetic simplify)
@@ -222,7 +222,7 @@
   [frac-add    (+.c (/.c a b) (/.c c d))  (/.c (+.c (*.c a d) (*.c b c)) (*.c b d))]
   [frac-sub    (-.c (/.c a b) (/.c c d))  (/.c (-.c (*.c a d) (*.c b c)) (*.c b d))]
   [frac-times  (*.c (/.c a b) (/.c c d))  (/.c (*.c a c) (*.c b d))]
-  [frac-2neg   (/.c a b)                  (/.c (-.c a) (-.c b))])
+  [frac-2neg   (/.c a b)                  (/.c (neg.c a) (neg.c b))])
 
 ; Square root
 (define-ruleset squares-reduce (arithmetic simplify)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -128,9 +128,14 @@
   [->tex (λ (x [y #f]) (if y (format "~a - ~a" x y) (format "-~a" x)))]
   [nonffi -])
 
-(define-operator (-.c complex [complex]) complex
-  ;; Override the normal argument handling because - can be unary
-  [args '(1 2)] [type (hash 1 '(((complex) complex)) 2 '(((complex complex) complex)))]
+(define-operator (neg.c complex) complex
+  [fl -] [bf bf-complex-neg] [cost 80]
+  [->c/double (curry format "-~a")]
+  [->c/mpfr (const "/* ERROR: no complex support in C */")]
+  [->tex (curry format "-~a")]
+  [nonffi -])
+
+(define-operator (-.c complex complex) complex
   [fl -] [bf bf-complex-sub] [cost 80]
   [->c/double (λ (x [y #f]) (if y (format "~a - ~a" x y) (format "-~a" x)))]
   [->c/mpfr (const "/* ERROR: no complex support in C */")]
@@ -701,7 +706,7 @@
 (define parametric-operators
   #hash([+ . ((+ real real real) (+.c complex complex complex))]
         [- . ((- real real real) (- real real)
-              (-.c complex complex complex) (-.c complex complex))]
+              (-.c complex complex complex) (neg.c complex complex))]
         [* . ((* real real real) (*.c complex complex complex))]
         [/ . ((/ real real real) (/.c complex complex complex))]
         [pow . ((pow real real real) (pow.c complex complex complex))]


### PR DESCRIPTION
The Herbie core now treats complex and real operations as different functions; the front-end does the renaming necessary to make this transparent for users. For example, `(exp (complex 1 0))` is replaced with `(exp.c (complex 1 0))`.

Doing this meant adding a new table of "parametric" operators, which the front-end will replace, and adding types to rules, to ensure that only valid rewritings were carried out. One benefit is that we are no longer type-checking expressions over and over again in the core of Herbie.