### PR TITLE
Constant simplification

### DIFF
--- a/src/core/egraph.rkt
+++ b/src/core/egraph.rkt
@@ -344,8 +344,19 @@
                 (λ (st)
                   (for/mutable-set ([expr st])
                                    (update-en-expr expr))))
+
+  ;; TODO: We want a single-member pack, which points to the
+  ;; expressions `expr`. If `expr` is a constant, that's easy. If
+  ;; `expr` is a function call, however, we have trouble knowing if
+  ;; it's the "right" expression. I've implemented a bad hack here of
+  ;; just checking the head op.
   (define leader* (pack-filter! (λ (inner-en)
-                                  (equal? (enode-expr inner-en) (enode-expr new-en)))
+                                  (match expr
+                                    [(list op _ ...)
+                                     (and (list? (enode-expr inner-en))
+                                          (equal? (car (enode-expr inner-en)) op))]
+                                    [_
+                                     (equal? (enode-expr inner-en) expr)]))
                                 leader))
   (update-leader! eg vars leader leader*))
 

--- a/src/core/egraph.rkt
+++ b/src/core/egraph.rkt
@@ -335,19 +335,19 @@
         (update-leader! eg old-vars leader leader*)))))
 
 (define (reduce-to-new! eg en expr)
-  (unless true
-    (let* ([new-en (mk-enode-rec! eg expr)]
-           [vars (enode-vars en)]
-           [leader (merge-egraph-nodes! eg en new-en)])
-      (hash-update! (egraph-leader->iexprs eg)
-                    leader
-                    (λ (st)
-                      (for/mutable-set ([expr st])
-                                       (update-en-expr expr))))
-      (let ([leader* (pack-filter! (λ (inner-en)
-                                     (equal? (enode-expr inner-en) (enode-expr new-en)))
-                                   leader)])
-        (update-leader! eg vars leader leader*)))))
+  (define new-en (mk-enode-rec! eg expr))
+  (define vars (enode-vars en))
+  (define leader (merge-egraph-nodes! eg en new-en))
+
+  (hash-update! (egraph-leader->iexprs eg)
+                leader
+                (λ (st)
+                  (for/mutable-set ([expr st])
+                                   (update-en-expr expr))))
+  (define leader* (pack-filter! (λ (inner-en)
+                                  (equal? (enode-expr inner-en) (enode-expr new-en)))
+                                leader))
+  (update-leader! eg vars leader leader*))
 
 ;; Draws a representation of the egraph to the output file specified
 ;; in the DOT format.

--- a/src/core/egraph.rkt
+++ b/src/core/egraph.rkt
@@ -378,4 +378,4 @@
 			  id vid (enode-pid (third var)))])))))
 	(displayln "}")))
   (system (format "dot -Tpng -o ~a.png ~a" fp fp))
-  (system (format "feh ~a.png" fp)))
+  #;(system (format "feh ~a.png" fp)))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -171,7 +171,7 @@
   (let loop ([iter 0])
     (define changed? #f)
     (debug #:from 'simplify #:depth 2
-           (format "Extracting #~a: cost ~a inf + ~a\n"
+           (format "Extracting #~a: cost ~a inf + ~a"
                    iter (count (compose not car) (hash-values work-list))
                    (apply + (filter identity (map car (hash-values work-list))))))
     (for ([leader (in-list (hash-keys work-list))])

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -238,8 +238,8 @@
                         (simplify `(+ (* (- ,(car arg*)) (log ,var))
                                       ,((cdr rest) 0)))
                         ((cdr rest) n))))))]
-    [`(pow ,(? (curry equal? var)) ,(? exact-integer? power))
-     (cons (- power) (λ (n) (if (= n 0) 1 0)))]
+    [`(pow ,base ,(? exact-integer? power))
+     (taylor-pow (taylor var base) power)]
     [`(pow ,base ,power)
      (taylor var `(exp (* ,power (log ,base))))]
     [_
@@ -415,6 +415,17 @@
                                             `(/ (pow ,(coeffs (cdr factor)) ,(car factor))
                                                 ,(factorial (car factor)))))
                                     0))))))))))
+
+(define (taylor-pow coeffs n)
+  (match n
+    [0 (taylor-exact 1)]
+    [1 coeffs]
+    [(? even?)
+     (define half (taylor-pow coeffs (/ n 2)))
+     (taylor-mult half half)]
+    [(? odd?)
+     (define half (taylor-pow coeffs (/ (- n 1) 2)))
+     (taylor-mult coeffs (taylor-mult half half))]))
 
 (define (taylor-cos coeffs)
   (let ([hash (make-hash)])

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -415,6 +415,7 @@
 
 (define (taylor-pow coeffs n)
   (match n ;; Russian peasant multiplication
+    [(? negative?) (taylor-pow (taylor-invert coeffs) (- n))]
     [0 (taylor-exact 1)]
     [1 coeffs]
     [(? even?)

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -188,9 +188,6 @@
      (taylor-invert (taylor var arg))]
     [`(/ ,num ,den)
      (taylor-quotient (taylor var num) (taylor var den))]
-    [`(sqr ,a)
-     (let ([ta (taylor var a)])
-       (taylor-mult ta ta))]
     [`(sqrt ,arg)
      (taylor-sqrt (taylor var arg))]
     [`(exp ,arg)
@@ -239,7 +236,7 @@
                                       ,((cdr rest) 0)))
                         ((cdr rest) n))))))]
     [`(pow ,base ,(? exact-integer? power))
-     (taylor-pow (taylor var base) power)]
+     (taylor-pow (normalize-series (taylor var base)) power)]
     [`(pow ,base ,power)
      (taylor var `(exp (* ,power (log ,base))))]
     [_
@@ -417,7 +414,7 @@
                                     0))))))))))
 
 (define (taylor-pow coeffs n)
-  (match n
+  (match n ;; Russian peasant multiplication
     [0 (taylor-exact 1)]
     [1 coeffs]
     [(? even?)


### PR DESCRIPTION
This PR enables constant simplification, so that the simplifier can turn `(+ 2 2)` into `4` and similar. Constant simplification only happens when the computation produces a Racket `exact?` value, so for example `(+ 2.0 2.0)` would not be computed down to `4.0`. This ensures that no rounding error can be incurred by computation.

This series of commits also adds to unrelated items:
+ A new egraph extraction algorithm
+ New series expansion support for `pow`s

The new egraph extraction algorithm improves on the old one by iteratively improving the extraction of any expression until fixed-point, while the old one improves it until the egraph root has an extraction. The fixedpoint can lead to simpler expressions, but it takes a lot longer, so is currently disabled.

The series expansion support for `pow`s treats `(pow E N)` specially if `N` is an exact integer, using Russian Peasant multiplication instead of immediately using the `(exp (* (log E) N))` trick. This avoids huge slowdowns even in expressions as simple as `(pow 1 3)`.