### PR TITLE
Enable GET-based submissions

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -36,7 +36,7 @@
   (dispatch-rules
    [("") main]
    [("improve-start") #:method "post" improve-start]
-   [("improve") #:method "post" improve]
+   [("improve") #:method (or "post" "get" "put") improve]
    [("check-status" (string-arg)) check-status]
    [((hash-arg) "interactive.js") generate-interactive]
    [((hash-arg) "graph.html") generate-report]


### PR DESCRIPTION
Allows users to submit expressions to Herbie web from a URL. It works with the standard concurrency and caching mechanisms. This will allow Herbie to be listed on the [FPBench benchmarks page](http://fpbench.org/benchmarks.html)!