### PR TITLE
Better recursive rewriting

### DIFF
--- a/bench/numerics/rump.rkt
+++ b/bench/numerics/rump.rkt
@@ -17,12 +17,12 @@
 
 (FPCore (x y)
   :name "From Rump in a 1983 paper"
-  ;:pre (and (== x 10864) (== y 18817))
-  :pre (and (< 10500 x 11000) (< 18500 y 19000))
+  :pre (and (== x 10864) (== y 18817))
+  ;:pre (and (< 10500 x 11000) (< 18500 y 19000))
   (+ (- (* 9 (pow x 4)) (pow y 4)) (* 2 (* y y))))
 
 (FPCore (x y)
   :name "From Rump in a 1983 paper, rewritten"
-  ;:pre (and (== x 10864) (== y 18817))
-  :pre (and (< 10500 x 11000) (< 18500 y 19000))
+  :pre (and (== x 10864) (== y 18817))
+  ;:pre (and (< 10500 x 11000) (< 18500 y 19000))
   (- (* 9 (pow x 4)) (* (* y y) (- (* y y) 2))))

--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -18,7 +18,7 @@
   (printf "Running Herbie on ~a tests (seed: ~a)...\n" (length tests) seed)
   (for/and ([test tests])
     (match (get-test-result test #:seed seed)
-      [(test-success test bits time timeline
+      [(test-success test bits time timeline warnings
                      start-alt end-alt points exacts start-est-error end-est-error
                      newpoints newexacts start-error end-error target-error
                      baseline-error oracle-error all-alts)
@@ -40,11 +40,11 @@
          (when (test-output test) (printf "Target: ~a\n" (test-output test))))
 
        success?]
-      [(test-failure test bits time timeline exn)
+      [(test-failure test bits time timeline warnings exn)
        (printf "[   CRASH   ]\t\t\t~a\n" (test-name test))
        ((error-display-handler) (exn-message exn) exn)
        #f]
-      [(test-timeout test bits time timeline)
+      [(test-timeout test bits time timeline warnings)
        (printf "[  timeout  ]\t\t\t~a\n" (test-name test))
        #f])))
 

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -13,6 +13,7 @@
          write-file write-string
          random-exp parse-flag get-seed set-seed!
          common-eval quasisyntax
+         reset register-reset
          format-time format-bits when-dict in-sorted-dict web-resource
          (all-from-out "config.rkt") (all-from-out "debug.rkt"))
 
@@ -360,3 +361,12 @@
   (if name
       (build-path web-resource-path name)
       web-resource-path))
+
+(define resetters '())
+
+(define (register-reset fn)
+  (set! resetters (cons fn resetters)))
+
+(define (reset!)
+  (for ([fn resetters]) (fn)))
+

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -13,7 +13,6 @@
          write-file write-string
          random-exp parse-flag get-seed set-seed!
          common-eval quasisyntax
-         reset register-reset
          format-time format-bits when-dict in-sorted-dict web-resource
          (all-from-out "config.rkt") (all-from-out "debug.rkt"))
 
@@ -361,12 +360,3 @@
   (if name
       (build-path web-resource-path name)
       web-resource-path))
-
-(define resetters '())
-
-(define (register-reset fn)
-  (set! resetters (cons fn resetters)))
-
-(define (reset!)
-  (for ([fn resetters]) (fn)))
-

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -8,7 +8,7 @@
          reap define-table table-ref table-set! table-remove!
          assert for/append string-prefix call-with-output-files
          ordinary-value? =-or-nan? </total <=/total nan?-all-types
-         take-up-to flip-lists list/true
+         take-up-to flip-lists list/true find-duplicates
          argmins argmaxs setfindf index-of set-disjoint?
          write-file write-string
          random-exp parse-flag get-seed set-seed!
@@ -222,6 +222,15 @@
 (module+ test
   (check-equal? (flip-lists '((1 2 3) (4 5 6) (7 8 9)))
                 '((1 4 7) (2 5 8) (3 6 9))))
+
+(define (find-duplicates l)
+  (define found (mutable-set))
+  (define duplicates '())
+  (for ([x l])
+    (when (set-member? found x)
+      (set! duplicates (cons x duplicates)))
+    (set-add! found x))
+  (reverse duplicates))
 
 (define (setfindf f s)
   (for/first ([elt (in-set s)] #:when (f elt))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -6,7 +6,7 @@
 (define all-flags
   #hash([precision . (double fallback)]
         [setup . (simplify early-exit)]
-        [generate . (rr taylor simplify)]
+        [generate . (rr taylor simplify better-rr)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics complex special bools branches)]))
 

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -90,3 +90,11 @@
 
 (define *herbie-branch*
   (git-command "rev-parse" "--abbrev-ref" "HEAD" #:default "release"))
+
+(define resetters '())
+
+(define (register-reset fn)
+  (set! resetters (cons fn resetters)))
+
+(define (reset!)
+  (for ([fn resetters]) (fn)))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -8,7 +8,7 @@
 (require "../programs.rkt")
 (require "../alternative.rkt")
 
-(provide localize-error reset-analyze-cache!)
+(provide localize-error)
 
 (define (repeat c)
   (for/list ([(p e) (in-pcontext (*pcontext*))])
@@ -44,9 +44,10 @@
 								     (->flonum ap))))) exact approx)])
                      (cons exact error))]))))
 
-(define (reset-analyze-cache!)
+(register-reset
+ (λ ()
   (*analyze-context* (*pcontext*))
-  (hash-clear! *analyze-cache*))
+  (hash-clear! *analyze-cache*)))
 
 (define (localize-error prog)
   (define varmap (map cons (program-variables prog)

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -186,7 +186,9 @@
                          ['() (k '())]
                          [out out]))))))
 
-         (when (> cdepth 0)
+         (when (and (> cdepth 0)
+                    (or (flag-set? 'generate 'better-rr)
+                        (not (and (list? expr) (equal? phead (car expr)) (= (length pattern) (length expr))))))
            ;; Sort of a brute force approach to getting the bindings
            (fix-up-variables
             sow pattern

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -16,7 +16,7 @@
            (write (option-split-indices opt) port)
            (display ">" port))])
 
-;; Struct represeting a splitpoint
+;; Struct representing a splitpoint
 ;; cidx = Candidate index: the index of the candidate program that should be used to the left of this splitpoint
 ;; bexpr = Branch Expression: The expression that this splitpoint should split on
 ;; point = Split Point: The point at which we should split.

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -7,7 +7,7 @@
 (require "reduce.rkt")
 (require "matcher.rkt")
 
-(provide approximate reset-taylor-caches!)
+(provide approximate)
 
 (define (approximate expr vars #:transform [tforms #f]
                      #:terms [terms 3] #:iters [iters 5])
@@ -161,10 +161,11 @@
 (define taylor-expansion-known
   '(+ - * / sqrt cbrt exp sin cos log pow))
 
-(define (reset-taylor-caches!)
+(register-reset
+ (λ ()
   (hash-clear! n-sum-to-cache)
   (hash-clear! logcache)
-  (hash-set! logcache 1 '((1 -1 1))))
+  (hash-set! logcache 1 '((1 -1 1)))))
 
 (define (taylor var expr*)
   "Return a pair (e, n), such that expr ~= e var^n"

--- a/src/debug.rkt
+++ b/src/debug.rkt
@@ -107,7 +107,7 @@
 (define (debug-print from depth args port)
   (fprintf port "~a ~a [~a]:"
            (~r (/ (current-inexact-milliseconds) 1000) #:precision '(= 3))
-           (string-join (build-list (range depth) (const "*")) " ")
+           (string-join (build-list depth (const "*")) " ")
            from)
   (for ([arg args]) (fprintf port " ~a" arg))
   (newline port)

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -3,7 +3,8 @@
 (provide raise-herbie-error raise-herbie-syntax-error
          herbie-error->string herbie-error-url
          (struct-out exn:fail:user:herbie)
-         (struct-out exn:fail:user:herbie:syntax))
+         (struct-out exn:fail:user:herbie:syntax)
+         warn warning-log)
 
 (struct exn:fail:user:herbie exn:fail:user (url)
         #:extra-constructor-name make-exn:fail:user:herbie)
@@ -55,3 +56,20 @@
              (exn-message err) *herbie-version*)]
     [else
      (old-error-display-handler message err)])))
+
+(define warnings-seen (mutable-set))
+(define warning-log '())
+
+(define (warn type message #:url [url #f] #:extra [extra '()] . args)
+  (unless (set-member? warnings-seen type)
+    (set-add! warnings-seen type)
+    (define url* (and url (format "https://herbie.uwplse.org/doc/~a/~a" *herbie-version* url)))
+    (set! warning-log (cons (list type message args url* extra) warning-log))
+    (eprintf "Warning: ~a\n" (apply format message args))
+    (for ([line extra]) (eprintf "  ~a\n" line))
+    (when url (eprintf "See <~a> for more.\n" url*))))
+
+(register-reset
+ (λ ()
+   (set-clear! warnings-seen)
+   (set! warning-log '())))

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -16,13 +16,14 @@
 (define (check-operator-fallbacks!)
   (prune-operators!)
   (prune-rules!)
-  (unless (null? (if (flag-set? 'precision 'double) (*unknown-d-ops*) (*unknown-f-ops*)))
-    (eprintf "Warning: native ~a not supported on your system; "
-             (string-join (map ~a (if (flag-set? 'precision 'double) (*unknown-d-ops*) (*unknown-f-ops*)))
-                          ", "))
-    (eprintf (if (flag-set? 'precision 'fallback) "fallbacks will be used.\n" "functions are disabled.\n"))
-    (eprintf "See <https://herbie.uwplse.org/doc/~a/faq.html#native-ops> for more info.\n"
-             *herbie-version*)))
+  (define unknown-ops (if (flag-set? 'precision 'double) (*unknown-d-ops*) (*unknown-f-ops*)))
+  (unless (null? unknown-ops)
+    (warn 'fallback #:url "faq.html#native-ops"
+          "native ~a not supported on your system; ~a"
+          (string-join (map ~a unknown-ops) ", ")
+          (if (flag-set? 'precision 'fallback)
+              "fallbacks will be used"
+              "functions are disabled"))))
 
 (module+ main
   (define quiet? #f)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -73,8 +73,6 @@
     (log! 'outcomes prepare-log)
     (^precondition^ precondition)
     (*pcontext* context)
-    (reset-analyze-cache!)
-    (reset-taylor-caches!)
     (debug #:from 'progress #:depth 3 "[2/2] Setting up program.")
     (^table^ (make-alt-table context altn))
     (assert (equal? (atab-all-alts (^table^)) (list altn)))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -86,7 +86,7 @@
       (match args
         [`(exit ,prec ,pt)
          (define key (list name 'exit prec))
-         (warn 'ground-truth #:url "faq.html#mpfr-prec-limit"
+         (warn 'ground-truth
                "could not determine a ground truth for program ~a" name
                #:extra (for/list ([var (program-variables prog)] [val pt])
                          (format "~a = ~a" var val)))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -79,8 +79,6 @@
   (eprintf "-> ~a benchmarks still not supported by the biginterval sampler.\n" unsup-count)
   (check <= unsup-count 50))
 
-(define ival-warnings (make-parameter '()))
-
 (define (point-logger name dict prog)
   (define start (current-inexact-milliseconds))
   (define (log! . args)
@@ -88,11 +86,10 @@
       (match args
         [`(exit ,prec ,pt)
          (define key (list name 'exit prec))
-         (unless (hash-has-key? dict key)
-           (eprintf "Warning: could not determine a ground truth for program ~a\n" name)
-           (for ([var (program-variables prog)] [val pt])
-             (eprintf "  ~a = ~a\n" var val))
-           (eprintf "See <https://herbie.uwplse.org/doc/~a/faq.html#mpfr-prec-limit> for more info.\n" *herbie-version*))
+         (warn 'ground-truth #:url "faq.html#mpfr-prec-limit"
+               "could not determine a ground truth for program ~a" name
+               #:extra (for/list ([var (program-variables prog)] [val pt])
+                         (format "~a = ~a" var val)))
          key]
         [`(sampled ,prec ,pt #f) (list name 'false prec)]
         [`(sampled ,prec ,pt #t) (list name 'true prec)]

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -14,7 +14,8 @@
          eval-prog eval-const-expr
          compile expression-cost program-cost
          free-variables replace-expression
-         desugar-program resugar-program)
+         desugar-program resugar-program
+         check-unused-variables)
 
 (define expr? (or/c list? symbol? number?))
 
@@ -352,3 +353,10 @@
    [#t
     expr]))
 
+(define (check-unused-variables vars expr)
+  (define used (free-variables expr))
+  (unless (set=? vars used)
+    (define unused (set-subtract vars used))
+    (warn 'unused-variable
+          "unused ~a ~a" (if (equal? (set-count unused) 1) "variable" "variables")
+          (string-join (map ~a unused) ", "))))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -137,7 +137,7 @@
                      baseline-errs
                      oracle-errs
                      all-alts)]
-      [`(error ,e ,bits ,timeline ,warnings)
+      [`(error ,bits ,timeline ,warnings ,e)
        (test-failure test bits (- (current-inexact-milliseconds) start-time) timeline warnings e)]
       [#f
        ;; TODO: These fields are meaningless because parameters don't work across engines

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -19,7 +19,7 @@
 
 
 ; For things that don't leave a thread
-(struct test-result (test bits time timeline))
+(struct test-result (test bits time timeline warnings))
 (struct test-success test-result
   (start-alt end-alt points exacts start-est-error end-est-error
    newpoints newexacts start-error end-error target-error
@@ -48,7 +48,7 @@
       (match debug-level
         [(cons x y) (set-debug-level! x y)]
         [_ (void)])
-      (with-handlers ([exn? (λ (e) `(error ,e ,(bf-precision)))])
+      (with-handlers ([exn? (λ (e) `(error ,(bf-precision) ,(^timeline^) ,warning-log ,e))])
         (reset!)
         (define alt
           (run-improve (test-program test)
@@ -91,8 +91,9 @@
         (when (test-output test)
           (debug #:from 'regime-testing #:depth 1
                  "Target error score:" (errors-score (errors (test-target test) newcontext))))
-        `(good ,(make-alt (test-program test)) ,alt ,context ,newcontext
-               ,(^timeline^) ,(bf-precision) ,baseline-errs ,oracle-errs ,all-alts))))
+        `(good ,(bf-precision) ,(^timeline^) ,warning-log
+               ,(make-alt (test-program test)) ,alt ,context ,newcontext
+               ,baseline-errs ,oracle-errs ,all-alts))))
 
   (define (in-engine _)
     (if profile?
@@ -104,8 +105,9 @@
     (engine-run (*timeout*) eng)
 
     (match (engine-result eng)
-      [`(good ,start ,end ,context ,newcontext ,timeline ,bits ,baseline-errs
-              ,oracle-errs ,all-alts)
+      [`(good ,bits ,timeline ,warnings
+              ,start ,end ,context ,newcontext
+              ,baseline-errs ,oracle-errs ,all-alts)
        (match-define (list newpoints newexacts) (get-p&es newcontext))
        (match-define (list points exacts) (get-p&es context))
        (define start-prog (alt-program start))
@@ -122,6 +124,7 @@
                      bits
                      (- (current-inexact-milliseconds) start-time)
                      timeline
+                     warnings
                      start-resugared end-resugared points exacts
                      (errors (alt-program start) context)
                      (errors (alt-program end) context)
@@ -134,10 +137,11 @@
                      baseline-errs
                      oracle-errs
                      all-alts)]
-      [`(error ,e ,bits)
-       (test-failure test bits (- (current-inexact-milliseconds) start-time) (^timeline^) e)]
+      [`(error ,e ,bits ,timeline ,warnings)
+       (test-failure test bits (- (current-inexact-milliseconds) start-time) timeline warnings e)]
       [#f
-       (test-timeout test (bf-precision) (*timeout*) (^timeline^))])))
+       ;; TODO: These fields are meaningless because parameters don't work across engines
+       (test-timeout test (bf-precision) (*timeout*) (^timeline^) '())])))
 
 (define (get-table-data result link)
   (cons (unparse-result result) (get-table-data* result link)))
@@ -202,7 +206,7 @@
 
 (define (unparse-result result)
   (match result
-    [(test-success test bits time timeline
+    [(test-success test bits time timeline warnings
                    start-alt end-alt points exacts start-est-error end-est-error
                    newpoints newexacts start-error end-error target-error
                    baseline-error oracle-error all-alts)
@@ -229,7 +233,7 @@
                     `(:herbie-target ,(test-output test))
                     '())
               ,(program-body (alt-program end-alt)))]
-    [(test-failure test bits time timeline exn)
+    [(test-failure test bits time timeline warnings exn)
      `(FPCore ,(test-vars test)
               :herbie-status ,(if (exn:fail:user:herbie? (test-failure-exn result)) 'error 'crash)
               :herbie-time ,time
@@ -243,7 +247,7 @@
                     `(:herbie-target ,(test-output test))
                     '())
               ,(test-input test))]
-    [(test-timeout test bits time timeline)
+    [(test-timeout test bits time timeline warnings)
      `(FPCore ,(test-vars test)
               :herbie-status timeout
               :herbie-time ,time

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -49,6 +49,7 @@
         [(cons x y) (set-debug-level! x y)]
         [_ (void)])
       (with-handlers ([exn? (λ (e) `(error ,e ,(bf-precision)))])
+        (reset!)
         (define alt
           (run-improve (test-program test)
                        (*num-iterations*)

--- a/src/shell.rkt
+++ b/src/shell.rkt
@@ -26,7 +26,7 @@
       (match output
         [(? test-success?)
          (pretty-print (unparse-result output) (current-output-port) 1)]
-        [(test-failure test bits time timeline exn)
+        [(test-failure test bits time timeline warnings exn)
          ((error-display-handler) (exn-message exn) exn)]
-        [(test-timeout test bits time timeline)
+        [(test-timeout test bits time timeline warnings)
          (printf "Timeout in ~as (see --timeout option)\n" (/ time 1000))]))))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -220,9 +220,14 @@
 ; Difference of squares
 (define-ruleset difference-of-squares-canonicalize (polynomials simplify)
   #:type ([a real] [b real])
+  [swap-sqr              (* (* a b) (* a b))   (* (* a a) (* b b))]
+  [unswap-sqr            (* (* a a) (* b b))   (* (* a b) (* a b))]
   [difference-of-squares (- (* a a) (* b b))   (* (+ a b) (- a b))]
   [difference-of-sqr-1   (- (* a a) 1)         (* (+ a 1) (- a 1))]
-  [difference-of-sqr--1  (+ (* a a) -1)        (* (+ a 1) (- a 1))])
+  [difference-of-sqr--1  (+ (* a a) -1)        (* (+ a 1) (- a 1))]
+  [sqr-pow               (pow x y)             (* (pow x (/ y 2)) (pow x (/ y 2)))]
+  [pow-sqr               (* (pow x y) (pow x y)) (pow x (* 2 y))]
+  )
 
 (define-ruleset difference-of-squares-canonicalize.p16 (polynomials simplify posit)
   #:type ([a posit16] [b posit16])
@@ -342,6 +347,8 @@
   #:type ([x real] [y real])
   [sqrt-prod         (sqrt (* x y))         (* (sqrt x) (sqrt y))]
   [sqrt-div          (sqrt (/ x y))         (/ (sqrt x) (sqrt y))]
+  [sqrt-pow1         (sqrt (pow x y))       (pow x (/ y 2))]
+  [sqrt-pow2         (pow (sqrt x) y)       (pow x (/ y 2))]
   [sqrt-unprod       (* (sqrt x) (sqrt y))  (sqrt (* x y))]
   [sqrt-undiv        (/ (sqrt x) (sqrt y))  (sqrt (/ x y))]
   [add-sqr-sqrt      x                      (* (sqrt x) (sqrt x))])

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -225,8 +225,8 @@
   [difference-of-squares (- (* a a) (* b b))   (* (+ a b) (- a b))]
   [difference-of-sqr-1   (- (* a a) 1)         (* (+ a 1) (- a 1))]
   [difference-of-sqr--1  (+ (* a a) -1)        (* (+ a 1) (- a 1))]
-  [sqr-pow               (pow x y)             (* (pow x (/ y 2)) (pow x (/ y 2)))]
-  [pow-sqr               (* (pow x y) (pow x y)) (pow x (* 2 y))]
+  [sqr-pow               (pow a b)             (* (pow a (/ b 2)) (pow a (/ b 2)))]
+  [pow-sqr               (* (pow a b) (pow a b)) (pow a (* 2 b))]
   )
 
 (define-ruleset difference-of-squares-canonicalize.p16 (polynomials simplify posit)

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -1,0 +1,29 @@
+#lang racket
+(require (only-in xml write-xexpr xexpr?))
+(require "../common.rkt" "../formats/test.rkt" "../sandbox.rkt")
+(provide render-menu render-warnings)
+
+(define/contract (render-menu sections links)
+  (-> (listof (cons/c string? string?)) (listof (cons/c string? string?)) xexpr?)
+  `(nav ([id "links"])
+    (div
+     ,@(for/list ([(text url) (in-dict links)])
+         `(a ([href ,url]) ,text)))
+    (div
+     ,@(for/list ([(text url) (in-dict sections)])
+         `(a ([href ,url]) ,text)))))
+
+(define/contract (render-warnings warnings)
+  (-> (listof (list/c symbol? string? (listof any/c) string? (listof string?))) xexpr?)
+  (if (null? warnings)
+      ""
+      `(ul ([class "warnings"])
+           ,@(for/list ([warning warnings])
+               (match-define (list type message args url extra) warning)
+               `(li (h2 ,(apply format message args)
+                        (a ([href ,url]) " (more)"))
+                    ,(if (null? extra)
+                         ""
+                         `(ol ([class "extra"])
+                              ,@(for/list ([line extra])
+                                  `(li ,line)))))))))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -335,7 +335,8 @@
      (head
       (meta ((charset "utf-8")))
       (title "Exception for " ,(~a (test-name test)))
-      (link ((rel "stylesheet") (type "text/css") (href "../report.css"))))
+      (link ((rel "stylesheet") (type "text/css") (href "../report.css")))
+      ,@js-tex-include)
      (body
       ,(render-menu
         (list/true)
@@ -399,7 +400,8 @@
      (head
       (meta ((charset "utf-8")))
       (title ,(format "Timeout for ~a" (test-name test)))
-      (link ([rel "stylesheet"] [type "text/css"] [href "../report.css"])))
+      (link ([rel "stylesheet"] [type "text/css"] [href "../report.css"]))
+      ,@js-tex-include)
      (body
       ,(render-menu
         (list/true)

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -347,7 +347,9 @@
 
       ,(render-warnings warnings)
 
-      (h1 "Error in " ,(format-time time))
+      (section ([id "program"])
+        (div ([class "program math"]) "\\[" ,(texify-prog (test-program test)) "\\]"))
+
       ,@(cond
          [(exn:fail:user:herbie? exn)
           `((section ([id "user-error"])
@@ -407,6 +409,10 @@
          (and profile? '("Profile" . "profile.txt"))
          '("Metrics" . "timeline.html")))
       ,(render-warnings warnings)
+
+      (section ([id "program"])
+        (div ([class "program math"]) "\\[" ,(texify-prog (test-program test)) "\\]"))
+
       (h1 "Timeout in " ,(format-time time))
       (p "Use the " (code "--timeout") " flag to change the timeout.")
       ,(render-reproduction test)))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -234,7 +234,7 @@
 
 (define (make-graph result out valid-js-prog profile?)
   (match-define
-   (test-success test bits time timeline
+   (test-success test bits time timeline warnings
                  start-alt end-alt points exacts start-est-error end-est-error
                  newpoints newexacts start-error end-error target-error
                  baseline-error oracle-error all-alts)
@@ -336,7 +336,7 @@
     out))
 
 (define (make-traceback result out profile?)
-  (match-define (test-failure test bits time timeline exn) result)
+  (match-define (test-failure test bits time timeline warnings exn) result)
   (fprintf out "<!doctype html>\n")
   (write-xexpr
    `(html
@@ -396,7 +396,7 @@
               (td ([colspan "3"]) "unknown"))])))))
 
 (define (make-timeout result out profile?)
-  (match-define (test-timeout test bits time timeline) result)
+  (match-define (test-timeout test bits time timeline warnings) result)
   (fprintf out "<!doctype html>\n")
   (write-xexpr
    `(html

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -5,7 +5,7 @@
 (require "../alternative.rkt" "../errors.rkt" "../plot.rkt")
 (require "../formats/test.rkt" "../formats/datafile.rkt" "../formats/tex.rkt")
 (require "../core/matcher.rkt" "../core/regimes.rkt" "../sandbox.rkt")
-(require "../fpcore/core2js.rkt" "timeline.rkt" "../syntax/softposit.rkt")
+(require "../fpcore/core2js.rkt" "timeline.rkt" "../syntax/softposit.rkt" "common.rkt")
 
 (provide all-pages make-page)
 
@@ -103,31 +103,6 @@
          (code
           ,(render-command-line) "\n"
           ,(render-fpcore test) "\n"))))
-
-(define/contract (render-menu sections links)
-  (-> (listof (cons/c string? string?)) (listof (cons/c string? string?)) xexpr?)
-  `(nav ([id "links"])
-    (div
-     ,@(for/list ([(text url) (in-dict links)])
-         `(a ([href ,url]) ,text)))
-    (div
-     ,@(for/list ([(text url) (in-dict sections)])
-         `(a ([href ,url]) ,text)))))
-
-(define/contract (render-warnings warnings)
-  (-> (listof (list/c symbol? string? (listof any/c) string? (listof string?))) xexpr?)
-  (if (null? warnings)
-      ""
-      `(ul ([class "warnings"])
-           ,@(for/list ([warning warnings])
-               (match-define (list type message args url extra) warning)
-               `(li (h2 ,(apply format message args)
-                        (a ([href ,url]) " (more)"))
-                    ,(if (null? extra)
-                         ""
-                         `(ol ([class "extra"])
-                              ,@(for/list ([line extra])
-                                  `(li ,line)))))))))
 
 (define (alt2fpcore alt)
   (match-define (list _ args expr) (alt-program alt))

--- a/src/web/report.css
+++ b/src/web/report.css
@@ -239,7 +239,7 @@ section h1 {
 .timeline-block dl { font-size: 90%; }
 .timeline-block dt { min-width: 6em; float: left; font-size: 100%; }
 .timeline-block dd { margin: 0 0 1ex 6em; max-width: 100%; overflow: auto; }
-table.times td { text-align: right; min-width: 8ex; }
+table.times td { text-align: right; min-width: 8ex; vertical-align: baseline; }
 table.times td:last-child { text-align: left; }
 table pre { padding: 0; margin: 0; text-align: left; }
 

--- a/src/web/report.css
+++ b/src/web/report.css
@@ -47,7 +47,7 @@ li.lt-target  {background-color: #ffdb4c;}
 li.eq-start   {background-color: #ff9500;}
 li.lt-start   {background-color: #ff5e3a; color: #f7f7f7;}
 #test-badges li.crash      {
-    background-color:#ff9d87; color:#ed2b00; border: 2px solid #ff5e3a;
+    background-color: #ff9d87; color:#ed2b00; border: 2px solid #ff5e3a;
     width: 71px; height: 36px; line-height: 36px;
 }
 #test-badges li.error      {background-color: #4a4a4a; color: #f7f7f7;}
@@ -59,8 +59,8 @@ li.timeout    {background-color: #8e8e93; color: #f7f7f7;}
 #about th { font-weight: bold; text-align: left; padding-right: 1em; }
 
 #flag-list { position: relative; }
-#flag-list kbd:not(:last-child):after {content: ", ";}
-#flag-list a {float: right; margin: 0 .5em;}
+#flag-list kbd:not(:last-child):after { content: ", "; }
+#flag-list a { float: right; margin: 0 .5em; }
 #flag-list a:before { content: "("; }
 #flag-list a:after { content: ")"; }
 #flag-list #changed-flags { display: none; }
@@ -134,6 +134,18 @@ section h1 {
     font-size: 24px; font-weight: normal; color: #aaa;
 }
 
+/* Warnings */
+
+.warnings { list-style: inside none; padding: 0; }
+.warnings > li {
+    margin: .25em 0; padding: .5em; background: #ffdb4c; border: 2px solid #ff9500;
+}
+.warnings h2 { font-size: 100%; font-weight: normal; margin: 0; }
+.warnings h2:before { content: "Warning: "; font-weight: bold; }
+.warnings h2 a { float: right; }
+.warnings ol { list-style: inside none; padding: 0 1em; }
+.warnings ol li { margin: .25em 0; }
+
 /* Big block for program input output */
 
 #program { background: #ddd; padding: 1em; text-align: center; font-size: 24px; }
@@ -198,7 +210,7 @@ section h1 {
 .history li > div > div { margin: 0; display: inline-block; text-align: right !important; }
 
 .history h2 { margin: 1.333em 0 .333em; }
-.history li {margin: .5em 0; border-top: 1px solid #ddd; padding-top: .5em; }
+.history li { margin: .5em 0; border-top: 1px solid #ddd; padding-top: .5em; }
 .history li:first-child { border-top: none; padding-top: 0; }
 .history .rule { text-decoration: underline; }
 .history .event { display: block; margin: .5em 0; }

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -1,6 +1,6 @@
 #lang racket
 (require json (only-in xml write-xexpr xexpr?))
-(require "../common.rkt" "../formats/test.rkt" "../sandbox.rkt" "../formats/datafile.rkt")
+(require "../common.rkt" "../formats/test.rkt" "../sandbox.rkt" "../formats/datafile.rkt" "common.rkt")
 (provide make-timeline make-timeline-json make-summary-html)
 
 (define timeline-phase? (listof (cons/c symbol? any/c)))
@@ -24,6 +24,7 @@
        (link ([rel "stylesheet"] [type "text/css"] [href "../report.css"]))
        (script ([src "../report.js"])))
       (body ([onload "timeline()"])
+       ,(render-menu '() '(("Report" . "graph.html")))
        (section ((id "process-info"))
          (h1 "Details")
          (p ((class "header"))

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -9,7 +9,7 @@
 ;; This first part handles timelines for a single Herbie run
 
 (define (make-timeline result out)
-  (match-define (test-result test bits fulltime timeline) result)
+  (match-define (test-result test bits fulltime timeline warnings) result)
 
   (define time
     (apply + (for/list ([phase timeline] [next (cdr timeline)])


### PR DESCRIPTION
The goal of this PR is to make recursive rewriting more powerful. In particular, if RR is trying to rewrite an expression like `(f e1 e2)` to have an `f` at its head, the existing RR algorithm will not allow any changes here, but this PR lifts that restriction. This allows rewriting, for example, `(* (* x x) (* y y))` as `(* (* x y) (* x y))`.

The PR also bundles some unrelated improvements (sorry!):
 - A "reset" system to reset all sorts of caches and so on in one step.
 - A warnings system, to avoid duplicate warnings and to push warnings into HTML
 - Added the program to timeout / traceback pages