### PR TITLE
Batch simplify

### DIFF
--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -14,9 +14,10 @@
 
 (define (run-tests . bench-dirs)
   (define tests (append-map load-tests bench-dirs))
-  (define seed (pseudo-random-generator->vector(current-pseudo-random-generator)))
+  (define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
   (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
   (for/and ([test tests])
+    (set-seed! seed)
     (match (get-test-result test #:seed seed)
       [(test-success test bits time timeline warnings
                      start-alt end-alt points exacts start-est-error end-est-error

--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -14,10 +14,12 @@
 
 (define (run-tests . bench-dirs)
   (define tests (append-map load-tests bench-dirs))
-  (define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
-  (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
+  #;(define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
+  #;(printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
   (for/and ([test tests])
     (set-seed! seed)
+    (define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
+    (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
     (match (get-test-result test #:seed seed)
       [(test-success test bits time timeline warnings
                      start-alt end-alt points exacts start-est-error end-est-error

--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -14,12 +14,9 @@
 
 (define (run-tests . bench-dirs)
   (define tests (append-map load-tests bench-dirs))
-  #;(define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
-  #;(printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
+  (define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
+  (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
   (for/and ([test tests])
-    #;(set-seed! seed)
-    (define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
-    (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
     (match (get-test-result test #:seed seed)
       [(test-success test bits time timeline warnings
                      start-alt end-alt points exacts start-est-error end-est-error

--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -17,7 +17,7 @@
   #;(define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
   #;(printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
   (for/and ([test tests])
-    (set-seed! seed)
+    #;(set-seed! seed)
     (define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
     (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
     (match (get-test-result test #:seed seed)

--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -14,8 +14,8 @@
 
 (define (run-tests . bench-dirs)
   (define tests (append-map load-tests bench-dirs))
-  (define seed (get-seed))
-  (printf "Running Herbie on ~a tests (seed: ~a)...\n" (length tests) seed)
+  (define seed (pseudo-random-generator->vector(current-pseudo-random-generator)))
+  (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
   (for/and ([test tests])
     (match (get-test-result test #:seed seed)
       [(test-success test bits time timeline warnings

--- a/src/core/egraph.rkt
+++ b/src/core/egraph.rkt
@@ -7,9 +7,8 @@
 (provide mk-enode! mk-enode-rec! mk-egraph
 	 merge-egraph-nodes!
 	 egraph? egraph-cnt
-	 map-enodes draw-egraph egraph-leaders
+	 draw-egraph egraph-leaders
          elim-enode-loops! reduce-to-single! reduce-to-new!
-         dedup-vars!
          )
 
 (provide (all-defined-out)
@@ -128,11 +127,6 @@
 ;; representing that expression with no expansion or saturation.
 (define (mk-egraph)
   (egraph 0 (make-hash) (make-hash)))
-
-;; Maps a given function over all the equivilency classes
-;; of a given egraph (node packs).
-(define (map-enodes f eg)
-  (map f (egraph-leaders eg)))
 
 ;; Gets all the pack leaders in the egraph
 (define (egraph-leaders eg)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
-(require "../common.rkt" "../alternative.rkt" "../programs.rkt" "../type-check.rkt"
-         "../syntax/softposit.rkt")
+(require "../common.rkt" "../alternative.rkt" "../programs.rkt")
+(require "../type-check.rkt" "../syntax/softposit.rkt" "../syntax/types.rkt")
 (require "../points.rkt" "../float.rkt") ; For binary search
 
 (module+ test

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -45,7 +45,7 @@
   (let* ([iters (min (*max-egraph-iters*) (apply max (map iters-needed exprs)))]
 	 [eg (mk-egraph)]
          [ens (for/list ([expr exprs]) (mk-enode-rec! eg expr))])
-    (parameterize ([*node-limit* (* (length exprs) (*node-limit*))])
+    (parameterize ([*node-limit* 1000 #;(* (length exprs) (*node-limit*))])
       (iterate-egraph! eg iters #:rules rls))
     (define out (for/list ([en ens]) (extract-smallest eg en))) ; TODO: batch extract
     (debug #:from 'simplify (format "Simplified to ~a" (string-join (map ~a out) ", ")))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -30,15 +30,7 @@
 
 (define/contract (simplify-expr expr #:rules rls)
   (-> expr? #:rules (listof rule?) expr?)
-  (debug #:from 'simplify (format "Simplifying ~a" expr))
-  (if (has-nan? expr) +nan.0
-      (let* ([iters (min (*max-egraph-iters*) (iters-needed expr))]
-	     [eg (mk-egraph)]
-             [en (mk-enode-rec! eg expr)])
-	(iterate-egraph! eg iters #:rules rls)
-	(define out (first (extract-smallest eg en)))
-        (debug #:from 'simplify (format "Simplified to ~a" out))
-        out)))
+  (if (has-nan? expr) +nan.0 (first (simplify-batch (list expr) #:rules rls))))
 
 (define (simplify-batch exprs #:rules rls)
   (debug #:from 'simplify (format "Simplifying ~a" (string-join (map ~a exprs) ", ")))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -109,13 +109,15 @@
   (match type
     ['real (exact? val)]
     ['complex (exact? val)]
-    ['boolean true]))
+    ['boolean true]
+    [_ false]))
 
 (define (val-to-type type val)
   (match type
     ['real val]
     ['complex (if (real? val) `(complex ,val 0) val)]
-    ['boolean (if val 'TRUE 'FALSE)]))
+    ['boolean (if val 'TRUE 'FALSE)]
+    [_ (error "Unknown type" type)]))
 
 (define (set-precompute! eg en)
   (define type (enode-type en))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -138,10 +138,11 @@
     (define constexpr
       (cons (car var)
             (map (compose (curry setfindf constant?) enode-vars) (cdr var))))
-    (with-handlers ([exn:fail:contract:divide-by-zero? void])
-      (define res (eval-const-expr constexpr))
-      (when (and (val-of-type type res) (exact-value? type res))
-        (merge-egraph-nodes! eg en (mk-enode-rec! (val-to-type type res)))))))
+    (when (andmap identity constexpr)
+      (with-handlers ([exn:fail:contract:divide-by-zero? void])
+        (define res (eval-const-expr constexpr))
+        (when (and (val-of-type type res) (exact-value? type res))
+          (merge-egraph-nodes! eg en (mk-enode-rec! eg (val-to-type type res))))))))
 
 (define (hash-set*+ hash assocs)
   (for/fold ([h hash]) ([assoc assocs])

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -40,7 +40,7 @@
         (debug #:from 'simplify (format "Simplified to ~a" out))
         out)))
 
-(define (simplify-batch #:rules rls . exprs)
+(define (simplify-batch exprs #:rules rls)
   (debug #:from 'simplify (format "Simplifying ~a" (string-join (map ~a exprs) ", ")))
   (let* ([iters (min (*max-egraph-iters*) (apply max (map iters-needed exprs)))]
 	 [eg (mk-egraph)]

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -24,8 +24,8 @@
 ;;#
 ;;################################################################################;;
 
-;; Cap the number of iterations to try at this.
-(define *node-limit* (make-parameter 1000))
+;; Cap the maximum size of an egraph
+(define *node-limit* (make-parameter 2000))
 
 (define/contract (simplify-expr expr #:rules rls)
   (-> expr? #:rules (listof rule?) expr?)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -7,7 +7,7 @@
 (require "ematch.rkt")
 (require "enode.rkt")
 
-(provide simplify-expr simplify-batch *max-egraph-iters*)
+(provide simplify-expr simplify-batch)
 
 (module+ test (require rackunit))
 
@@ -44,11 +44,12 @@
   out)
 
 (define (iterate-egraph! eg #:rules [rls (*simplify-rules*)])
-  (let ([start-cnt (egraph-cnt eg)])
-    (debug #:from 'simplify #:depth 2 (format "iters left: ~a (~a enodes)" iters start-cnt))
+  (let loop ([iter 1])
+    (define start-cnt (egraph-cnt eg))
+    (debug #:from 'simplify #:depth 2 (format "iteration ~a: (~a enodes)" iter start-cnt))
     (one-iter eg rls)
     (when (< start-cnt (egraph-cnt eg) (*node-limit*))
-      (iterate-egraph! eg #:rules rls))))
+      (loop (+ iter 1)))))
 
 ;; Iterates the egraph by applying each of the given rules in parallel
 ;; to the egraph nodes.

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -106,7 +106,7 @@
 
   (for ([m (find-matches (egraph-leaders eg))])
     (apply-match m))
-  (map-enodes (curry set-precompute! eg) eg)
+  (for-each (curry set-precompute! eg) (egraph-leaders eg))
   (void))
 
 (define-syntax-rule (matches? expr pattern)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -240,7 +240,39 @@
   (when (flag-set? 'generate 'simplify)
     (define log! (timeline-event! 'simplify))
 
-    (define exprs '())
+    (define to-simplify
+      (reap [sow]
+        (for ([child (^children^)] [n (in-naturals 1)])
+          (debug #:from 'progress #:depth 4 "[" n "/" (length (^children^)) "] simplifiying candidate" child)
+          ;; We want to avoid simplifying if possible, so we only
+          ;; simplify things produced by function calls in the rule
+          ;; pattern. This means no simplification if the rule output as
+          ;; a whole is not a function call pattern, and no simplifying
+          ;; subexpressions that don't correspond to function call
+          ;; patterns.
+          (define locs
+            (match (alt-event child)
+              [(list 'taylor _ loc) (list loc)]
+              [(list 'change cng)
+               (match-define (change rule loc _) cng)
+               (define pattern (rule-output rule))
+               (define expr (location-get loc (alt-program child)))
+               (cond
+                [(not (list? pattern)) '()]
+                [else
+                 (for/list ([pos (in-naturals 1)]
+                            [arg-pattern (cdr pattern)] #:when (list? arg-pattern))
+                   (append (change-location cng) (list pos)))])]
+              [_ (list '(2))]))
+
+          (for ([loc locs])
+            (sow (location-get loc (alt-program child)))))))
+
+    (define simplifications
+      (simplify-batch to-simplify #:rules (*simplify-rules*)))
+
+    (define simplify-hash
+      (make-immutable-hash (map cons to-simplify simplifications)))
 
     (define simplified
       (for/list ([child (^children^)] [n (in-naturals 1)])
@@ -267,17 +299,13 @@
             [_ (list '(2))]))
 
         (for/fold ([child child]) ([loc locs])
-          (define tnow (current-inexact-milliseconds))
-          (define child* (location-do loc (alt-program child) (λ (expr) (simplify-expr expr #:rules (*simplify-rules*)))))
-          (set! exprs (cons (cons (location-get loc (alt-program child)) (- (current-inexact-milliseconds) tnow)) exprs))
+          (define child* (location-do loc (alt-program child) (λ (expr) (hash-ref simplify-hash expr))))
           (debug #:from 'simplify "Simplified" loc "to" child*)
           (if (> (program-cost (alt-program child)) (program-cost child*))
               (alt child* (list 'simplify loc) (list child))
               child))))
 
-    (log! 'inputs (length exprs))
-    (log! 'slowest (take-up-to (sort exprs > #:key cdr) 5))
-    (log! 'times (map cdr exprs))
+    (log! 'inputs (length to-simplify))
     (log! 'outputs (length simplified))
 
     (^children^ simplified))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -269,9 +269,7 @@
             (sow (location-get loc (alt-program child)))))))
 
     (define simplifications
-      (if (null? to-simplify)
-          '()
-          (simplify-batch to-simplify #:rules (*simplify-rules*))))
+      (simplify-batch to-simplify #:rules (*simplify-rules*)))
 
     (define simplify-hash
       (make-immutable-hash (map cons to-simplify simplifications)))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -266,7 +266,7 @@
     (define to-simplify
       (for/list ([child (^children^)] [locs locs-list]
                  #:when true [loc locs])
-        (location-get loc child)))
+        (location-get loc (alt-program child))))
 
     (define simplifications
       (simplify-batch to-simplify #:rules (*simplify-rules*)))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -269,7 +269,9 @@
             (sow (location-get loc (alt-program child)))))))
 
     (define simplifications
-      (simplify-batch to-simplify #:rules (*simplify-rules*)))
+      (if (null? to-simplify)
+          '()
+          (simplify-batch to-simplify #:rules (*simplify-rules*))))
 
     (define simplify-hash
       (make-immutable-hash (map cons to-simplify simplifications)))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require math/bigfloat math/flonum)
-(require "common.rkt" "syntax/syntax.rkt" "errors.rkt" "bigcomplex.rkt" "type-check.rkt"
+(require "common.rkt" "syntax/types.rkt" "syntax/syntax.rkt" "errors.rkt" "bigcomplex.rkt" "type-check.rkt"
          "biginterval.rkt" "syntax/softposit.rkt")
 
 (module+ test (require rackunit))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -135,7 +135,7 @@
   (define body*
     (let inductor ([prog (program-body prog)])
       (match prog
-        [(? real?) (real->precision prog)]
+        [(? value?) (real->precision prog)]
         [(? constant?) ((constant-info prog mode))]
         [(? variable?) prog]
         #;[(list 'if cond ift iff)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -4,8 +4,7 @@
 (require "../common.rkt" "../float.rkt" "../errors.rkt" "types.rkt")
 (require "../bigcomplex.rkt" "../biginterval.rkt" "softposit.rkt")
 
-(provide types type? value? bigvalue?
-         constant? variable? operator? operator-info constant-info parametric-operators
+(provide constant? variable? operator? operator-info constant-info parametric-operators
          variary-operators parametric-operators-reverse
          *unknown-d-ops* *unknown-f-ops* *loaded-ops*)
 
@@ -17,16 +16,6 @@
 (define *unknown-f-ops* (make-parameter '()))
 
 (define *loaded-ops* (make-parameter '()))
-
-(define types '(bool real complex _posit8 _posit16 _posit32 _quire8 _quire16 _quire32))
-(define (type? x) (set-member? types x))
-
-(define/match (value-of type) [('bool) boolean?] [('real) real?] [('complex) complex?]
-  [('_posit8) posit8?] [('_posit16) posit16?] [('_posit32) posit32?]
-  [('_quire8) quire8?] [('_quire16) quire16?]  [('_quire32) quire32?])
-(define/match (bigvalue-of type) [('bool) boolean?] [('real) bigfloat?] [('complex) bigcomplex?]
-  [('_posit8 ) big-posit8?] [('_posit16) big-posit16?] [('_posit32) big-posit32?]
-  [('_quire8) big-quire8?] [('_quire16) big-quire16?] [('_quire32) big-quire32?])
 
 (define value? (apply or/c (map value-of types)))
 (define bigvalue? (apply or/c (map bigvalue-of types)))

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -1,15 +1,19 @@
 #lang racket
 
 (require math/bigfloat)
-(require "../common.rkt" "../bigcomplex.rkt")
+(require "../common.rkt" "../bigcomplex.rkt" "softposit.rkt")
 
-(provide types type? value? bigvalue?)
+(provide types type? value? bigvalue? value-of bigvalue-of)
 
-(define types '(bool real complex))
+(define types '(bool real complex _posit8 _posit16 _posit32 _quire8 _quire16 _quire32))
 (define (type? x) (set-member? types x))
 
-(define/match (value-of type) [('bool) boolean?] [('real) real?] [('complex) complex?])
-(define/match (bigvalue-of type) [('bool) boolean?] [('real) bigfloat?] [('complex) bigcomplex?])
+(define/match (value-of type) [('bool) boolean?] [('real) real?] [('complex) complex?]
+  [('_posit8) posit8?] [('_posit16) posit16?] [('_posit32) posit32?]
+  [('_quire8) quire8?] [('_quire16) quire16?]  [('_quire32) quire32?])
+(define/match (bigvalue-of type) [('bool) boolean?] [('real) bigfloat?] [('complex) bigcomplex?]
+  [('_posit8 ) big-posit8?] [('_posit16) big-posit16?] [('_posit32) big-posit32?]
+  [('_quire8) big-quire8?] [('_quire16) big-quire16?] [('_quire32) big-quire32?])
 
 (define value? (apply or/c (map value-of types)))
 (define bigvalue? (apply or/c (map bigvalue-of types)))


### PR DESCRIPTION
This simple changes significantly speeds up Herbie. Every time we are in the simplify phase, we simplify a whole bunch of expressions at once. With this change, we use a single egraph for that: add each expression, iterate the egraph, and then extract the best result for each expression. Since most expressions are similar, the shared egraph saves a significant amount of time.

Initial results seem promising: simplify is 3–6× faster and Herbie as a whole is 1.5–3× faster.

- [x] Fix crash in `3.9.1` with seed 2019125
- [x] Fix Travis failure on `expax`