### PR TITLE
Faster harder node limit

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -56,7 +56,7 @@
 (define *max-mpfr-prec* (make-parameter 10000))
 
 ;; The maximum size of an egraph
-(define *node-limit* (make-parameter 2000))
+(define *node-limit* (make-parameter 1000))
 
 ;; In localization, the maximum number of locations returned
 (define *localize-expressions-limit* (make-parameter 4))

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -1,7 +1,7 @@
 #lang racket
 (provide (all-defined-out))
 
-;; Flag Stuff
+;;; Flags
 
 (define all-flags
   #hash([precision . (double fallback)]
@@ -41,6 +41,8 @@
               [(#t #f) (list 'enabled class flag)]
               [(#f #t) (list 'disabled class flag)]))))
 
+;;; Herbie internal parameters
+
 ;; Number of points to sample for evaluating program accuracy
 (define *num-points* (make-parameter 256))
 
@@ -50,26 +52,21 @@
 ;; The maximum number of consecutive skipped points for sampling valid points
 (define *max-skipped-points* (make-parameter 100))
 
-;; The step size with which arbitrary-precision precision is increased
-;; DANGEROUS TO CHANGE
-(define *precision-step* (make-parameter 256))
-
 ;; Maximum MPFR precision allowed during exact evaluation
 (define *max-mpfr-prec* (make-parameter 10000))
 
-;; In periodicity analysis,
-;; this is how small the period of a function must be to count as periodic
-(define *max-period-coeff* 20)
+;; The maximum size of an egraph
+(define *node-limit* (make-parameter 2000))
 
 ;; In localization, the maximum number of locations returned
 (define *localize-expressions-limit* (make-parameter 4))
 
-(define *binary-search-test-points* (make-parameter 16))
-
 ;; How accurate to make the binary search
+(define *binary-search-test-points* (make-parameter 16))
 (define *binary-search-accuracy* (make-parameter 48))
 
 ;;; About Herbie:
+
 (define (run-command cmd)
   (parameterize ([current-error-port (open-output-nowhere)])
     (string-trim (with-output-to-string (λ () (system cmd))))))
@@ -91,6 +88,8 @@
 (define *herbie-branch*
   (git-command "rev-parse" "--abbrev-ref" "HEAD" #:default "release"))
 
+;;; The "reset" mechanism for clearing caches and such
+
 (define resetters '())
 
 (define (register-reset fn #:priority [priority 0])
@@ -98,3 +97,13 @@
 
 (define (reset!)
   (for ([fn-rec (sort resetters < #:key car)]) ((cdr fn-rec))))
+
+;; OBSOLETE
+
+;; The step size with which arbitrary-precision precision is increased
+;; DANGEROUS TO CHANGE
+(define *precision-step* (make-parameter 256))
+
+;; In periodicity analysis,
+;; this is how small the period of a function must be to count as periodic
+(define *max-period-coeff* 20)

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -56,7 +56,7 @@
 (define *max-mpfr-prec* (make-parameter 10000))
 
 ;; The maximum size of an egraph
-(define *node-limit* (make-parameter 1000))
+(define *node-limit* (make-parameter 2000))
 
 ;; In localization, the maximum number of locations returned
 (define *localize-expressions-limit* (make-parameter 4))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -314,9 +314,9 @@
          (define ift* (loop ift))
          (define iff* (loop iff))
          (list 'if cond* ift* iff*)]
-        [(list 'real->posit8 (? real?)) expr]
-        [(list 'real->posit16 (? real?)) expr]
-        [(list 'real->posit32 (? real?)) expr]
+        [(list 'real->posit8  (? real? x)) x]
+        [(list 'real->posit16 (? real? x)) x]
+        [(list 'real->posit32 (? real? x)) x]
         [(list op args ...)
          (define args* (for/list ([arg args]) (loop arg)))
          (cons op args*)]

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -407,11 +407,9 @@
   [rem-exp-log  (exp (log x))        x]
   [rem-log-exp  (log (exp x))        x])
 
-(define-ruleset exp-reduce-fp-safe (exponents simplify fp-safe)
+(define-ruleset exp-constants (exponents simplify fp-safe)
   [exp-0        (exp 0)              1]
-  [exp-1-e      (exp 1)              E])
-
-(define-ruleset exp-expand-fp-safe (exponents fp-safe)
+  [exp-1-e      (exp 1)              E]
   [1-exp        1                    (exp 0)]
   [e-exp-1      E                    (exp 1)])
 


### PR DESCRIPTION
This PR refactors `simplify.rkt` to enforce the node limit after every rule application, instead of just after every iteration. This cures the issue where sometimes Herbie runs out of memory and hard crashes, since that seems to have been due to a runaway egraph explosion.

The PR also substantially decreases the node limit: formally from 2000 to 1000 but in practice significantly more since before this PR the node limit was usually surpassed by 2–5× before it kicked in. The new node limit was chosen by a set of experiments on the `mathematics` and `libraries` suites, which suggested that the decrease would not cost accuracy and would increase performance.