### PR TITLE
Use the private MPFR library instead of `math/bigfloat` in biginterval

### DIFF
--- a/src/biginterval.rkt
+++ b/src/biginterval.rkt
@@ -72,6 +72,7 @@
 (define 1.bf (bf 1))
 (define 2.bf (bf 2))
 (define +inf.bf (bf +inf.0))
+(define +nan.bf (bf +nan.0))
 
 (define (ival-pi)
   (ival (rnd 'down identity (pi.bf)) (rnd 'up identity (pi.bf)) #f #f))


### PR DESCRIPTION
This PR switches the interval library from using `math/bigfloat` to using `math/private/bigfloat/mpfr`. This allows us to use the MPFR functions without checking contracts on every call. Since each interval function calls lots of MPFR functions, this is a big win (25% speedup for sampling in some tests, so projected 5–10% speedup to Herbie).

The actual change is just renaming a lot of functions, and the internals of `math/bigfloat` have been pretty stable, so I don't see this as adding much maintenance burden.