### PR TITLE
Move resugaring

### DIFF
--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -97,22 +97,11 @@
               ,baseline-errs ,oracle-errs ,all-alts)
        (define-values (newpoints newexacts) (get-p&es newcontext))
        (define-values (points exacts) (get-p&es context))
-       (define start-prog (alt-program start))
-       (define end-prog (alt-program end))
-       (define start-resugared (alt
-         (list 'λ (program-variables start-prog)
-               (resugar-program (program-body start-prog)))
-         'resugar
-         (list end)))
-       (define end-resugared (struct-copy alt end
-         [program (list 'λ (program-variables start-prog)
-                        (resugar-program (program-body end-prog)))]))
        (test-success test
                      bits
                      (- (current-inexact-milliseconds) start-time)
                      (reverse (unbox timeline))
-                     warnings
-                     start-resugared end-resugared points exacts
+                     warnings start end points exacts
                      (errors (alt-program start) context)
                      (errors (alt-program end) context)
                      newpoints newexacts
@@ -135,8 +124,8 @@
 
 (define (dummy-table-row result status link)
   (define test (test-result-test result))
-  (table-row (test-name test) status (test-precondition test) (test-precision test)
-             (test-vars test) (test-input test) #f (test-output test)
+  (table-row (test-name test) status (resugar-program (test-precondition test)) (test-precision test)
+             (test-vars test) (resugar-program (test-input test)) #f (resugar-program (test-output test))
              #f #f #f #f #f #f #f
              (test-result-time result) (test-result-bits result) link))
 
@@ -175,14 +164,9 @@
            [else "uni-start"])))
 
     (struct-copy table-row (dummy-table-row result status link)
-                 [output (program-body (alt-program (test-success-end-alt result)))]
-                 [start start-score]
-                 [result end-score]
-                 [target target-score]
-                 [start-est est-start-score]
-                 [result-est est-end-score]
-                 [inf- (length good-inf)]
-                 [inf+ (length bad-inf)])]
+                 [output (resugar-program (program-body (alt-program (test-success-end-alt result))))]
+                 [start start-score] [result end-score] [target target-score]
+                 [start-est est-start-score] [result-est est-end-score] [inf- (length good-inf)] [inf+ (length bad-inf)])]
    [(test-failure? result)
     (define status (if (exn:fail:user:herbie? (test-failure-exn result)) "error" "crash"))
     (dummy-table-row result status link)]
@@ -204,10 +188,6 @@
            '())
      :name ,(table-row-name row)
      :precision ,(table-row-precision row)
-     ,@(if (eq? (table-row-pre row) 'TRUE)
-           '()
-           `(:pre ,(resugar-program (table-row-pre row))))
-     ,@(if (table-row-target-prog row)
-           `(:herbie-target ,(table-row-target-prog row))
-           '())
+     ,@(if (eq? (table-row-pre row) 'TRUE) '() `(:pre (table-row-pre row)))
+     ,@(if (table-row-target-prog row) `(:herbie-target ,(table-row-target-prog row)) '())
      ,(table-row-output row)))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -467,21 +467,10 @@
     (if (null? pts*) pcontext (mk-pcontext pts* exs*))))
 
 (define (render-history altn pcontext pcontext2 precision)
-  (-> alt? (listof xexpr?))
-
-  (define prog* (if (set-member? '(final-simplify resugar) (alt-event altn))
-    (let* ([prog (alt-program altn)]
-           [vars (program-variables prog)]
-           [expr (third prog)]
-           [precision-ctx (for/list ([var vars])
-                            (cons var precision))]
-           [desugared-expr (desugar-program expr precision-ctx)])
-      (list 'λ vars desugared-expr))
-    (alt-program altn)))
   (define err
-    (format-bits (errors-score (errors prog* pcontext))))
+    (format-bits (errors-score (errors (alt-program altn) pcontext))))
   (define err2
-    (format "Internally ~a" (format-bits (errors-score (errors prog* pcontext2)))))
+    (format "Internally ~a" (format-bits (errors-score (errors (alt-program altn) pcontext2)))))
 
   (match altn
     [(alt prog 'start (list))
@@ -535,8 +524,4 @@
        (li (p "Applied " (span ([class "rule"]) ,(~a (rule-name (change-rule cng))))
               (span ([class "error"] [title ,err2]) ,err))
            (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog #:loc (change-location cng) #:color "blue") "\\]")))]
-    [(alt prog 'resugar `(,prev))
-     `(,@(render-history prev pcontext pcontext2 precision)
-       (li (p "Resugaring" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog) "\\]")))]
     ))


### PR DESCRIPTION
Resugaring (replacing specialized functions like `+.p16` with their more general versions) is currently done too early in the pipeline, which leads to some convoluted code later on. This PR changes the state of affairs to move resugaring later. This should also fix some bugs associated with said convoluted code.