### PR TITLE
Split sample-multi-bounded

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -10,7 +10,7 @@
          take-up-to flip-lists list/true find-duplicates all-partitions
          argmins argmaxs setfindf index-of set-disjoint? comparator sample-double
          write-file write-string
-         random-exp parse-flag get-seed set-seed!
+         random-exp random-ranges parse-flag get-seed set-seed!
          common-eval quasisyntax
          format-time format-bits when-dict in-sorted-dict web-resource
          (all-from-out "config.rkt") (all-from-out "debug.rkt"))
@@ -173,8 +173,32 @@
   "Like (random (expt 2 k)), but k is allowed to be arbitrarily large"
   (if (< k 31) ; Racket generates random numbers in the range [0, 2^32-2]; I think it's a bug
       (random (expt 2 k))
-      (let ([head (* (expt 2 31) (random-exp (- k 31)))])
+      (let ([head (arithmetic-shift (random-exp (- k 31)) 31)])
         (+ head (random (expt 2 31))))))
+
+(define (random-ranges . ranges)
+  (->* () #:rest (cons/c integer? integer?) integer?)
+
+  (define weights
+    (for/list ([(lo hi) (in-dict ranges)])
+      ;; The `max` handles the case lo > hi and similar
+      (max 0 (- hi lo))))
+
+  (define total-weight (apply + weights))
+  (when (= total-weight 0)
+    (error 'random-ranges "Empty ranges"))
+
+  (define num-bits (inexact->exact (ceiling (/ (log total-weight) (log 2)))))
+  (define sample ; Rejection sampling
+    (let loop ()
+      (define sample (random-exp num-bits))
+      (if (< sample total-weight) sample (loop))))
+
+  (let loop ([sample sample] [ranges ranges] [weights weights])
+    ;; The `(car)` is guaranteed to succeed by the construction of `sample`
+    (if (< sample (car weights))
+        (+ (caar ranges) sample)
+        (loop (- sample (car weights)) (cdr ranges) (cdr weights)))))
 
 (define (parse-flag s)
   (match (string-split s ":")

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -22,36 +22,15 @@
   (define ordinal-ranges
     (for/list ([range ranges])
       (match-define (interval (app <-exact lo) (app <-exact hi) lo? hi?) range)
-      (list (->ordinal lo) (->ordinal hi) lo? hi?)))
+      (cons (+ (->ordinal lo) (if lo? 0 1)) (+ (->ordinal hi) (if hi? 1 0)))))
 
-  (define (points-in-range lo hi lo? hi?)
-    ;; The `max` handles the case lo > hi and similar
-    (max 0 (- hi lo (if lo? 0 1) (if hi? -1 0))))
-
-  (define total-weight
-    (apply +
-           (for/list ([range ordinal-ranges])
-             (match-define (list lo hi lo? hi?) range)
-             (points-in-range lo hi lo? hi?))))
-
-  (match total-weight
-   [0 #f]
-   [_
-    (define num-bits (ceiling (/ (log total-weight) (log 2))))
-    (define sample
-      (let loop ()
-        (define sample (random-exp (inexact->exact num-bits)))
-        (if (< sample total-weight) sample (loop))))
-    (let loop ([sample sample] [ordinal-ranges ordinal-ranges])
-      ;; The `(car)` is guaranteed to succeed by the construction of `sample`
-      (match-define (list lo hi lo? hi?) (car ordinal-ranges))
-      (if (< sample (points-in-range lo hi lo? hi?))
-          (<-ordinal (+ lo (if lo? 0 1) sample))
-          (loop (- sample (points-in-range lo hi lo? hi?)) (cdr ordinal-ranges))))]))
+  (<-ordinal (apply random-ranges ordinal-ranges)))
 
 (module+ test
   (check-true (set-member? '(0.0 1.0) (sample-multi-bounded (list (interval 0 0 #t #t) (interval 1 1 #t #t)))))
-  (check-false (sample-multi-bounded (list (interval 0 0 #t #f) (interval 1 1 #f #t)))))
+  (check-exn
+   exn:fail?
+   (λ () (sample-multi-bounded (list (interval 0 0 #t #f) (interval 1 1 #f #t))))))
 
 (define *pcontext* (make-parameter #f))
 


### PR DESCRIPTION
I moved the guts of the sampling code to `random-ranges` in `common.rkt`, which deals only with integers and is not Herbie-specific. `sample-multi-bounded` now just converts to and from ordinals and uses the intervals data structure.