### PR TITLE
Interface2: Remove representation inference from values in `float.rkt`

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -4,7 +4,7 @@
 (require "config.rkt" "errors.rkt" "debug.rkt" "interface.rkt")
 (module+ test (require rackunit))
 
-(provide *start-prog* *all-alts*
+(provide *start-prog* *all-alts* *output-prec* *var-precs*
          reap define-table table-ref table-set! table-remove!
          assert for/append string-prefix call-with-output-files
          take-up-to flip-lists list/true find-duplicates all-partitions
@@ -21,6 +21,10 @@
 
 (define *start-prog* (make-parameter '()))
 (define *all-alts* (make-parameter '()))
+
+;; Global precision tacking
+(define *output-prec* (make-parameter '()))
+(define *var-precs* (make-parameter '()))
 
 ;; Various syntactic forms of convenience used in Herbie
 

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -47,7 +47,8 @@
 
                    (define exact (map (curry apply (operator-info f 'bf)) argexacts))
                    (define approx (map (curry apply (operator-info f 'fl)) argapprox))
-                   (cons exact (map (λ (ex ap) (+ 1 (abs (ulp-difference (<-bf ex) ap)))) exact approx))]))))
+                   (define repr (infer-double-representation (<-bf ex) ap))
+                   (cons exact (map (λ (ex ap) (+ 1 (abs (ulp-difference (<-bf ex) ap repr)))) exact approx))]))))
 
 (register-reset
  (λ ()

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -47,8 +47,9 @@
 
                    (define exact (map (curry apply (operator-info f 'bf)) argexacts))
                    (define approx (map (curry apply (operator-info f 'fl)) argapprox))
-                   (define repr (infer-double-representation (<-bf ex) ap))
-                   (cons exact (map (λ (ex ap) (+ 1 (abs (ulp-difference (<-bf ex) ap repr)))) exact approx))]))))
+                   (cons exact (map (λ (ex ap)
+                                       (define repr (infer-double-representation (<-bf ex) ap))
+                                       (+ 1 (abs (ulp-difference (<-bf ex) ap repr)))) exact approx))]))))
 
 (register-reset
  (λ ()

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -23,9 +23,11 @@
              (λ ()
                 (match expr
                   [(? constant?)
-                   (cons (repeat (->bf expr)) (repeat 1))]
+                   (cons (repeat (->bf expr (infer-representation expr))) (repeat 1))]
                   [(? variable?)
-                   (cons (map ->bf (dict-ref vars expr)) (repeat 1))]
+                   (cons (map (curryr ->bf (get-representation 'binary64))
+                              (dict-ref vars expr))
+                         (repeat 1))]
                   [`(if ,c ,ift ,iff)
                    (let ([exact-ift (car (localize-on-expression ift vars cache))]
                          [exact-iff (car (localize-on-expression iff vars cache))]

--- a/src/core/periodicity.rkt
+++ b/src/core/periodicity.rkt
@@ -95,8 +95,9 @@
       [(list (or 'lambda 'λ) (list vars ...) body)
        `(λ ,vars ,(loop body (cons 2 loc)))]
       [(? constant? c)
+       (define repr (infer-representation c))
        ;; TODO : Do something more intelligent with 'PI
-       (let ([val (if (rational? c) c (->flonum c))])
+       (let ([val (if (rational? c) c (->flonum c repr))])
          (annotation val (reverse loc) 'constant val))]
       [(? variable? x)
        (annotation x (reverse loc) 'linear `((,x . 1)))]

--- a/src/core/periodicity.rkt
+++ b/src/core/periodicity.rkt
@@ -22,6 +22,7 @@
 (require "../alternative.rkt")
 (require "../points.rkt")
 (require "../syntax/rules.rkt")
+(require "../float.rkt")
 (require "matcher.rkt")
 
 (struct annotation (expr loc type coeffs) #:transparent)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -117,7 +117,10 @@
 
 (define (sort-context-on-expr context expr variables)
   (let ([p&e (sort (for/list ([(pt ex) (in-pcontext context)]) (cons pt ex))
-		   </total #:key (compose (eval-prog `(λ ,variables ,expr) 'fl) car))])
+		   (λ (x1 x2)
+          (define repr (infer-double-representation x1 x2))
+          (</total x1 x2 repr))
+       #:key (compose (eval-prog `(λ ,variables ,expr) 'fl) car))])
     (mk-pcontext (map car p&e) (map cdr p&e))))
 
 (define (option-on-expr alts expr)
@@ -126,7 +129,10 @@
   (define pcontext* (sort-context-on-expr (*pcontext*) expr vars))
   (define pts (for/list ([(pt ex) (in-pcontext pcontext*)]) pt))
   (define splitvals (map (eval-prog `(λ ,vars ,expr) 'fl) pts))
-  (define can-split? (append (list #f) (for/list ([val (cdr splitvals)] [prev splitvals]) (<-all-precisions prev val))))
+  (define can-split? (append (list #f)
+                             (for/list ([val (cdr splitvals)] [prev splitvals])
+                               (define repr (infer-double-representation prev val))
+                               (<-all-precisions prev val repr))))
   (define err-lsts
     (for/list ([alt alts]) (errors (alt-program alt) pcontext*)))
   (define bit-err-lsts (map (curry map ulps->bits) err-lsts))
@@ -167,8 +173,9 @@
 
 ;; (pred p1) and (not (pred p2))
 (define (binary-search-floats pred p1 p2)
-  (let ([midpoint (midpoint p1 p2)])
-    (cond [(< (bit-difference p1 p2) 48) midpoint]
+  (define repr (infer-double-representation p1 p2))
+  (let ([midpoint (midpoint p1 p2 repr)])
+    (cond [(< (bit-difference p1 p2 repr) 48) midpoint]
 	  [(pred midpoint) (binary-search-floats pred midpoint p2)]
 	  [else (binary-search-floats pred p1 midpoint)])))
 
@@ -323,7 +330,9 @@
     (λ (pt)
       (define val (prog pt))
       (for/first ([right splitpoints]
-                  #:when (or (nan?-all-types (sp-point right)) (<=/total val (sp-point right))))
+                  #:when (or (nan?-all-types (sp-point right))
+                             (<=/total val (sp-point right)
+                                       (infer-double-splitpoint val (sp-point right)))))
         ;; Note that the last splitpoint has an sp-point of +nan.0, so we always find one
         (equal? (sp-cidx right) i)))))
 

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -330,9 +330,10 @@
     (λ (pt)
       (define val (prog pt))
       (for/first ([right splitpoints]
-                  #:when (or (nan?-all-types (sp-point right))
+                  #:when (or (nan?-all-types (sp-point right)
+                                             (infer-representation (sp-point right)))
                              (<=/total val (sp-point right)
-                                       (infer-double-splitpoint val (sp-point right)))))
+                                       (infer-double-representation val (sp-point right)))))
         ;; Note that the last splitpoint has an sp-point of +nan.0, so we always find one
         (equal? (sp-cidx right) i)))))
 

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -98,10 +98,10 @@
      [else (< ((representation-repr->ordinal repr) x1)
               ((representation-repr->ordinal repr) x2))])]))
 
-(define (nan?-all-types x)
+(define (nan?-all-types x repr)
   (if (or (real? x) (complex? x))
       (nan? x)
-      (set-member? (representation-special-values (infer-representation x)) x)))
+      (set-member? (representation-special-values repr) x)))
 
 (define (<=/total x1 x2 repr)
   (or (</total x1 x2 repr) (=-or-nan? x1 x2)))
@@ -120,13 +120,11 @@
     ['boolean (if val 'TRUE 'FALSE)]
     [_ (error "Unknown type" type)]))
 
-(define (flval x)
+(define (flval x repr)
   (match x
     [(? real?) x]
     [(? complex?) (hash 'type "complex" 'real (real-part x) 'imag (real-part x))]
-    [_
-     (define repr (infer-representation x))
-     (hash 'type (~a repr) 'ordinal (~a ((representation-repr->ordinal repr) x)))]))
+    [_ (hash 'type (~a repr) 'ordinal (~a ((representation-repr->ordinal repr) x)))]))
 
 (define/contract (->flonum x)
   (-> any/c value?)

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -66,7 +66,10 @@
 
 (define (ordinary-value? x repr)
   (if (and (complex? x) (not (real? x)))
-      (and (ordinary-value? (real-part x)) (ordinary-value? (imag-part x)))
+      ;; TODO: Once complex is a separate type rather than a repr, check to see
+      ;; what repr the complex implementation is using
+      (and (ordinary-value? (real-part x) (get-representation 'binary64))
+           (ordinary-value? (imag-part x) (get-representation 'binary64)))
       (not (special-value? x repr))))
 
 (module+ test

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -145,14 +145,14 @@
 (define (repr->fl x repr)
   (bigfloat->flonum ((representation-repr->bf repr) x)))
 
-(define/contract (->bf x)
-  (-> any/c bigvalue?)
+(define/contract (->bf x repr)
+  (-> any/c representation? bigvalue?)
   (cond
    [(and (symbol? x) (constant? x)) ((constant-info x 'bf))]
    [(and (complex? x) (not (real? x)))
     (bigcomplex (bf (real-part x)) (bf (imag-part x)))]
    [else
-    ((representation-repr->bf (infer-representation x)) x)]))
+    ((representation-repr->bf repr) x)]))
 
 (define (<-all-precisions x1 x2 repr)
   (cond

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -19,17 +19,6 @@
          (if (flag-set? 'precision 'double) 'binary64 'binary32)
          type))))
 
-(define (infer-big-representation x)
-  (let/ec return
-     (for ([(type rec) (in-hash type-dict)] #:unless (equal? type 'complex))
-       (define name
-         (if (equal? type 'real)
-           (if (flag-set? 'precision 'double) 'binary64 'binary32)
-           type))
-       (cond
-        [((car rec) x) (return (cons (get-representation name) 'fl))]))
-     (error "Could not infer big representation for" x)))
-
 (define (infer-double-representation x y)
   (define repr1 (infer-representation x))
   (define repr2 (infer-representation y))
@@ -156,10 +145,8 @@
    [(and (symbol? x) (constant? x))
     (->flonum ((constant-info x 'fl)))]
    [else
-    (match-define (cons repr kind) (infer-big-representation x))
-    (match kind
-      ['bf ((representation-bf->repr repr) x)]
-      ['fl (if (and (real? x) (exact? x)) (exact->inexact x) x)])]))
+    (define repr (infer-representation x))
+    (if (and (real? x) (exact? x)) (exact->inexact x) x)]))
 
 (define (fl->repr x repr)
   ((representation-exact->repr repr) x))

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -61,19 +61,19 @@
 (define (random-generate repr)
   ((representation-ordinal->repr repr) (random-exp (representation-total-bits repr))))
 
-(define (special-value? x)
-  (define repr (infer-representation x))
+(define (special-value? x repr)
   (set-member? (representation-special-values repr) x))
 
-(define (ordinary-value? x)
+(define (ordinary-value? x repr)
   (if (and (complex? x) (not (real? x)))
       (and (not (and (real? x) (nan? x))) (not (and (real? x) (infinite? x))))
-      (not (special-value? x))))
+      (not (special-value? x repr))))
 
 (module+ test
-  (check-true (ordinary-value? 2.5))
-  (check-false (ordinary-value? +nan.0))
-  (check-false (ordinary-value? -inf.0)))
+  (define binary64 (get-representation 'binary64))
+  (check-true (ordinary-value? 2.5 binary64))
+  (check-false (ordinary-value? +nan.0 binary64))
+  (check-false (ordinary-value? -inf.0 binary64)))
 
 (define (=-or-nan? x1 x2)
   (and (number? x1) (number? x2)

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -34,8 +34,8 @@
 
 (define (ulp-difference x y repr)
   (if (and (complex? x) (complex? y) (not (real? x)) (not (real? y)))
-    (+ (ulp-difference (real-part x) (real-part y))
-       (ulp-difference (imag-part x) (imag-part y)))
+    (+ (ulp-difference (real-part x) (real-part y) repr)
+       (ulp-difference (imag-part x) (imag-part y) repr))
     (let ([->ordinal (representation-repr->ordinal repr)])
       (- (->ordinal y) (->ordinal x)))))
 

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -34,8 +34,8 @@
 
 (define (ulp-difference x y repr)
   (if (and (complex? x) (complex? y) (not (real? x)) (not (real? y)))
-    (+ (ulp-difference (real-part x) (real-part y) repr)
-       (ulp-difference (imag-part x) (imag-part y) repr))
+    (+ (ulp-difference (real-part x) (real-part y) (get-representation 'binary64))
+       (ulp-difference (imag-part x) (imag-part y) (get-representation 'binary64)))
     (let ([->ordinal (representation-repr->ordinal repr)])
       (- (->ordinal y) (->ordinal x)))))
 

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -66,7 +66,7 @@
 
 (define (ordinary-value? x repr)
   (if (and (complex? x) (not (real? x)))
-      (and (not (and (real? x) (nan? x))) (not (and (real? x) (infinite? x))))
+      (and (ordinary-value? (real-part x)) (ordinary-value? (imag-part x)))
       (not (special-value? x repr))))
 
 (module+ test

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -126,17 +126,17 @@
     [(? complex?) (hash 'type "complex" 'real (real-part x) 'imag (real-part x))]
     [_ (hash 'type (~a repr) 'ordinal (~a ((representation-repr->ordinal repr) x)))]))
 
-(define/contract (->flonum x)
-  (-> any/c value?)
+(define/contract (->flonum x repr)
+  (-> any/c representation? value?)
   (cond
    [(and (complex? x) (not (real? x)))
-    (make-rectangular (->flonum (real-part x)) (->flonum (imag-part x)))]
+    (make-rectangular (->flonum (real-part x) repr) (->flonum (imag-part x) repr))]
    [(bigcomplex? x)
-    (make-rectangular (->flonum (bigcomplex-re x)) (->flonum (bigcomplex-im x)))]
+    (make-rectangular (->flonum (bigcomplex-re x) repr)
+                      (->flonum (bigcomplex-im x) repr))]
    [(and (symbol? x) (constant? x))
-    (->flonum ((constant-info x 'fl)))]
+    (->flonum ((constant-info x 'fl)) repr)]
    [else
-    (define repr (infer-representation x))
     (if (and (real? x) (exact? x)) (exact->inexact x) x)]))
 
 (define (fl->repr x repr)

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -5,7 +5,8 @@
 
 (provide (struct-out test) test-program test-target load-tests parse-test)
 
-(struct test (name vars input output expected precondition precision) #:prefab)
+(struct test (name vars input output expected precondition
+                   output-prec var-precs) #:prefab)
 
 (define (test-program test)
   `(λ ,(test-vars test) ,(test-input test)))

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -18,12 +18,23 @@
   (assert-program! stx)
   (assert-program-type! stx)
   (match-define (list 'FPCore (list args ...) props ... body) (syntax->datum stx))
+  (define arg-names (for/list ([arg args])
+                      (if (list? arg)
+                        (last arg)
+                        arg)))
 
   (define prop-dict
     (let loop ([props props])
       (match props
         ['() '()]
         [(list prop val rest ...) (cons (cons prop val) (loop rest))])))
+
+  (define default-prec (dict-ref prop-dict ':precision 'binary64))
+  (define var-precs (for/list ([arg args] [arg-name arg-names])
+                      (if (and (list? arg) (set-member? args ':precision))
+                        (cons arg-name
+                              (list-ref args (add1 (index-of args ':precision))))
+                        (cons arg-name default-prec))))
 
   (define ctx-prec
     ;; Default to 'real because types and precisions are mixed up right now
@@ -34,12 +45,13 @@
   (define type-ctx (map (curryr cons ctx-prec) args))
 
   (test (~a (dict-ref prop-dict ':name body))
-        args
+        arg-names
         (desugar-program body type-ctx)
         (desugar-program (dict-ref prop-dict ':herbie-target #f) type-ctx)
         (dict-ref prop-dict ':herbie-expected #t)
         (desugar-program (dict-ref prop-dict ':pre 'TRUE) type-ctx)
-        (dict-ref prop-dict ':precision 'binary64)))
+        default-prec
+        var-precs))
 
 (define (load-stdin)
   (for/list ([test (in-port (curry read-syntax "stdin") (current-input-port))])

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -66,6 +66,7 @@
 ;; Setting up
 (define (setup-prog! prog #:precondition [precondition 'TRUE]
                      #:precision [precision 'binary64])
+  (*output-prec* precision)
   (*start-prog* prog)
   (rollback-improve!)
   (check-unused-variables (program-variables prog) precondition (program-body prog))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -255,7 +255,7 @@
 
 (define (filter-p&e pts exacts)
   "Take only the points and exacts for which the exact value and the point coords are ordinary"
-  (define repr (infer-representation (car pts)))
+  (define repr (infer-representation (caar pts)))
   (for/lists (ps es)
       ([pt pts] [ex exacts] #:when (ordinary-value? ex repr)
                             #:when (andmap (curryr ordinary-value? repr) pt))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -40,7 +40,7 @@
   (in-parallel (in-vector (pcontext-points context)) (in-vector (pcontext-exacts context))))
 
 (define/contract (mk-pcontext points exacts)
-  ;; TODO: The second argumnet type should be any of the possible input types,
+  ;; TODO: The second argument type should be any of the possible input types,
   ;; not just any type in general (maybe the first argument too?)
   (-> (non-empty-listof (listof any/c)) (non-empty-listof any/c) pcontext?)
   (pcontext (list->vector points) (list->vector exacts)))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -194,7 +194,7 @@
   (eval-errors baseline newpcontext))
 
 (define (errors-score e)
-  (define repr (infer-representation e))
+  (define repr (get-representation 'binary64))
   (let-values ([(reals unreals) (partition (curryr ordinary-value? repr) e)])
     (if (flag-set? 'reduce 'avg-error)
         (/ (+ (apply + (map ulps->bits reals))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -129,9 +129,9 @@
       (define ex
         (and pre (ival-eval body-fn pt precision #:log (point-logger 'body log prog))))
 
-      (define repr (infer-representation pt))
+      (define repr (infer-representation (car pt)))
       (cond
-       [(and (andmap ordinary-value? pt repr) pre (ordinary-value? ex repr))
+       [(and (andmap (curryr ordinary-value? repr) pt) pre (ordinary-value? ex repr))
         (if (>= sampled (- (*num-points*) 1))
             (values points exacts)
             (loop (+ 1 sampled) 0 (cons pt points) (cons ex exacts)))]

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -170,8 +170,9 @@
 
 
 (define (point-error out exact)
+  (define repr (infer-double-representation out exact))
   (if (ordinary-value? out)
-      (+ 1 (abs (ulp-difference out exact)))
+      (+ 1 (abs (ulp-difference out exact repr)))
       (+ 1 (expt 2 (*bit-width*)))))
 
 (define (eval-errors eval-fn pcontext)

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -255,7 +255,7 @@
 
 (define (filter-p&e pts exacts)
   "Take only the points and exacts for which the exact value and the point coords are ordinary"
-  (define repr (infer-representation (caar pts)))
+  (define repr (get-representation (*output-prec*)))
   (for/lists (ps es)
       ([pt pts] [ex exacts] #:when (ordinary-value? ex repr)
                             #:when (andmap (curryr ordinary-value? repr) pt))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -81,8 +81,13 @@
     (location-do loc prog return)))
 
 (define (eval-prog prog mode)
-  (define real->precision (match mode ['bf ->bf] ['fl ->flonum] ['ival mk-ival] ['nonffi identity])) ; Keep exact numbers exact
-  (define precision->real (match mode ['bf identity] ['fl ->flonum] ['ival identity] ['nonffi identity]))
+  ; Keep exact numbers exact
+  (define real->precision (match mode ['bf ->bf]
+                            ['fl (λ (x) (->flonum x (infer-representation x)))]
+                            ['ival mk-ival] ['nonffi identity]))
+  (define precision->real (match mode ['bf identity]
+                            ['fl (λ (x) (->flonum x (infer-representation x)))]
+                            ['ival identity] ['nonffi identity]))
 
   (define body*
     (let inductor ([prog (program-body prog)])

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -82,12 +82,16 @@
 
 (define (eval-prog prog mode)
   ; Keep exact numbers exact
-  (define real->precision (match mode ['bf ->bf]
+  (define real->precision (match mode
+                            ['bf (λ (x) (->bf x (infer-representation x)))]
                             ['fl (λ (x) (->flonum x (infer-representation x)))]
-                            ['ival mk-ival] ['nonffi identity]))
-  (define precision->real (match mode ['bf identity]
+                            ['ival mk-ival]
+                            ['nonffi identity]))
+  (define precision->real (match mode
+                            ['bf identity]
                             ['fl (λ (x) (->flonum x (infer-representation x)))]
-                            ['ival identity] ['nonffi identity]))
+                            ['ival identity]
+                            ['nonffi identity]))
 
   (define body*
     (let inductor ([prog (program-body prog)])

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -145,7 +145,7 @@
     (define est-end-score (errors-score (test-success-end-est-error result)))
 
     ;; TODO: this is broken because errors are always ordinary values now!
-    (define binary64 (get-representation 'binar64))
+    (define binary64 (get-representation 'binary64))
     (define-values (reals infs) (partition (curryr ordinary-value? binary64)
                                            (map - end-errors start-errors)))
     (define-values (good-inf bad-inf) (partition positive? infs))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -44,13 +44,13 @@
           (run-improve (test-program test)
                        (*num-iterations*)
                        #:precondition (test-precondition test)
-                       #:precision (test-precision test)))
+                       #:precision (test-output-prec test)))
         (define context (*pcontext*))
         (when seed (set-seed! seed))
         (timeline-event! 'sample)
         (define newcontext
           (parameterize ([*num-points* (*reeval-pts*)])
-            (prepare-points (test-program test) (test-precondition test) (test-precision test))))
+            (prepare-points (test-program test) (test-precondition test) (test-output-prec test))))
         (timeline-event! 'end)
         (define end-err (errors-score (errors (alt-program alt) newcontext)))
 
@@ -123,7 +123,7 @@
 
 (define (dummy-table-row result status link)
   (define test (test-result-test result))
-  (table-row (test-name test) status (resugar-program (test-precondition test)) (test-precision test)
+  (table-row (test-name test) status (resugar-program (test-precondition test)) (test-output-prec test)
              (test-vars test) (resugar-program (test-input test)) #f
              (and (test-output test) (resugar-program (test-output test)))
              #f #f #f #f #f #f #f (test-result-time result) (test-result-bits result) link))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -1,9 +1,8 @@
 #lang racket
 (require profile math/bigfloat racket/engine)
-(require "common.rkt" "errors.rkt" "debug.rkt")
-(require "float.rkt" "points.rkt" "programs.rkt")
-(require "mainloop.rkt" "alternative.rkt" "timeline.rkt" (submod "timeline.rkt" debug))
-(require "formats/datafile.rkt" "formats/test.rkt")
+(require "common.rkt" "errors.rkt" "debug.rkt" "float.rkt" "points.rkt" "programs.rkt"
+         "mainloop.rkt" "alternative.rkt" "timeline.rkt" (submod "timeline.rkt" debug)
+         "interface.rkt" "formats/datafile.rkt" "formats/test.rkt")
 
 (provide get-test-result *reeval-pts* *timeout*
          (struct-out test-result) (struct-out test-success)
@@ -146,7 +145,9 @@
     (define est-end-score (errors-score (test-success-end-est-error result)))
 
     ;; TODO: this is broken because errors are always ordinary values now!
-    (define-values (reals infs) (partition ordinary-value? (map - end-errors start-errors)))
+    (define binary64 (get-representation 'binar64))
+    (define-values (reals infs) (partition (curryr ordinary-value? binary64)
+                                           (map - end-errors start-errors)))
     (define-values (good-inf bad-inf) (partition positive? infs))
 
     (define status

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -58,9 +58,10 @@
   (define errs
     (for/list ([pt points] [v1 ex1] [v2 ex2]
                #:when (and (ordinary-value? v1) (ordinary-value? v2)))
+      (define repr (infer-double-representation v1 v2))
       (with-check-info (['point (map cons fv pt)] ['method (object-name ground-truth)]
                         ['input v1] ['output v2])
-        (check-eq? (ulp-difference v1 v2) 0))))
+        (check-eq? (ulp-difference v1 v2 repr) 0))))
   (when (< (length errs) 100)
     (fail-check "Not enough points sampled to test rule")))
 

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -57,7 +57,8 @@
   (define ex2 (map prog2 points))
   (define errs
     (for/list ([pt points] [v1 ex1] [v2 ex2]
-               #:when (and (ordinary-value? v1) (ordinary-value? v2)))
+               #:when (and (ordinary-value? v1 (infer-representation v1))
+                           (ordinary-value? v2 (infer-representation v2))))
       (define repr (infer-double-representation v1 v2))
       (with-check-info (['point (map cons fv pt)] ['method (object-name ground-truth)]
                         ['input v1] ['output v2])

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -238,7 +238,7 @@
                  newpoints newexacts start-error end-error target-error
                  baseline-error oracle-error all-alts)
    result)
-   (define precision (test-precision test))
+   (define precision (test-output-prec test))
    ;; render-history expects the precision to be 'real rather than 'binary64 or 'binary32
    ;; remove this when the number system interface is added
    (define precision* (if (set-member? '(binary64 binary32) precision)

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -166,7 +166,10 @@
        (match-define (list prog category prec) outcome)
        (hash 'count count 'time time
              'program (~a prog) 'category (~a category) 'precision prec))]
-    [('bstep v) (map (λ (x) (map (curryr apply '()) (list flval flval identity flval) x)) v)]
+    [('bstep v) (map (λ (x) (map (curryr apply '())
+                                 (list flval flval (λ (x _) x) flval) x))
+                                 v
+                                 (map (infer-representation) v))]
     [(_ v) v])
 
   (define data


### PR DESCRIPTION
This PR begins the process of removing the process of checking values for their associated representation, and instead passing the representation through to the necessary functions. This change focuses on `infer-representation` and `infer-double-representation` in `float.rkt` and removes all references to these functions from the file (aside from the definition). Note that these functions are still called by other files; this is just the first step in removing this process from interface code.