### PR TITLE
Support some FPCore 1.2 syntax

### DIFF
--- a/src/biginterval.rkt
+++ b/src/biginterval.rkt
@@ -448,7 +448,7 @@
            (match tail
              ['() acc]
              [(cons next rest)
-              (loop next rest (ival-and (f head next) ival-true))]))))
+              (loop next rest (ival-and (f head next) acc))]))))
    name))
 
 (define ival-<  (ival-comparator ival-<2  'ival-<))

--- a/src/biginterval.rkt
+++ b/src/biginterval.rkt
@@ -73,7 +73,7 @@
 (define +nan.bf (bf +nan.0))
 
 (define (ival-pi)
-  (ival (rnd 'down identity (pi.bf)) (rnd 'up identity (pi.bf)) #f #f))
+  (ival (rnd 'down pi.bf) (rnd 'up pi.bf) #f #f))
 
 (define (ival-e)
   (ival (rnd 'down bfexp 1.bf) (rnd 'up bfexp 1.bf) #f #f))
@@ -273,8 +273,8 @@
   (ival (not (ival-hi x)) (not (ival-lo x)) (ival-err? x) (ival-err x)))
 
 (define (ival-cos x)
-  (define lopi (rnd 'down identity (pi.bf)))
-  (define hipi (rnd 'up identity (pi.bf)))
+  (define lopi (rnd 'down pi.bf))
+  (define hipi (rnd 'up pi.bf))
   (define a (rnd 'down bffloor (bfdiv (ival-lo x) (if (bflt? (ival-lo x) 0.bf) lopi hipi))))
   (define b (rnd 'up   bffloor (bfdiv (ival-hi x) (if (bflt? (ival-hi x) 0.bf) hipi lopi))))
   (cond
@@ -290,8 +290,8 @@
     (ival -1.bf 1.bf (ival-err? x) (ival-err x))]))
 
 (define (ival-sin x)
-  (define lopi (rnd 'down identity (pi.bf)))
-  (define hipi (rnd 'up identity (pi.bf)))
+  (define lopi (rnd 'down pi.bf))
+  (define hipi (rnd 'up pi.bf))
   (define a (rnd 'down bffloor (bfsub (bfdiv (ival-lo x) (if (bflt? (ival-lo x) 0.bf) lopi hipi)) half.bf))) ; half.bf is exact
   (define b (rnd 'up bffloor (bfsub (bfdiv (ival-hi x) (if (bflt? (ival-hi x) 0.bf) hipi lopi)) half.bf)))
   (cond
@@ -337,7 +337,7 @@
 
   (if a-lo
       (ival (rnd 'down apply bfatan2 a-lo) (rnd 'up apply bfatan2 a-hi) err? err)
-      (ival (rnd 'down bfneg (pi.bf)) (rnd 'up identity (pi.bf))
+      (ival (rnd 'down bfneg (pi.bf)) (rnd 'up pi.bf)
             (or err? (bfgte? (ival-hi x) 0.bf))
             (or err (and (bf=? (ival-lo x) 0.bf) (bf=? (ival-hi x) 0.bf) (bf=? (ival-lo y) 0.bf) (bf=? (ival-hi y) 0.bf))))))
 

--- a/src/formats/datafile.rkt
+++ b/src/formats/datafile.rkt
@@ -9,7 +9,7 @@
 
 
 (struct table-row
-  (name status pre precision vars input output target-prog
+  (name status pre precision vars input output spec target-prog
         start result target inf- inf+ start-est result-est
         time bits link) #:prefab)
 
@@ -32,7 +32,7 @@
 (define (write-datafile file info)
   (define (simplify-test test)
     (match test
-      [(table-row name status pre prec vars input output target-prog
+      [(table-row name status pre prec vars input output spec target-prog
                   start-bits end-bits target-bits inf- inf+ start-est end-est
                   time bits link)
        (make-hash
@@ -50,6 +50,7 @@
           (vars . ,(if vars (map symbol->string vars) #f))
           (input . ,(write-string (write input)))
           (output . ,(write-string (write output)))
+          (spec . ,(write-string (write spec)))
           (target-prog . ,(write-string (write target-prog)))
           (time . ,time)
           (bits . ,bits)
@@ -102,6 +103,7 @@
                          [string-lst (parse-string string-lst)]))
                      (table-row (get 'name) (get 'status) (parse-string (hash-ref test 'pre "TRUE")) (string->symbol (hash-ref test 'prec "binary64"))
                                 vars (parse-string (get 'input)) (parse-string (get 'output))
+                                (parse-string (hash-ref test 'spec "#f"))
                                 (parse-string (hash-ref test 'target-prog "#f"))
                                 (get 'start) (get 'end) (get 'target)
                                 (get 'ninf) (get 'pinf) (hash-ref test 'start-est 0) (hash-ref test 'end-est 0)

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -3,15 +3,18 @@
 (require "../common.rkt" "../errors.rkt")
 (require "../programs.rkt" "../syntax-check.rkt" "../type-check.rkt")
 
-(provide (struct-out test) test-program test-target load-tests parse-test)
+(provide (struct-out test) test-program test-target test-specification load-tests parse-test)
 
-(struct test (name vars input output expected precondition precision) #:prefab)
+(struct test (name vars input output expected spec precondition precision) #:prefab)
 
 (define (test-program test)
   `(λ ,(test-vars test) ,(test-input test)))
 
 (define (test-target test)
   `(λ ,(test-vars test) ,(test-output test)))
+
+(define (test-specification test)
+  `(λ ,(test-vars test) ,(test-spec test)))
 
 (define (parse-test stx)
   (assert-program! stx)
@@ -37,6 +40,7 @@
         (desugar-program body type-ctx)
         (desugar-program (dict-ref prop-dict ':herbie-target #f) type-ctx)
         (dict-ref prop-dict ':herbie-expected #t)
+        (desugar-program (dict-ref prop-dict ':spec body) type-ctx)
         (desugar-program (dict-ref prop-dict ':pre 'TRUE) type-ctx)
         (dict-ref prop-dict ':precision 'binary64)))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -64,15 +64,18 @@
           (string-join (map ~a unused) ", "))))
 
 ;; Setting up
-(define (setup-prog! prog #:precondition [precondition 'TRUE]
-                     #:precision [precision 'binary64])
+(define (setup-prog! prog
+                     #:precondition [precondition 'TRUE]
+                     #:precision [precision 'binary64]
+                     #:specification [specification #f])
   (*start-prog* prog)
   (rollback-improve!)
   (check-unused-variables (program-variables prog) precondition (program-body prog))
 
   (debug #:from 'progress #:depth 3 "[1/2] Preparing points")
   (timeline-event! 'sample)
-  (define context (prepare-points prog precondition precision))
+  ;; If the specification is given, it is used for sampling points
+  (define context (prepare-points (or specification prog) precondition precision))
   (^precondition^ precondition)
   (^precision^ precision)
   (*pcontext* context)
@@ -336,10 +339,12 @@
 	     (finalize-iter!)))
   (void))
 
-(define (run-improve prog iters #:precondition [precondition 'TRUE]
-                     #:precision [precision 'binary64])
+(define (run-improve prog iters
+                     #:precondition [precondition 'TRUE]
+                     #:precision [precision 'binary64]
+                     #:specification [specification #f])
   (debug #:from 'progress #:depth 1 "[Phase 1 of 3] Setting up.")
-  (setup-prog! prog #:precondition precondition #:precision precision)
+  (setup-prog! prog #:specification specification #:precondition precondition #:precision precision)
   (cond
    [(and (flag-set? 'setup 'early-exit)
          (< (errors-score (errors (*start-prog*) (*pcontext*))) 0.1))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -121,7 +121,7 @@
 (define (make-sampler precondition)
   (define range-table (condition->range-table (program-body precondition)))
   (for ([var (program-variables precondition)]
-        #:unless (range-table-ref range-table var))
+        #:when (null? (range-table-ref range-table var)))
     (raise-herbie-error "No valid values of variable ~a" var
                         #:url "faq.html#no-valid-values"))
   (λ ()

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -186,7 +186,11 @@
   (match expr
     [`(let ([,vars ,vals] ...) ,body)
      (define bindings (map cons vars vals))
-     (unfold-let (replace-vars bindings body))]
+     (replace-vars bindings (unfold-let body))]
+    [`(let* () ,body)
+     (unfold-let body)]
+    [`(let* ([,var ,val] ,rest ...) ,body)
+     (replace-vars (list (cons var val)) (unfold-let `(let* ,rest ,body)))]
     [`(,head ,args ...)
      (cons head (map unfold-let args))]
     [x x]))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -52,7 +52,7 @@
         (timeline-event! 'sample)
         (define newcontext
           (parameterize ([*num-points* (*reeval-pts*)])
-            (prepare-points (test-program test) (test-precondition test) (test-precision test))))
+            (prepare-points (test-specification test) (test-precondition test) (test-precision test))))
         (timeline-event! 'end)
         (define end-err (errors-score (errors (alt-program alt) newcontext)))
 

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -45,6 +45,7 @@
           (run-improve (test-program test)
                        (*num-iterations*)
                        #:precondition (test-precondition test)
+                       #:specification (test-specification test)
                        #:precision (test-precision test)))
         (define context (*pcontext*))
         (when seed (set-seed! seed))
@@ -126,7 +127,7 @@
   (define test (test-result-test result))
   (table-row (test-name test) status (resugar-program (test-precondition test)) (test-precision test)
              (test-vars test) (resugar-program (test-input test)) #f
-             (and (test-output test) (resugar-program (test-output test)))
+             (resugar-program (test-spec test)) (and (test-output test) (resugar-program (test-output test)))
              #f #f #f #f #f #f #f (test-result-time result) (test-result-bits result) link))
 
 (define (get-table-data result link)

--- a/src/type-check.rkt
+++ b/src/type-check.rkt
@@ -112,6 +112,11 @@
        (for/fold ([env2 env]) ([var id] [val expr])
          (dict-set env2 var (expression->type val env error!))))
      (expression->type body env2 error!)]
+    [#`(let* ((,id #,expr) ...) #,body)
+     (define env2
+       (for/fold ([env2 env]) ([var id] [val expr])
+         (dict-set env2 var (expression->type val env2 error!))))
+     (expression->type body env2 error!)]
     [#`(if #,branch #,ifstmt #,elsestmt)
      (define branch-type (expression->type branch env error!))
      (unless (equal? branch-type 'bool)

--- a/src/web/run.rkt
+++ b/src/web/run.rkt
@@ -14,7 +14,9 @@
   (define tests
     (for/list ([row (report-info-tests data)])
       (test (table-row-name row) (table-row-vars row)
-            (table-row-input row) (table-row-output row) #f (table-row-pre row))))
+            (table-row-input row) (table-row-output row)
+            (table-row-target-prog row) (table-row-spec row)
+            (table-row-pre row) (table-row-precision row))))
   (*flags* (report-info-flags data))
   (set-seed! (report-info-seed data))
   (*num-points* (report-info-points data))


### PR DESCRIPTION
Adds support for `:spec` and `let*`.