### PR TITLE
Interface2: Remove Representation Inference

### DIFF
--- a/src/biginterval.rkt
+++ b/src/biginterval.rkt
@@ -526,7 +526,8 @@
     (or (ival-err? ival)
         (if (bigfloat? pt)
             (if (bfnan? pt)
-                (ival-err? ival)
+                (or (ival-err? ival)
+                    (and (bfnan? (ival-lo ival)) (bfnan? (ival-hi ival))))
                 (and (bflte? (ival-lo ival) pt) (bflte? pt (ival-hi ival))))
             (or (equal? pt (ival-lo ival)) (equal? pt (ival-hi ival))))))
 

--- a/src/biginterval.rkt
+++ b/src/biginterval.rkt
@@ -57,9 +57,8 @@
 (define (mk-ival x)
   (match x
     [(? real?)
-     (define err? (or (nan? x) (infinite? x)))
      (define x* (bf x)) ;; TODO: Assuming that float precision < bigfloat precision
-     (ival x* x* err? err?)]
+     (ival x* x* #f #f)]
     [(? boolean?)
      (ival x x #f #f)]))
 

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -11,7 +11,7 @@
          argmins argmaxs setfindf index-of set-disjoint? comparator sample-double
          write-file write-string
          random-exp random-ranges parse-flag get-seed set-seed!
-         common-eval quasisyntax
+         common-eval quasisyntax value->string
          format-time format-bits when-dict in-sorted-dict web-resource
          (all-from-out "config.rkt") (all-from-out "debug.rkt"))
 
@@ -258,6 +258,18 @@
          #`(app syntax-e #,(datum->syntax stx (cons #'list parts))))]
       [(_ a)
        #'(app syntax-e 'a)])))
+
+(define (value->string n repr)
+  ;; Prints a number with relatively few digits
+  (define ->bf (representation-repr->bf repr))
+  (define <-bf (representation-bf->repr repr))
+  ;; Linear search because speed not an issue
+  (let loop ([precision 16])
+    (parameterize ([bf-precision precision])
+  (define bf (->bf n))
+  (if (=-or-nan? n (<-bf bf))
+      (bigfloat->string bf)
+      (loop (+ precision 4)))))) ; 2^4 > 10
 
 ;; String formatting operations
 

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -11,7 +11,7 @@
          argmins argmaxs setfindf index-of set-disjoint? comparator sample-double
          write-file write-string
          random-exp random-ranges parse-flag get-seed set-seed!
-         common-eval quasisyntax value->string
+         common-eval quasisyntax
          format-time format-bits when-dict in-sorted-dict web-resource
          (all-from-out "config.rkt") (all-from-out "debug.rkt"))
 
@@ -258,18 +258,6 @@
          #`(app syntax-e #,(datum->syntax stx (cons #'list parts))))]
       [(_ a)
        #'(app syntax-e 'a)])))
-
-(define (value->string n repr)
-  ;; Prints a number with relatively few digits
-  (define ->bf (representation-repr->bf repr))
-  (define <-bf (representation-bf->repr repr))
-  ;; Linear search because speed not an issue
-  (let loop ([precision 16])
-    (parameterize ([bf-precision precision])
-  (define bf (->bf n))
-  (if (=-or-nan? n (<-bf bf))
-      (bigfloat->string bf)
-      (loop (+ precision 4)))))) ; 2^4 > 10
 
 ;; String formatting operations
 

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -1,8 +1,7 @@
 #lang racket
 
-(require "../common.rkt")
-(require "../alternative.rkt")
-(require "../points.rkt")
+(require "../common.rkt" "../alternative.rkt" "../points.rkt"
+         "../interface.rkt")
 
 (provide
  (contract-out

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -11,11 +11,11 @@
   (atab-not-done-alts (alt-table? . -> . (listof alt?)))
   (atab-add-altns (alt-table? (listof alt?) any/c . -> . alt-table?))
   (atab-pick-alt (alt-table? #:picking-func ((listof alt?) . -> . alt?)
-			     #:only-fresh boolean?
-			     . -> . (values alt? alt-table?)))
+                             #:only-fresh boolean?
+                             . -> . (values alt? alt-table?)))
   (atab-peek-alt (alt-table? #:picking-func ((listof alt?) . -> . alt?)
-			     #:only-fresh boolean?
-			     . -> . (values alt? alt-table?)))
+                             #:only-fresh boolean?
+                             . -> . (values alt? alt-table?)))
   (atab-completed? (alt-table? . -> . boolean?))
   (atab-context (alt-table? . -> . pcontext?))
   (atab-min-errors (alt-table? . -> . (listof real?)))
@@ -32,13 +32,12 @@
 
 (define (make-alt-table context initial-alt prec)
   (alt-table (make-immutable-hash
-	      (for/list ([(pt ex) (in-pcontext context)]
-	 	  [err (errors (alt-program initial-alt) context prec)])
-	  (cons pt (point-rec err (list initial-alt)))))
-	     (hash initial-alt (for/list ([(pt ex) (in-pcontext context)])
-	 		  pt))
-	     (hash initial-alt #f)
-	     context))
+               (for/list ([(pt ex) (in-pcontext context)]
+                          [err (errors (alt-program initial-alt) context prec)])
+                 (cons pt (point-rec err (list initial-alt)))))
+             (hash initial-alt (for/list ([(pt ex) (in-pcontext context)]) pt))
+             (hash initial-alt #f)
+             context))
 
 (define (atab-new-context atab ctx prec)
   (let* ([old-done (alt-table-alt->done? atab)]
@@ -57,16 +56,17 @@
     (atab-add-altn atab altn prec)))
 
 (define (atab-pick-alt atab #:picking-func [pick car]
-		       #:only-fresh [only-fresh? #t])
+           #:only-fresh [only-fresh? #t])
   (let* ([picked (atab-peek-alt atab #:picking-func pick #:only-fresh only-fresh?)]
-	 [atab* (struct-copy alt-table atab [alt->done? (hash-set (alt-table-alt->done? atab) picked #t)])])
+         [atab* (struct-copy alt-table atab
+                             [alt->done? (hash-set (alt-table-alt->done? atab)
+                                                   picked #t)])])
     (values picked atab*)))
 
-(define (atab-peek-alt atab #:picking-func [pick car]
-		       #:only-fresh [only-fresh? #f])
+(define (atab-peek-alt atab #:picking-func [pick car] #:only-fresh [only-fresh? #f])
   (pick (if only-fresh?
-	    (atab-not-done-alts atab)
-	    (atab-all-alts atab))))
+      (atab-not-done-alts atab)
+      (atab-all-alts atab))))
 
 (define (atab-all-alts atab)
   (hash-keys (alt-table-alt->points atab)))
@@ -79,20 +79,20 @@
 (define (split-atab atab preds)
   (for/list ([pred preds])
     (let* ([point->alts (make-immutable-hash (for/list ([(pt ex) (in-atab-pcontext atab)]
-							#:when (pred pt))
-					       (cons pt (hash-ref (alt-table-point->alts atab) pt))))]
-	   [alt->points (make-immutable-hash (filter (compose (negate null?) cdr)
-						     (for/list ([(alt points)
-								 (in-hash (alt-table-alt->points atab))])
-						       (cons alt (filter pred points)))))]
-	   [alt->done? (make-immutable-hash (for/list ([alt (in-hash-keys alt->points)])
-					      (cons alt (hash-ref (alt-table-alt->done? atab) alt))))]
-	   [context (call-with-values
-			(λ () (for/lists (pts exs)
-				  ([(pt ex) (in-atab-pcontext atab)]
-				   #:when (pred pt))
-				(values pt ex)))
-		      mk-pcontext)])
+              #:when (pred pt))
+                 (cons pt (hash-ref (alt-table-point->alts atab) pt))))]
+     [alt->points (make-immutable-hash (filter (compose (negate null?) cdr)
+                 (for/list ([(alt points)
+                 (in-hash (alt-table-alt->points atab))])
+                   (cons alt (filter pred points)))))]
+     [alt->done? (make-immutable-hash (for/list ([alt (in-hash-keys alt->points)])
+                (cons alt (hash-ref (alt-table-alt->done? atab) alt))))]
+     [context (call-with-values
+      (λ () (for/lists (pts exs)
+          ([(pt ex) (in-atab-pcontext atab)]
+           #:when (pred pt))
+        (values pt ex)))
+          mk-pcontext)])
       (minimize-alts (alt-table point->alts alt->points alt->done? context)))))
 
 ;; Helper Functions
@@ -100,8 +100,8 @@
 (define (alternate . lsts)
   (let loop ([rest-lsts lsts] [acc '()])
     (if (ormap null? rest-lsts)
-	(reverse acc)
-	(loop (map cdr rest-lsts) (append (reverse (map car rest-lsts)) acc)))))
+  (reverse acc)
+  (loop (map cdr rest-lsts) (append (reverse (map car rest-lsts)) acc)))))
 
 (define (hash-set-lsts hash keys values)
   (apply hash-set* hash (alternate keys values)))
@@ -128,12 +128,12 @@
 
 (define (remove-chnged-pnts point->alts alt->points chnged-pnts)
   (let* ([chnged-entries (map (curry hash-ref point->alts) chnged-pnts)]
-	 [chnged-altns (remove-duplicates (append-map point-rec-altns chnged-entries))])
+   [chnged-altns (remove-duplicates (append-map point-rec-altns chnged-entries))])
     (hash-set-lsts
      alt->points chnged-altns
      (map (λ (altn)
-	    (remove* chnged-pnts (hash-ref alt->points altn)))
-	  chnged-altns))))
+      (remove* chnged-pnts (hash-ref alt->points altn)))
+    chnged-altns))))
 
 (define (override-at-pnts points->alts pnts altn errs)
   (let ([pnt->alt-err (for/hash ([(pnt ex) (in-pcontext (*pcontext*))] [err errs])
@@ -141,24 +141,24 @@
     (hash-set-lsts
      points->alts pnts
      (map (λ (pnt) (point-rec (hash-ref pnt->alt-err pnt) (list altn)))
-	  pnts))))
+    pnts))))
 
 (define (append-at-pnts points->alts pnts altn)
   (hash-set-lsts
    points->alts pnts
    (map (λ (pnt) (let ([old-val (hash-ref points->alts pnt)])
-		   (point-rec (point-rec-berr old-val)
-			      (cons altn (point-rec-altns old-val)))))
-	pnts)))
+       (point-rec (point-rec-berr old-val)
+            (cons altn (point-rec-altns old-val)))))
+  pnts)))
 
 (define (minimize-alts atab)
   (define (get-essential pnts->alts)
     (remove-duplicates (filter identity
-			       (map (λ (pnt-rec) (let ([altns (point-rec-altns pnt-rec)])
-						   (cond [(> (length altns) 1) #f]
-							 [(= (length altns) 1) (car altns)]
-							 [else (error "This point has no alts which are best at it!" pnt-rec)])))
-				    (hash-values pnts->alts)))))
+             (map (λ (pnt-rec) (let ([altns (point-rec-altns pnt-rec)])
+               (cond [(> (length altns) 1) #f]
+               [(= (length altns) 1) (car altns)]
+               [else (error "This point has no alts which are best at it!" pnt-rec)])))
+            (hash-values pnts->alts)))))
 
   (define (get-tied-alts essential-alts alts->pnts pnts->alts)
     (remove* essential-alts (hash-keys alts->pnts)))
@@ -176,28 +176,28 @@
 
   (let loop ([cur-atab atab])
     (let* ([alts->pnts (alt-table-alt->points cur-atab)]
-	   [pnts->alts (alt-table-point->alts cur-atab)]
-	   [essential-alts (get-essential pnts->alts)]
-	   [tied-alts (get-tied-alts essential-alts alts->pnts pnts->alts)])
+     [pnts->alts (alt-table-point->alts cur-atab)]
+     [essential-alts (get-essential pnts->alts)]
+     [tied-alts (get-tied-alts essential-alts alts->pnts pnts->alts)])
       (if (null? tied-alts) cur-atab
-	  (let ([atab* (rm-alts cur-atab (worst cur-atab tied-alts))])
-	    (loop atab*))))))
+    (let ([atab* (rm-alts cur-atab (worst cur-atab tied-alts))])
+      (loop atab*))))))
 
 (define (rm-alts atab . altns)
   (let* ([rel-points (remove-duplicates
-		      (apply append
-			     (map (curry hash-ref (alt-table-alt->points atab))
-				  altns)))]
-	 [pnts->alts* (let ([pnts->alts (alt-table-point->alts atab)])
-			(hash-set-lsts
-			 pnts->alts rel-points
-			 (map (λ (pnt) (let ([old-val (hash-ref pnts->alts pnt)])
-					 (point-rec (point-rec-berr old-val) (remove* altns (point-rec-altns old-val)))))
-			      rel-points)))]
-	 [alts->pnts* (hash-remove* (alt-table-alt->points atab)
-				    altns)]
-	 [alts->done?* (hash-remove* (alt-table-alt->done? atab)
-				     altns)])
+          (apply append
+           (map (curry hash-ref (alt-table-alt->points atab))
+          altns)))]
+   [pnts->alts* (let ([pnts->alts (alt-table-point->alts atab)])
+      (hash-set-lsts
+       pnts->alts rel-points
+       (map (λ (pnt) (let ([old-val (hash-ref pnts->alts pnt)])
+           (point-rec (point-rec-berr old-val) (remove* altns (point-rec-altns old-val)))))
+            rel-points)))]
+   [alts->pnts* (hash-remove* (alt-table-alt->points atab)
+            altns)]
+   [alts->done?* (hash-remove* (alt-table-alt->done? atab)
+             altns)])
     (alt-table pnts->alts* alts->pnts* alts->done?* (alt-table-context atab))))
 
 (define (atab-add-altn atab altn prec)
@@ -217,7 +217,7 @@
 
 (define (atab-not-done-alts atab)
   (filter (negate (curry hash-ref (alt-table-alt->done? atab)))
-	  (hash-keys (alt-table-alt->points atab))))
+    (hash-keys (alt-table-alt->points atab))))
 
 (define (atab-min-errors atab)
   (for/list ([(pt ex) (in-pcontext (alt-table-context atab))])
@@ -227,8 +227,8 @@
 ;; alt that is best at it.
 (define (check-completeness-invariant atab #:message [message ""])
   (if (andmap (negate (compose null? point-rec-altns
-			       (curry hash-ref (alt-table-point->alts atab))))
-	      (hash-keys (alt-table-point->alts atab)))
+             (curry hash-ref (alt-table-point->alts atab))))
+        (hash-keys (alt-table-point->alts atab)))
       atab
       (error (string-append "Completeness invariant violated. " message))))
 
@@ -237,15 +237,15 @@
 ;; it maps to, those alternatives also map back to the point.
 (define (check-reflexive-invariant atab #:message [message ""])
   (if (and (andmap (λ (altn)
-		     (andmap (λ (pnt)
-			       (member altn (point-rec-altns (hash-ref (alt-table-point->alts atab) pnt))))
-			     (hash-ref (alt-table-alt->points atab) altn)))
-		   (hash-keys (alt-table-alt->done? atab)))
-	   (andmap (λ (pnt)
-		     (andmap (λ (altn)
-			       (member pnt (hash-ref (alt-table-alt->points atab) altn)))
-			     (point-rec-altns (hash-ref (alt-table-point->alts atab) pnt))))
-		   (hash-keys (alt-table-point->alts atab))))
+         (andmap (λ (pnt)
+             (member altn (point-rec-altns (hash-ref (alt-table-point->alts atab) pnt))))
+           (hash-ref (alt-table-alt->points atab) altn)))
+       (hash-keys (alt-table-alt->done? atab)))
+     (andmap (λ (pnt)
+         (andmap (λ (altn)
+             (member pnt (hash-ref (alt-table-alt->points atab) altn)))
+           (point-rec-altns (hash-ref (alt-table-point->alts atab) pnt))))
+       (hash-keys (alt-table-point->alts atab))))
       atab
       (error (string-append "Reflexive invariant violated. " message))))
 
@@ -261,10 +261,10 @@
 
 (define (assert-points-orphaned alts->pnts opnts all-pnts #:message [msg ""])
   (hash-for-each alts->pnts
-		 (λ (altn pnts)
-		   (when (ormap (curryr member pnts) opnts)
-		     (error (string-append "Assert Failed: The given points were not orphaned. " msg)))))
+     (λ (altn pnts)
+       (when (ormap (curryr member pnts) opnts)
+         (error (string-append "Assert Failed: The given points were not orphaned. " msg)))))
   (let ([hopefully-unorphaned-points (remove* opnts all-pnts)]
-	[actually-unorphaned-points (remove-duplicates (apply append (hash-values alts->pnts)))])
+  [actually-unorphaned-points (remove-duplicates (apply append (hash-values alts->pnts)))])
     (when (ormap (negate (curryr member actually-unorphaned-points)) hopefully-unorphaned-points)
       (error (string-append "Assert Failed: Points other than the given points were orphaned. " msg)))))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -30,9 +30,10 @@
 (define in-atab-pcontext (compose in-pcontext atab-context))
 
 (define (make-alt-table context initial-alt prec)
+  (define repr (get-representation prec))
   (alt-table (make-immutable-hash
                (for/list ([(pt ex) (in-pcontext context)]
-                          [err (errors (alt-program initial-alt) context prec)])
+                          [err (errors (alt-program initial-alt) context repr)])
                  (cons pt (point-rec err (list initial-alt)))))
              (hash initial-alt (for/list ([(pt ex) (in-pcontext context)]) pt))
              (hash initial-alt #f)
@@ -200,7 +201,8 @@
     (alt-table pnts->alts* alts->pnts* alts->done?* (alt-table-context atab))))
 
 (define (atab-add-altn atab altn prec)
-  (define errs (errors (alt-program altn) (alt-table-context atab) prec))
+  (define repr (get-representation prec))
+  (define errs (errors (alt-program altn) (alt-table-context atab) repr))
   (match-define (alt-table point->alts alt->points _ _) atab)
   (define-values (best-pnts tied-pnts) (best-and-tied-at-points atab altn errs))
   (cond

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -29,6 +29,8 @@
                          (->bf expr (infer-representation expr))))
                    (cons (repeat bf) (repeat 1))]
                   [(? variable?)
+                   ;; TODO(interface): when the syntax checker is udpated,
+                   ;; use *var-precs* to get the representation
                    (cons (map (curryr ->bf (get-representation 'binary64))
                               (dict-ref vars expr))
                          (repeat 1))]

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -16,7 +16,7 @@
 (define (localize-on-expression expr vars cache repr)
   (define ctx
     (for/hash ([(var vals) (in-dict vars)])
-      (values var (match (representation-name (infer-representation (first vals)))
+      (values var (match (representation-name repr)
                     [(or 'binary32 'binary64) 'real]
                     [x x]))))
   (hash-ref! cache expr
@@ -26,7 +26,7 @@
                    (define bf
                      (if (symbol? expr)
                          ((constant-info expr 'bf))
-                         (->bf expr (infer-representation expr))))
+                         (->bf expr repr)))
                    (cons (repeat bf) (repeat 1))]
                   [(? variable?)
                    ;; TODO(interface): when the syntax checker is udpated,

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -55,9 +55,8 @@
 
                    (define exact (map (curry apply (operator-info f 'bf)) argexacts))
                    (define approx (map (curry apply (operator-info f 'fl)) argapprox))
-                   (cons exact (map (λ (ex ap)
-                                       (define repr (infer-double-representation (<-bf ex) ap))
-                                       (+ 1 (abs (ulp-difference (<-bf ex) ap repr)))) exact approx))]))))
+                   (cons exact (map (λ (ex ap) (+ 1 (abs (ulp-difference (<-bf ex) ap repr))))
+                                    exact approx))]))))
 
 (register-reset
  (λ ()

--- a/src/core/periodicity.rkt
+++ b/src/core/periodicity.rkt
@@ -17,13 +17,8 @@
 ; bubbled up the expression tree.
 
 (require racket/match)
-(require "../common.rkt")
-(require "../programs.rkt")
-(require "../alternative.rkt")
-(require "../points.rkt")
-(require "../syntax/rules.rkt")
-(require "../float.rkt")
-(require "matcher.rkt")
+(require "../common.rkt" "../programs.rkt" "../alternative.rkt" "../points.rkt"
+         "../syntax/rules.rkt" "../float.rkt" "matcher.rkt" "../interface.rkt")
 
 (struct annotation (expr loc type coeffs) #:transparent)
 (struct lp (loc periods) #:prefab)

--- a/src/core/periodicity.rkt
+++ b/src/core/periodicity.rkt
@@ -96,7 +96,7 @@
       [(list (or 'lambda 'λ) (list vars ...) body)
        `(λ ,vars ,(loop body (cons 2 loc)))]
       [(? constant? c)
-       (define repr (infer-representation c))
+       (define repr (get-representation (*output-prec*)))
        ;; TODO : Do something more intelligent with 'PI
        (let ([val (if (rational? c) c (->flonum c repr))])
          (annotation val (reverse loc) 'constant val))]

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -322,11 +322,10 @@
   ;; Extract the splitpoints from our data structure, and reverse it.
   (reverse (cse-indices (last final))))
 
-(define (splitpoints->point-preds splitpoints alts precision)
+(define (splitpoints->point-preds splitpoints alts repr)
   (assert (= (set-count (list->set (map sp-bexpr splitpoints))) 1))
   (assert (nan? (sp-point (last splitpoints))))
 
-  (define repr (get-representation precision))
   (define vars (program-variables (alt-program (first alts))))
   (define expr `(λ ,vars ,(sp-bexpr (car splitpoints))))
   (define prog (eval-prog expr 'fl repr))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -135,7 +135,7 @@
                                (define repr (infer-double-representation prev val))
                                (<-all-precisions prev val repr))))
   (define err-lsts
-    (for/list ([alt alts]) (errors (alt-program alt) pcontext* (*output-prec*))))
+    (for/list ([alt alts]) (errors (alt-program alt) pcontext* (representation-name repr))))
   (define bit-err-lsts (map (curry map ulps->bits) err-lsts))
   (define split-indices (err-lsts->split-indices bit-err-lsts can-split?))
   (for ([pidx (map si-pidx (drop-right split-indices 1))])

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -334,10 +334,8 @@
     (λ (pt)
       (define val (prog pt))
       (for/first ([right splitpoints]
-                  #:when (or (nan?-all-types (sp-point right)
-                                             (infer-representation (sp-point right)))
-                             (<=/total val (sp-point right)
-                                       (infer-double-representation val (sp-point right)))))
+                  #:when (or (nan?-all-types (sp-point right) repr)
+                             (<=/total val (sp-point right) repr)))
         ;; Note that the last splitpoint has an sp-point of +nan.0, so we always find one
         (equal? (sp-cidx right) i)))))
 

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -135,7 +135,7 @@
                                (define repr (infer-double-representation prev val))
                                (<-all-precisions prev val repr))))
   (define err-lsts
-    (for/list ([alt alts]) (errors (alt-program alt) pcontext* (representation-name repr))))
+    (for/list ([alt alts]) (errors (alt-program alt) pcontext* repr)))
   (define bit-err-lsts (map (curry map ulps->bits) err-lsts))
   (define split-indices (err-lsts->split-indices bit-err-lsts can-split?))
   (for ([pidx (map si-pidx (drop-right split-indices 1))])
@@ -210,8 +210,8 @@
         (parameterize ([*num-points* (*binary-search-test-points*)]
                        [*timeline-disabled* true])
           (prepare-points start-prog `(== ,(caadr start-prog) ,v) precision)))
-      (< (errors-score (errors prog1 ctx (*output-prec*)))
-         (errors-score (errors prog2 ctx (*output-prec*)))))
+      (< (errors-score (errors prog1 ctx repr))
+         (errors-score (errors prog2 ctx repr))))
     (define pt (binary-search-floats pred v1 v2))
     (timeline-push! 'bstep v1 v2 iters pt)
     pt)

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -7,25 +7,9 @@
 (provide midpoint ulp-difference *bit-width* ulps->bits bit-difference
          </total <=/total =-or-nan? nan?-all-types ordinary-value?
          exact-value? val-to-type flval
-         infer-representation infer-double-representation
          ->flonum ->bf random-generate fl->repr repr->fl value->string
          <-all-precisions mk-<= special-value?
          get-representation*)
-
-(define (infer-representation x)
-  (get-representation
-   (for/first ([(type rec) (in-hash type-dict)] #:when ((car rec) x))
-     (if (equal? type 'real)
-         (if (flag-set? 'precision 'double) 'binary64 'binary32)
-         type))))
-
-(define (infer-double-representation x y)
-  (define repr1 (infer-representation x))
-  (define repr2 (infer-representation y))
-  (unless (equal? repr1 repr2)
-    (error 'infer-representation "Different representations: ~a for ~a and ~a for ~a"
-           repr1 x repr2 y))
-  repr1)
 
 (define (get-representation* x)
   (match x

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -8,7 +8,7 @@
          </total <=/total =-or-nan? nan?-all-types ordinary-value?
          exact-value? val-to-type flval
          infer-representation infer-double-representation
-         ->flonum ->bf random-generate fl->repr repr->fl
+         ->flonum ->bf random-generate fl->repr repr->fl value->string
          <-all-precisions mk-<= special-value?
          get-representation*)
 
@@ -147,6 +147,18 @@
 
 (define (repr->fl x repr)
   (bigfloat->flonum ((representation-repr->bf repr) x)))
+
+(define (value->string n repr)
+  ;; Prints a number with relatively few digits
+  (define ->bf (representation-repr->bf repr))
+  (define <-bf (representation-bf->repr repr))
+  ;; Linear search because speed not an issue
+  (let loop ([precision 16])
+    (parameterize ([bf-precision precision])
+  (define bf (->bf n))
+  (if (=-or-nan? n (<-bf bf))
+      (bigfloat->string bf)
+      (loop (+ precision 4)))))) ; 2^4 > 10
 
 (define/contract (->bf x repr)
   (-> any/c representation? bigvalue?)

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -124,7 +124,12 @@
    [(and (symbol? x) (constant? x))
     (->flonum ((constant-info x 'fl)) repr)]
    [else
-    (if (and (real? x) (exact? x)) (exact->inexact x) x)]))
+    ;; TODO(interface): Once we have complex numbers as types rather than
+    ;; reprs, we don't have to do this additional check abd we can just use
+    ;; repr->bf for everything.
+    (if (eq? (representation-name repr) 'complex)
+      (bigfloat->flonum x)
+      (if (and (real? x) (exact? x)) (exact->inexact x) x))]))
 
 (define (fl->repr x repr)
   ((representation-exact->repr repr) x))
@@ -151,7 +156,12 @@
    [(and (complex? x) (not (real? x)))
     (bigcomplex (bf (real-part x)) (bf (imag-part x)))]
    [else
-    ((representation-repr->bf repr) x)]))
+    ;; TODO(interface): Once we have complex numbers as types rather than
+    ;; reprs, we don't have to do this additional check abd we can just use
+    ;; repr->bf for everything.
+    (if (eq? (representation-name repr) 'complex)
+      (bf x)
+      ((representation-repr->bf repr) x))]))
 
 (define (<-all-precisions x1 x2 repr)
   (cond

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -22,6 +22,9 @@
   (assert-program! stx)
   (assert-program-type! stx)
   (match-define (list 'FPCore (list args ...) props ... body) (syntax->datum stx))
+  ;; TODO(interface): Currently, this code doesn't fire because annotations aren't
+  ;; allowed for variables because of the syntax checker yet. This should run correctly
+  ;; once the syntax checker is updated to the FPBench 1.1 standard.
   (define arg-names (for/list ([arg args])
                       (if (list? arg)
                         (last arg)

--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -53,11 +53,11 @@
 
   (test (~a (dict-ref prop-dict ':name body))
         arg-names
-        (desugar-program body type-ctx)
-        (desugar-program (dict-ref prop-dict ':herbie-target #f) type-ctx)
+        (desugar-program body default-prec var-precs)
+        (desugar-program (dict-ref prop-dict ':herbie-target #f) default-prec var-precs)
         (dict-ref prop-dict ':herbie-expected #t)
-        (desugar-program (dict-ref prop-dict ':spec body) type-ctx)
-        (desugar-program (dict-ref prop-dict ':pre 'TRUE) type-ctx)
+        (desugar-program (dict-ref prop-dict ':spec body) default-prec var-precs)
+        (desugar-program (dict-ref prop-dict ':pre 'TRUE) default-prec var-precs)
         default-prec
         var-precs))
 

--- a/src/formats/tex.rkt
+++ b/src/formats/tex.rkt
@@ -98,7 +98,9 @@
                  (if (or (< (imag-part expr) 0) (equal? (imag-part expr) -0.0)) '- '+)
                  (texify (abs (imag-part expr)) '+ loc))]
         [(? value?)
-         (match (string-split (texify-number expr) "e")
+         (define repr (get-representation prec))
+         (define s (bigfloat->string ((representation-repr->bf repr) expr)))
+         (match (string-split s "e")
            [(list "-inf.bf") "-\\infty"]
            [(list "+inf.bf") "+\\infty"]
            [(list num) num]

--- a/src/formats/tex.rkt
+++ b/src/formats/tex.rkt
@@ -30,19 +30,6 @@
   [('lambda2) "\\lambda_2"]
   [(_) (symbol->string var)])
 
-(define (texify-number n)
-  ;; Prints a number with relatively few digits
-  (define repr (infer-representation n))
-  (define ->bf (representation-repr->bf repr))
-  (define <-bf (representation-bf->repr repr))
-  ;; Linear search because speed not an issue
-  (let loop ([precision 16])
-    (parameterize ([bf-precision precision])
-      (define bf (->bf n))
-      (if (=-or-nan? n (<-bf bf))
-          (bigfloat->string bf)
-          (loop (+ precision 4)))))) ; 2^4 > 10
-
 ; self-paren-level : #t --> paren me
 ;                    #f --> do not paren me
 ;

--- a/src/formats/tex.rkt
+++ b/src/formats/tex.rkt
@@ -77,10 +77,10 @@
     [else
      (list (list #t expr loc))]))
 
-(define (texify-prog expr #:loc [color-loc #f] #:color [color "red"])
-  (texify-expr (program-body expr) #:loc color-loc #:color color))
+(define (texify-prog expr prec #:loc [color-loc #f] #:color [color "red"])
+  (texify-expr (program-body expr) prec #:loc color-loc #:color color))
 
-(define (texify-expr expr #:loc [color-loc #f] #:color [color "red"])
+(define (texify-expr expr prec #:loc [color-loc #f] #:color [color "red"])
   "Compile an expression to math mode TeX."
   (let texify ([expr expr] [parens #t] [loc '(2)])
     (format

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -72,5 +72,9 @@
   (λ (x) (make-rectangular (ordinal->flonum (quotient x (expt 2 64))) (ordinal->flonum (modulo x (expt 2 64)))))
   (λ (x) (+ (* (expt 2 64) (flonum->ordinal (real-part x))) (flonum->ordinal (imag-part x))))
   128
+  ;; TODO(interface): note that these values for special-values are incorrect;
+  ;; any value that includes +nan.0 should be a special value, but because
+  ;; types and representations are not cleanly separated, this is not reasonable to
+  ;; express. Once types and representations are separated, fix this.
   '(+nan.0 +inf.0)
   real->double-flonum)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -69,6 +69,7 @@
                      #:precision [precision 'binary64]
                      #:specification [specification #f])
   (*output-prec* precision)
+  ;; TODO(interface): when the syntax checker is udpated, set *var-precs* too
   (*start-prog* prog)
   (rollback-improve!)
   (check-unused-variables (program-variables prog) precondition (program-body prog))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -110,12 +110,12 @@
 
 (define (best-alt alts prec)
   (define repr (get-representation prec))
-  (argmins (λ (alt) (errors-score (errors (alt-program alt) (*pcontext*) repr)))
+  (argmin (λ (alt) (errors-score (errors (alt-program alt) (*pcontext*) repr)))
 		   alts))
 
 (define (choose-best-alt!)
   (let-values ([(picked table*) (atab-pick-alt (^table^)
-                                  #:picking-func (λ (x) (best-alt x (*output-prec*)))
+                                  #:picking-func (curryr best-alt (*output-prec*))
                                   #:only-fresh #t)])
     (^next-alt^ picked)
     (^table^ table*)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -1,9 +1,9 @@
 #lang racket
 
-(require "common.rkt" "programs.rkt" "points.rkt" "alternative.rkt" "errors.rkt" "timeline.rkt")
-(require "core/localize.rkt" "core/taylor.rkt" "core/alt-table.rkt" "core/simplify.rkt"
-         "core/matcher.rkt" "core/regimes.rkt")
-(require "type-check.rkt") ;; For taylor not running on complex exprs
+(require "common.rkt" "programs.rkt" "points.rkt" "alternative.rkt" "errors.rkt"
+         "timeline.rkt" "core/localize.rkt" "core/taylor.rkt" "core/alt-table.rkt"
+         "core/simplify.rkt" "core/matcher.rkt" "core/regimes.rkt" "interface.rkt"
+         "type-check.rkt") ;; For taylor not running on complex exprs
 
 (provide (all-defined-out))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -109,7 +109,8 @@
 	(void))))
 
 (define (best-alt alts prec)
-  (argmin (λ (alt) (errors-score (errors (alt-program alt) (*pcontext*) prec)))
+  (define repr (get-representation prec))
+  (argmins (λ (alt) (errors-score (errors (alt-program alt) (*pcontext*) repr)))
 		   alts))
 
 (define (choose-best-alt!)
@@ -346,10 +347,11 @@
                      #:precision [precision 'binary64]
                      #:specification [specification #f])
   (debug #:from 'progress #:depth 1 "[Phase 1 of 3] Setting up.")
+  (define repr (get-representation precision))
   (setup-prog! prog #:specification specification #:precondition precondition #:precision precision)
   (cond
    [(and (flag-set? 'setup 'early-exit)
-         (< (errors-score (errors (*start-prog*) (*pcontext*) precision))
+         (< (errors-score (errors (*start-prog*) (*pcontext*) repr))
             0.1))
     (debug #:from 'progress #:depth 1 "Initial program already accurate, stopping.")
     (make-alt (*start-prog*))]

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -129,7 +129,7 @@
       (define ex
         (and pre (ival-eval body-fn pt precision #:log (point-logger 'body log prog))))
 
-      (define repr (infer-representation (car pt)))
+      (define repr precision)
       (cond
        [(and (andmap (curryr ordinary-value? repr) pt) pre (ordinary-value? ex repr))
         (if (>= sampled (- (*num-points*) 1))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -181,14 +181,12 @@
   (for/list ([(point exact) (in-pcontext pcontext)])
     (point-error (eval-fn point) exact repr)))
 
-(define (oracle-error-idx alt-bodies points exacts)
+(define (oracle-error-idx alt-bodies points exacts repr)
   (for/list ([point points] [exact exacts])
-    (define repr (infer-double-representation ((list-ref alt-bodies i) point) exact))
     (list point (argmin (λ (i) (point-error ((list-ref alt-bodies i) point) exact repr)) (range (length alt-bodies))))))
 
-(define (oracle-error alt-bodies pcontext)
+(define (oracle-error alt-bodies pcontext repr)
   (for/list ([(point exact) (in-pcontext pcontext)])
-    (define repr (infer-double-representation (alt point) exact))
     (argmin identity (map (λ (alt) (point-error (alt point) exact repr)) alt-bodies))))
 
 (define (baseline-error alt-bodies pcontext newpcontext repr)

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -203,8 +203,7 @@
            (length e))
         (apply max (map ulps->bits reals)))))
 
-(define (errors prog pcontext prec)
-  (define repr (get-representation prec))
+(define (errors prog pcontext repr)
   (define fn (eval-prog prog 'fl repr))
   (for/list ([(point exact) (in-pcontext pcontext)])
     (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" prog point) (raise e))])

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -272,10 +272,6 @@
      (and (andmap identity pts) pts)]
     [_ #f]))
 
-(define (filter-valid-points prog precondition points)
-  (define f (eval-prog (list 'λ (program-variables prog) precondition) 'fl))
-  (filter f points))
-
 ;; This is the obsolete version for the "halfpoint" method
 (define (prepare-points-halfpoints prog precondition precision)
   (timeline-log! 'method 'halfpoints)

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -176,10 +176,9 @@
       (+ 1 (abs (ulp-difference out exact repr)))
       (+ 1 (expt 2 (*bit-width*)))))
 
-(define (eval-errors eval-fn pcontext)
+(define (eval-errors eval-fn pcontext repr)
   (define max-ulps (expt 2 (*bit-width*)))
   (for/list ([(point exact) (in-pcontext pcontext)])
-    (define repr (infer-double-representation (eval-fn point) exact))
     (point-error (eval-fn point) exact repr)))
 
 (define (oracle-error-idx alt-bodies points exacts)
@@ -192,9 +191,9 @@
     (define repr (infer-double-representation (alt point) exact))
     (argmin identity (map (λ (alt) (point-error (alt point) exact repr)) alt-bodies))))
 
-(define (baseline-error alt-bodies pcontext newpcontext)
-  (define baseline (argmin (λ (alt) (errors-score (eval-errors alt pcontext))) alt-bodies))
-  (eval-errors baseline newpcontext))
+(define (baseline-error alt-bodies pcontext newpcontext repr)
+  (define baseline (argmin (λ (alt) (errors-score (eval-errors alt pcontext repr))) alt-bodies))
+  (eval-errors baseline newpcontext repr))
 
 (define (errors-score e)
   (define repr (get-representation 'binary64))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -86,12 +86,7 @@
             (cond
              [err
               (log! 'nan precision pt)
-              ;; TODO(interface): Right now we have this weird check because we are
-              ;; are mixing up types and representations. Once we have a clean
-              ;; distinction, this check should be propagated out.
-              (if (and (eq? prec 'bool) (eq? lo hi))
-                lo
-                +nan.0)]
+              +nan.0]
              [(and (not err?) (or (equal? lo* hi*)
                                   (and (equal? lo* -0.0) (equal? hi* +0.0))
                                   (and (equal? lo* -0.0f0) (equal? hi* +0.0f0))))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -86,7 +86,12 @@
             (cond
              [err
               (log! 'nan precision pt)
-              +nan.0]
+              ;; TODO(interface): Right now we have this weird check because we are
+              ;; are mixing up types and representations. Once we have a clean
+              ;; distinction, this check should be propagated out.
+              (if (and (eq? prec 'bool) (eq? lo hi))
+                lo
+                +nan.0)]
              [(and (not err?) (or (equal? lo* hi*)
                                   (and (equal? lo* -0.0) (equal? hi* +0.0))
                                   (and (equal? lo* -0.0f0) (equal? hi* +0.0f0))))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -1,8 +1,8 @@
 #lang racket
 
 (require math/bigfloat math/flonum)
-(require "common.rkt" "syntax/types.rkt" "syntax/syntax.rkt" "plugin.rkt")
-(require "errors.rkt" "type-check.rkt" "biginterval.rkt" "float.rkt" "interface.rkt")
+(require "common.rkt" "syntax/types.rkt" "syntax/syntax.rkt" "plugin.rkt"
+         "errors.rkt" "type-check.rkt" "biginterval.rkt" "float.rkt" "interface.rkt")
 
 (module+ test (require rackunit))
 
@@ -90,14 +90,8 @@
   ;; and representations are cleanly distinguished, we can get rid of the
   ;; additional check to see if the repr is complex.
   (define real->precision (match mode
-    ['bf
-     (if (eq? (representation-name repr) 'complex)
-       bf
-       (λ (x) (->bf x repr)))]
-    ['fl
-     (if (eq? (representation-name repr) 'complex)
-       identity
-       (λ (x) (->flonum x repr)))]
+    ['bf (curryr ->bf repr)]
+    ['fl (curryr ->flonum repr)]
     ['ival mk-ival]
     ['nonffi identity]))
   (define precision->real (match mode

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -219,7 +219,14 @@
          (define sigs (hash-ref parametric-operators op))
          (define-values (args* actual-types)
            (for/lists (args* actual-types) ([arg args])
-             (loop arg)))
+             ;; TODO(interface): Right now we check if the actual-type is binary64
+             ;; or binary32 because we don't have a distinction between them (both
+             ;; are included in real). Once the operator code is fixed, this check
+             ;; can be removed.
+             (define-values (arg* actual-type) (loop arg))
+             (if (set-member? '(binary64 binary32) actual-type)
+               (values arg* 'real)
+               (values arg* actual-type))))
          (match-define (cons op* rtype)
            (for/or ([sig sigs])
              (match-define (list* true-name rtype atypes) sig)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -83,15 +83,15 @@
 (define (eval-prog prog mode)
   ; Keep exact numbers exact
   (define real->precision (match mode
-                            ['bf (λ (x) (->bf x (infer-representation x)))]
-                            ['fl (λ (x) (->flonum x (infer-representation x)))]
-                            ['ival mk-ival]
-                            ['nonffi identity]))
+    ['bf (λ (x) (->bf x (get-representation (*output-precision*))))]
+    ['fl (λ (x) (->flonum x (get-representation (*output-precision*))))]
+    ['ival mk-ival]
+    ['nonffi identity]))
   (define precision->real (match mode
-                            ['bf identity]
-                            ['fl (λ (x) (->flonum x (infer-representation x)))]
-                            ['ival identity]
-                            ['nonffi identity]))
+    ['bf identity]
+    ['fl (λ (x) (->flonum x (get-representation (*output-precision*))))]
+    ['ival identity]
+    ['nonffi identity]))
 
   (define body*
     (let inductor ([prog (program-body prog)])

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -82,9 +82,22 @@
 
 (define (eval-prog prog mode repr)
   ; Keep exact numbers exact
+  ;; TODO(interface): Right now, real->precision and precision->real are
+  ;; mixed up for bf and fl because there is a mismatch between the fpbench
+  ;; input format for how we specify complex numbers (which is the format
+  ;; the interface will ultimately use), and the 1.3 herbie input format
+  ;; (which has no way of specifying complex numbers as input.) Once types
+  ;; and representations are cleanly distinguished, we can get rid of the
+  ;; additional check to see if the repr is complex.
   (define real->precision (match mode
-    ['bf (λ (x) (->bf x repr))]
-    ['fl (λ (x) (->flonum x repr))]
+    ['bf
+     (if (eq? (representation-name repr) 'complex)
+       bf
+       (λ (x) (->bf x repr)))]
+    ['fl
+     (if (eq? (representation-name repr) 'complex)
+       identity
+       (λ (x) (->flonum x repr)))]
     ['ival mk-ival]
     ['nonffi identity]))
   (define precision->real (match mode

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -83,13 +83,13 @@
 (define (eval-prog prog mode)
   ; Keep exact numbers exact
   (define real->precision (match mode
-    ['bf (λ (x) (->bf x (get-representation (*output-precision*))))]
-    ['fl (λ (x) (->flonum x (get-representation (*output-precision*))))]
+    ['bf (λ (x) (->bf x (get-representation (*output-prec*))))]
+    ['fl (λ (x) (->flonum x (get-representation (*output-prec*))))]
     ['ival mk-ival]
     ['nonffi identity]))
   (define precision->real (match mode
     ['bf identity]
-    ['fl (λ (x) (->flonum x (get-representation (*output-precision*))))]
+    ['fl (λ (x) (->flonum x (get-representation (*output-prec*))))]
     ['ival identity]
     ['nonffi identity]))
 
@@ -211,7 +211,6 @@
 ;; TODO(interface): This needs to be changed once the syntax checker is updated
 ;; and supports multiple precisions
 (define (expand-parametric expr prec var-precs)
-  (define precision (if (and (list? ctx) (not (empty? ctx))) (cdr (first ctx)) 'real))
   (define-values (expr* type)
     (let loop ([expr expr])
       ;; Run after unfold-let, so no need to track lets
@@ -243,14 +242,14 @@
          (values (cons op args*)
                  (second (first (first(hash-values (operator-info op 'type))))))]
         [(? real?) (values
-                     (fl->repr expr (get-representation (match precision
+                     (fl->repr expr (get-representation (match prec
                         ['real (if (flag-set? 'precision 'double) 'binary64 'binary32)]
                         [x x])))
-                     precision)]
+                     prec)]
         [(? complex?) (values expr 'complex)]
         [(? value?) (values expr prec)]
         [(? constant?) (values expr (constant-info expr 'type))]
-        [(? variable?) (values expr (dict-ref ctx expr))])))
+        [(? variable?) (values expr (dict-ref var-precs expr))])))
   expr*)
 
 ;; TODO(interface): This needs to be changed once the syntax checker is updated

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -53,7 +53,6 @@
         (timeline-event! 'sample)
         (define newcontext
           (parameterize ([*num-points* (*reeval-pts*)])
-            (prepare-points (test-specification test) (test-precondition test) (test-output-prec test))))
             (prepare-points (test-specification test) (test-precondition test) output-prec)))
         (timeline-event! 'end)
         (define end-err (errors-score (errors (alt-program alt) newcontext output-repr)))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -60,7 +60,7 @@
 
         (define all-alts (remove-duplicates (*all-alts*)))
         (define baseline-errs
-          (baseline-error (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr)) all-alts) context newcontext))
+          (baseline-error (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr)) all-alts) context newcontext output-repr))
         (define oracle-errs
           (oracle-error (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr)) all-alts) newcontext))
 

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -62,7 +62,7 @@
         (define baseline-errs
           (baseline-error (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr)) all-alts) context newcontext output-repr))
         (define oracle-errs
-          (oracle-error (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr)) all-alts) newcontext))
+          (oracle-error (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr)) all-alts) newcontext output-repr))
 
         (debug #:from 'regime-testing #:depth 1
                "Baseline error score:" (errors-score baseline-errs))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -77,7 +77,7 @@
   (define point-sequence (in-producer make-point))
   (define points (for/list ([n (in-range num-test-points)] [pt point-sequence]) pt))
   (define prog1 (eval-prog `(λ ,fv ,p1) 'fl (get-representation 'binary64)))
-  (define prog2 (eval-prog `(λ ,fv, p2) 'fl (get-representation 'binary64)))
+  (define prog2 (eval-prog `(λ ,fv ,p2) 'fl (get-representation 'binary64)))
   (define ex1 (map prog1 points))
   (define ex2 (map prog2 points))
   (for ([pt points] [v1 ex1] [v2 ex2])

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -57,9 +57,8 @@
   (define ex2 (map prog2 points))
   (define errs
     (for/list ([pt points] [v1 ex1] [v2 ex2]
-               #:when (and (ordinary-value? v1 (infer-representation v1))
-                           (ordinary-value? v2 (infer-representation v2))))
-      (define repr (infer-double-representation v1 v2))
+               #:when (and (ordinary-value? v1 repr)
+                           (ordinary-value? v2 repr)))
       (with-check-info (['point (map cons fv pt)] ['method (object-name ground-truth)]
                         ['input v1] ['output v2])
         (check-eq? (ulp-difference v1 v2 repr) 0))))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -3,7 +3,7 @@
 (require rackunit math/bigfloat)
 (require "../common.rkt" "../programs.rkt" (submod "../points.rkt" internals))
 (require "rules.rkt" (submod "rules.rkt" internals) "../interface.rkt")
-(require "../programs.rkt" "../float.rkt" "../bigcomplex.rkt" "../type-check.rkt")
+(require "../programs.rkt" "../float.rkt")
 
 (define num-test-points 1000)
 

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -57,6 +57,7 @@
   (define ex2 (map prog2 points))
   (define errs
     (for/list ([pt points] [v1 ex1] [v2 ex2]
+               #:unless (or (eq? v1 +nan.0) (eq? v2 +nan.0))
                #:when (and (ordinary-value? v1 repr)
                            (ordinary-value? v2 repr)))
       (with-check-info (['point (map cons fv pt)] ['method (object-name ground-truth)]

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -25,13 +25,13 @@
     [atan-tan-s . (<= (fabs x) ,(/ pi 2))]))
 
 (define (ival-ground-truth fv p repr)
-  (λ (x) (ival-eval (eval-prog `(λ ,fv ,p) 'ival) x (representation-name repr))))
+  (λ (x) (ival-eval (eval-prog `(λ ,fv ,p) 'ival repr) x (representation-name repr))))
 
 (define ((with-hiprec f) x)
   (parameterize ([bf-precision 2000]) (f x)))
 
 (define (bf-ground-truth fv p repr)
-  (with-hiprec (compose (representation-bf->repr repr) (eval-prog `(λ ,fv ,p) 'bf))))
+  (with-hiprec (compose (representation-bf->repr repr) (eval-prog `(λ ,fv ,p) 'bf repr))))
 
 (define (check-rule-correct test-rule ground-truth)
   (match-define (rule name p1 p2 itypes otype) test-rule)
@@ -77,8 +77,8 @@
         ['complex (make-rectangular (sample-double) (sample-double))])))
   (define point-sequence (in-producer make-point))
   (define points (for/list ([n (in-range num-test-points)] [pt point-sequence]) pt))
-  (define prog1 (eval-prog `(λ ,fv ,p1) 'fl))
-  (define prog2 (eval-prog `(λ ,fv, p2) 'fl))
+  (define prog1 (eval-prog `(λ ,fv ,p1) 'fl (get-representation 'binary64)))
+  (define prog2 (eval-prog `(λ ,fv, p2) 'fl (get-representation 'binary64)))
   (define ex1 (map prog1 points))
   (define ex2 (map prog2 points))
   (for ([pt points] [v1 ex1] [v2 ex2])

--- a/src/type-check.rkt
+++ b/src/type-check.rkt
@@ -36,7 +36,9 @@
   (match expr
     [(? real?) 'real]
     [(? complex?) 'complex]
-    [(? value?) (match (representation-name (infer-representation expr)) [(or 'binary32 'binary64) 'real] [x x])]
+    ;; TODO(interface): Once we update the syntax checker to FPCore 1.1
+    ;; standards, this will have to have more information passed in
+    [(? value?) (*output-prec*)]
     [(? constant?) (constant-info expr 'type)]
     [(? variable?) (dict-ref env expr)]
     [(list 'if cond ift iff)

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -35,8 +35,9 @@
                          ,@values)))
 
 (define languages
-  `(("TeX" . ,(curryr texify-prog (*output-prec*)))
-    ("C" . ,program->c)))
+  `(("TeX" . ,texify-prog)
+    ;; TODO(interface): currently program->c doesn't take the repr into account
+    ("C" . ,(λ (prog repr) (program->c prog)))))
 
 (define (render-program #:to [result #f] test)
   (define output-prec (test-output-prec test))
@@ -62,8 +63,8 @@
              `()))
      ,@(for/list ([(lang fn) (in-dict languages)])
          `(div ([class "implementation"] [data-language ,lang])
-            (pre ([class "program"]) ,(fn (test-program test)))
+            (pre ([class "program"]) ,(fn (test-program test) output-prec))
             ,@(if result
                   `((div ([class "arrow"]) "↓")
-                    (pre ([class "program"]) ,(fn result)))
+                    (pre ([class "program"]) ,(fn result output-prec)))
                   `())))))

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -2,19 +2,7 @@
 (require (only-in xml write-xexpr xexpr?))
 (require "../common.rkt" "../formats/test.rkt" "../sandbox.rkt")
 (require "../formats/c.rkt" "../formats/tex.rkt" "../interface.rkt")
-(provide render-menu render-warnings render-large render-program value->string)
-
-(define (value->string n repr)
-  ;; Prints a number with relatively few digits
-  (define ->bf (representation-repr->bf repr))
-  (define <-bf (representation-bf->repr repr))
-  ;; Linear search because speed not an issue
-  (let loop ([precision 16])
-    (parameterize ([bf-precision precision])
-  (define bf (->bf n))
-  (if (=-or-nan? n (<-bf bf))
-      (bigfloat->string bf)
-      (loop (+ precision 4)))))) ; 2^4 > 10
+(provide render-menu render-warnings render-large render-program)
 
 (define/contract (render-menu sections links)
   (-> (listof (cons/c string? string?)) (listof (cons/c string? string?)) xexpr?)

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -39,12 +39,13 @@
     ("C" . ,program->c)))
 
 (define (render-program #:to [result #f] test)
+  (define output-prec (test-output-prec test))
   `(section ([id "program"])
      ,(if (equal? (test-precondition test) 'TRUE)
           ""
           `(div ([id "precondition"])
              (div ([class "program math"])
-                  "\\[" ,(texify-expr (test-precondition test) (*output-prec*)) "\\]")))
+                  "\\[" ,(texify-expr (test-precondition test) output-prec) "\\]")))
      (select ([id "language"])
        (option "Math")
        ,@(for/list ([(lang fn) (in-dict languages)])
@@ -52,12 +53,12 @@
      (div ([class "implementation"] [data-language "Math"])
        (div ([class "program math"]) "\\[" ,(texify-prog
                                               (test-program test)
-                                              (*output-prec*)) "\\]")
+                                              output-prec) "\\]")
        ,@(if result
              `((div ([class "arrow"]) "↓")
                (div ([class "program math"]) "\\[" ,(texify-prog
                                                       result
-                                                      (*output-prec*)) "\\]"))
+                                                      output-prec) "\\]"))
              `()))
      ,@(for/list ([(lang fn) (in-dict languages)])
          `(div ([class "implementation"] [data-language ,lang])

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -35,7 +35,7 @@
                          ,@values)))
 
 (define languages
-  `(("TeX" . ,texify-prog)
+  `(("TeX" . ,(curryr texify-prog (*output-prec*)))
     ("C" . ,program->c)))
 
 (define (render-program #:to [result #f] test)
@@ -44,16 +44,20 @@
           ""
           `(div ([id "precondition"])
              (div ([class "program math"])
-                  "\\[" ,(texify-expr (test-precondition test)) "\\]")))
+                  "\\[" ,(texify-expr (test-precondition test) (*output-prec*)) "\\]")))
      (select ([id "language"])
        (option "Math")
        ,@(for/list ([(lang fn) (in-dict languages)])
            `(option ,lang)))
      (div ([class "implementation"] [data-language "Math"])
-       (div ([class "program math"]) "\\[" ,(texify-prog (test-program test)) "\\]")
+       (div ([class "program math"]) "\\[" ,(texify-prog
+                                              (test-program test)
+                                              (*output-prec*)) "\\]")
        ,@(if result
              `((div ([class "arrow"]) "↓")
-               (div ([class "program math"]) "\\[" ,(texify-prog result) "\\]"))
+               (div ([class "program math"]) "\\[" ,(texify-prog
+                                                      result
+                                                      (*output-prec*)) "\\]"))
              `()))
      ,@(for/list ([(lang fn) (in-dict languages)])
          `(div ([class "implementation"] [data-language ,lang])

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -1,8 +1,20 @@
 #lang racket
 (require (only-in xml write-xexpr xexpr?))
 (require "../common.rkt" "../formats/test.rkt" "../sandbox.rkt")
-(require "../formats/c.rkt" "../formats/tex.rkt")
-(provide render-menu render-warnings render-large render-program)
+(require "../formats/c.rkt" "../formats/tex.rkt" "../interface.rkt")
+(provide render-menu render-warnings render-large render-program value->string)
+
+(define (value->string n repr)
+  ;; Prints a number with relatively few digits
+  (define ->bf (representation-repr->bf repr))
+  (define <-bf (representation-bf->repr repr))
+  ;; Linear search because speed not an issue
+  (let loop ([precision 16])
+    (parameterize ([bf-precision precision])
+  (define bf (->bf n))
+  (if (=-or-nan? n (<-bf bf))
+      (bigfloat->string bf)
+      (loop (+ precision 4)))))) ; 2^4 > 10
 
 (define/contract (render-menu sections links)
   (-> (listof (cons/c string? string?)) (listof (cons/c string? string?)) xexpr?)

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -1,11 +1,11 @@
 #lang racket
 
 (require (only-in xml write-xexpr xexpr?))
-(require "../common.rkt" "../points.rkt" "../float.rkt" "../programs.rkt")
-(require "../alternative.rkt" "../errors.rkt" "../plot.rkt")
-(require "../formats/test.rkt" "../formats/datafile.rkt" "../formats/tex.rkt" "../formats/c.rkt")
-(require "../core/matcher.rkt" "../core/regimes.rkt" "../sandbox.rkt")
-(require "../fpcore/core2js.rkt" "timeline.rkt" "common.rkt")
+(require "../common.rkt" "../points.rkt" "../float.rkt" "../programs.rkt"
+         "../alternative.rkt" "../errors.rkt" "../plot.rkt" "../interface.rkt"
+         "../formats/test.rkt" "../formats/tex.rkt" "../core/matcher.rkt"
+         "../core/regimes.rkt" "../sandbox.rkt" "../fpcore/core2js.rkt"
+         "timeline.rkt" "common.rkt")
 
 (provide all-pages make-page)
 
@@ -193,7 +193,7 @@
   (alt-plot best-alt-point-renderers #:port out #:kind 'png #:title title))
 
 (define (make-point-alt-idxs result)
-  (define repr (get-representation (test-output-prec (test-success-test result))))
+  (define repr (get-representation (test-output-prec (test-result-test result))))
   (define all-alts (test-success-all-alts result))
   (define all-alt-bodies (map (λ (alt) (eval-prog (alt-program alt) 'fl repr)) all-alts))
   (define newpoints (test-success-newpoints result))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -491,7 +491,7 @@
            (for/list ([entry prevs] [idx (in-naturals)]
                       [new-pcontext (split-pcontext pcontext splitpoints
                                                     prevs precision)]
-                      [new-pcontext2 (split-pcontext pcontext2splitpoints
+                      [new-pcontext2 (split-pcontext pcontext splitpoints
                                                      prevs precision)])
              (define entry-ivals (filter (λ (intrvl) (= (interval-alt-idx intrvl) idx)) intervals))
              (define condition (string-join (map interval->string entry-ivals) " or "))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -326,7 +326,9 @@
                (tr (th "Original") (td ,(format-bits (errors-score start-error))))
                (tr (th "Target") (td ,(format-bits (errors-score target-error))))
                (tr (th "Herbie") (td ,(format-bits (errors-score end-error)))))
-              (div ([class "math"]) "\\[" ,(texify-prog `(λ ,(test-vars test) ,(test-output test)) (*output-prec*)) "\\]"))
+              (div ([class "math"]) "\\[" ,(texify-prog `(λ ,(test-vars test)
+                                                            ,(test-output test))
+                                                        precision) "\\]"))
             "")
 
        (section ([id "history"])
@@ -467,7 +469,12 @@
     (if (null? pts*) pcontext (mk-pcontext pts* exs*))))
 
 (define (render-history altn pcontext pcontext2 precision)
-  (define repr (get-representation precision))
+  (define precision* (if (eq? precision 'real)
+                       (if (flag-set? 'precision 'double)
+                         'binary64
+                         'binary32)
+                       precision))
+  (define repr (get-representation precision*))
   (define err
     (format-bits (errors-score (errors (alt-program altn) pcontext repr))))
   (define err2
@@ -477,7 +484,7 @@
     [(alt prog 'start (list))
      (list
       `(li (p "Initial program " (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[" ,(texify-prog prog (*output-prec*)) "\\]")))]
+           (div ([class "math"]) "\\[" ,(texify-prog prog precision*) "\\]")))]
     [(alt prog `(start ,strategy) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li ([class "event"]) "Using strategy " (code ,(~a strategy))))]
@@ -505,26 +512,28 @@
     [(alt prog `(taylor ,pt ,loc) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Taylor expanded around " ,(~a pt) " " (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*) #:loc loc #:color "blue") "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision* #:loc loc
+                                                               #:color "blue") "\\]")))]
 
     [(alt prog `(simplify ,loc) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Simplified" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*) #:loc loc #:color "blue") "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision* #:loc loc
+                                                               #:color "blue") "\\]")))]
 
     [(alt prog `initial-simplify `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Initial simplification" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*)) "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision*) "\\]")))]
 
     [(alt prog `final-simplify `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Final simplification" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*)) "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision*) "\\]")))]
 
     [(alt prog (list 'change cng) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Applied " (span ([class "rule"]) ,(~a (rule-name (change-rule cng))))
               (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*) #:loc (change-location cng) #:color "blue") "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision* #:loc (change-location cng) #:color "blue") "\\]")))]
     ))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -465,10 +465,11 @@
     (if (null? pts*) pcontext (mk-pcontext pts* exs*))))
 
 (define (render-history altn pcontext pcontext2 precision)
+  (define repr (get-representation precision))
   (define err
-    (format-bits (errors-score (errors (alt-program altn) pcontext precision))))
+    (format-bits (errors-score (errors (alt-program altn) pcontext repr))))
   (define err2
-    (format "Internally ~a" (format-bits (errors-score (errors (alt-program altn) pcontext2 precision)))))
+    (format "Internally ~a" (format-bits (errors-score (errors (alt-program altn) pcontext2 repr)))))
 
   (match altn
     [(alt prog 'start (list))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -321,7 +321,7 @@
                (tr (th "Original") (td ,(format-bits (errors-score start-error))))
                (tr (th "Target") (td ,(format-bits (errors-score target-error))))
                (tr (th "Herbie") (td ,(format-bits (errors-score end-error)))))
-              (div ([class "math"]) "\\[" ,(texify-prog `(λ ,(test-vars test) ,(test-output test))) "\\]"))
+              (div ([class "math"]) "\\[" ,(texify-prog `(λ ,(test-vars test) ,(test-output test)) (*output-prec*)) "\\]"))
             "")
 
        (section ([id "history"])
@@ -470,7 +470,7 @@
     [(alt prog 'start (list))
      (list
       `(li (p "Initial program " (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[" ,(texify-prog prog) "\\]")))]
+           (div ([class "math"]) "\\[" ,(texify-prog prog (*output-prec*)) "\\]")))]
     [(alt prog `(start ,strategy) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li ([class "event"]) "Using strategy " (code ,(~a strategy))))]
@@ -496,26 +496,26 @@
     [(alt prog `(taylor ,pt ,loc) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Taylor expanded around " ,(~a pt) " " (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog #:loc loc #:color "blue") "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*) #:loc loc #:color "blue") "\\]")))]
 
     [(alt prog `(simplify ,loc) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Simplified" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog #:loc loc #:color "blue") "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*) #:loc loc #:color "blue") "\\]")))]
 
     [(alt prog `initial-simplify `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Initial simplification" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog) "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*)) "\\]")))]
 
     [(alt prog `final-simplify `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Final simplification" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog) "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*)) "\\]")))]
 
     [(alt prog (list 'change cng) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Applied " (span ([class "rule"]) ,(~a (rule-name (change-rule cng))))
               (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog #:loc (change-location cng) #:color "blue") "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog (*output-prec*) #:loc (change-location cng) #:color "blue") "\\]")))]
     ))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -35,6 +35,8 @@
 
 (define (make-page page out result profile?)
   (with-handlers ([exn:fail? (page-error-handler (test-result-test result) page)])
+    (define test (test-result-test result))
+    (define precision (test-output-prec test))
     (match page
       ["graph.html"
        (match result
@@ -46,7 +48,7 @@
       ["timeline.html"
        (make-timeline result out)]
       ["timeline.json"
-       (make-timeline-json result out)]
+       (make-timeline-json result out precision)]
       [(regexp #rx"^plot-([0-9]+).png$" (list _ idx))
        (make-axis-plot result out (string->number idx))]
       [(regexp #rx"^plot-([0-9]+)([rbg]).png$" (list _ idx letter))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -201,7 +201,7 @@
   (define all-alt-bodies (map (λ (alt) (eval-prog (alt-program alt) 'fl repr)) all-alts))
   (define newpoints (test-success-newpoints result))
   (define newexacts (test-success-newexacts result))
-  (oracle-error-idx all-alt-bodies newpoints newexacts))
+  (oracle-error-idx all-alt-bodies newpoints newexacts repr))
 
 (define (make-contour-plot point-colors var-idxs title out)
   (define point-renderers (herbie-ratio-point-renderers point-colors var-idxs))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -448,7 +448,8 @@
         (format " < ~a" (repr->fl end (infer-representation end)))))))
 
 (define (split-pcontext pcontext splitpoints alts precision)
-  (define preds (splitpoints->point-preds splitpoints alts precision))
+  (define repr (get-representation precision))
+  (define preds (splitpoints->point-preds splitpoints alts repr))
 
   (for/list ([pred preds])
     (define-values (pts* exs*)

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -155,7 +155,8 @@
                    `(tr (td ,(format-time time)) (td ,(~a count) "×")
                         (td ,(~a prog)) (td ,(~a prec)) (td ,(~a category))))))))
 
-(define (make-timeline-json result out)
+(define (make-timeline-json result out precision)
+  (define repr (get-representation precision))
   (define timeline (test-result-timeline result))
   (define ((cons->hash k1 f1 k2 f2) c) (hash k1 (f1 (car c)) k2 (f2 (cdr c))))
 
@@ -172,7 +173,7 @@
        (hash 'count count 'time time
              'program (~a prog) 'category (~a category) 'precision prec))]
     [('bstep v)
-     (define (flval-wrapper x) (flval x (infer-representation x)))
+     (define (flval-wrapper x) (flval x repr))
      (map (λ (x) (map (curryr apply '())
                       (list flval-wrapper flval-wrapper identity flval-wrapper) x))
           v)]

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -1,6 +1,8 @@
 #lang racket
 (require json (only-in xml write-xexpr xexpr?))
-(require "../common.rkt" "../formats/test.rkt" "../sandbox.rkt" "../formats/datafile.rkt" "common.rkt" "../float.rkt")
+(require "../common.rkt" "../formats/test.rkt" "../sandbox.rkt"
+         "../formats/datafile.rkt" "common.rkt" "../float.rkt"
+         "../interface.rkt")
 (provide make-timeline make-timeline-json make-summary-html)
 
 (define timeline-phase? (hash/c symbol? any/c))


### PR DESCRIPTION
This PR removes all instances of `infer-representation` and `infer-double-representation` from the code. Rather than looking at values to figure out their representation, we now pass through relevant representation information and set a global variable `*output-prec*` which tracks the output precision for a given FPCore. Note that currently the representation that is passed through only corresponds to the output precision since input FPCores are not yet allowed to have variable precision.