### PR TITLE
Generalize the erfc-erf rule (for #247)

### DIFF
--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -661,7 +661,7 @@
   #:type ([x real])
   [erf-odd          (erf (- x))          (- (erf x))]
   [erf-erfc         (erfc x)             (- 1 (erf x))]
-  [erfc-erf         (- 1 (erf x))        (erfc x)])
+  [erfc-erf         (erf x)              (- 1 (erfc x))])
 
 (define (*rules*)
   (for/append ([rec (*rulesets*)])

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -298,14 +298,14 @@
   [libm erf erff] [bf bferf] [ival ival-erf]
   [->c/double (curry format "erf(~a)")]
   [->c/mpfr (curry format "mpfr_erf(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{erf} ~a")]
+  [->tex (curry format "\\mathsf{erf}\\left(~a\\right)")]
   [nonffi erf])
 
 (define-operator/libm (erfc real) real
   [libm erfc erfcf] [bf bferfc] [ival ival-erfc]
   [->c/double (curry format "erfc(~a)")]
   [->c/mpfr (curry format "mpfr_erfc(~a, ~a, MPFR_RNDN)")]
-  [->tex (curry format "\\mathsf{erfc} ~a")]
+  [->tex (curry format "\\mathsf{erfc}\\left(~a\\right)")]
   [nonffi erfc])
 
 (define-operator/libm (exp real) real


### PR DESCRIPTION
The `erfc-erf` rule would only operate on `(- 1 (erf x))`; that's needlessly specific since we can introduce the subtraction on the right hand side.