### PR TITLE
Fix web bug for single-precision runs

### DIFF
--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -248,9 +248,6 @@
    (define precision (test-output-prec test))
    ;; render-history expects the precision to be 'real rather than 'binary64 or 'binary32
    ;; remove this when the number system interface is added
-   (define precision* (if (set-member? '(binary64 binary32) precision)
-                          'real
-                          precision))
 
    (fprintf out "<!doctype html>\n")
    (write-xexpr
@@ -336,7 +333,7 @@
        (section ([id "history"])
         (h1 "Derivation")
         (ol ([class "history"])
-         ,@(render-history end-alt (mk-pcontext newpoints newexacts) (mk-pcontext points exacts) precision*)))
+         ,@(render-history end-alt (mk-pcontext newpoints newexacts) (mk-pcontext points exacts) precision)))
 
        ,(render-reproduction test)))
     out))
@@ -471,12 +468,7 @@
     (if (null? pts*) pcontext (mk-pcontext pts* exs*))))
 
 (define (render-history altn pcontext pcontext2 precision)
-  (define precision* (if (eq? precision 'real)
-                       (if (flag-set? 'precision 'double)
-                         'binary64
-                         'binary32)
-                       precision))
-  (define repr (get-representation precision*))
+  (define repr (get-representation precision))
   (define err
     (format-bits (errors-score (errors (alt-program altn) pcontext repr))))
   (define err2
@@ -486,7 +478,7 @@
     [(alt prog 'start (list))
      (list
       `(li (p "Initial program " (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[" ,(texify-prog prog precision*) "\\]")))]
+           (div ([class "math"]) "\\[" ,(texify-prog prog precision) "\\]")))]
     [(alt prog `(start ,strategy) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li ([class "event"]) "Using strategy " (code ,(~a strategy))))]
@@ -514,28 +506,28 @@
     [(alt prog `(taylor ,pt ,loc) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Taylor expanded around " ,(~a pt) " " (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision* #:loc loc
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision #:loc loc
                                                                #:color "blue") "\\]")))]
 
     [(alt prog `(simplify ,loc) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Simplified" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision* #:loc loc
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision #:loc loc
                                                                #:color "blue") "\\]")))]
 
     [(alt prog `initial-simplify `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Initial simplification" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision*) "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision) "\\]")))]
 
     [(alt prog `final-simplify `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Final simplification" (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision*) "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision) "\\]")))]
 
     [(alt prog (list 'change cng) `(,prev))
      `(,@(render-history prev pcontext pcontext2 precision)
        (li (p "Applied " (span ([class "rule"]) ,(~a (rule-name (change-rule cng))))
               (span ([class "error"] [title ,err2]) ,err))
-           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision* #:loc (change-location cng) #:color "blue") "\\]")))]
+           (div ([class "math"]) "\\[\\leadsto " ,(texify-prog prog precision #:loc (change-location cng) #:color "blue") "\\]")))]
     ))


### PR DESCRIPTION
A bug appeared that crashed the web interface whenever a user tried to run in single-precision mode. This was caused when generating the report due to a mix-up between precisions and types, sometimes passing through `real` as the precision when we should have instead been passing through `binary32` or `binary64`. We would then check the flag to see if we were running in double or single precision mode rather than just using the precision that we already had from the test output, and because we are no longer running in the sandbox when the report is generated, we would get the incorrect precision and then try to call the `binary64` version of `repr->ordinal` on `binary32` points. This PR fixes that crash by never passing through precision as the type `real` rather than the actual precision.