### PR TITLE
Fix bug in value->string causing an infinite loop

### DIFF
--- a/src/float.rkt
+++ b/src/float.rkt
@@ -148,7 +148,7 @@
     (if (> precision (*max-mpfr-prec*))
       (begin
         (warn 'value-to-string #:url "faq.html#value-to-string"
-               "Could not find a unique string representation for value ~a" n)
+               "Could not uniquely print ~a" n)
         n)
       (parameterize ([bf-precision precision])
         (define bf (->bf n*))

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -139,15 +139,21 @@
 
 (define (value->string n repr)
   ;; Prints a number with relatively few digits
+  (define n* (if (exact? n) (exact->inexact n) n))
   (define ->bf (representation-repr->bf repr))
   (define <-bf (representation-bf->repr repr))
   ;; Linear search because speed not an issue
   (let loop ([precision 16])
-    (parameterize ([bf-precision precision])
-  (define bf (->bf n))
-  (if (=-or-nan? n (<-bf bf))
-      (bigfloat->string bf)
-      (loop (+ precision 4)))))) ; 2^4 > 10
+    (if (> precision (*max-mpfr-prec*))
+      (begin
+        (printf "Error: value->string could not find a unique representation for ~a" n)
+        (printf "in the allowed mpfr precision\n")
+        n)
+      (parameterize ([bf-precision precision])
+        (define bf (->bf n*))
+        (if (=-or-nan? n* (<-bf bf))
+            (bigfloat->string bf)
+            (loop (+ precision 4))))))) ; 2^4 > 10
 
 (define/contract (->bf x repr)
   (-> any/c representation? bigvalue?)

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -146,8 +146,8 @@
   (let loop ([precision 16])
     (if (> precision (*max-mpfr-prec*))
       (begin
-        (printf "Error: value->string could not find a unique representation for ~a" n)
-        (printf "in the allowed mpfr precision\n")
+        (warn 'value-to-string #:url "faq.html#value-to-string"
+               "Could not find a unique string representation for value ~a" n)
         n)
       (parameterize ([bf-precision precision])
         (define bf (->bf n*))

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -1,7 +1,8 @@
 #lang racket
 
 (require math/flonum math/bigfloat)
-(require "config.rkt" "common.rkt" "interface.rkt" "syntax/types.rkt" "bigcomplex.rkt" "syntax/syntax.rkt")
+(require "config.rkt" "common.rkt" "interface.rkt" "syntax/types.rkt" "bigcomplex.rkt"
+         "syntax/syntax.rkt" "errors.rkt")
 (module+ test (require rackunit))
 
 (provide midpoint ulp-difference *bit-width* ulps->bits bit-difference

--- a/www/doc/1.3/faq.html
+++ b/www/doc/1.3/faq.html
@@ -91,6 +91,19 @@
     with <code>--disable precision:fallback</code>.
   </p>
 
+  <h3 id="value-to-string">Could not find a unique string representation
+                           for value <var>val</var></h3>
+
+  <p>
+    Herbie will raise this warning when it has to use more than 10,000
+    bits to find a unique string representation for the given value.
+    If you are using non-herbie provided representation plugins, then it
+    could mean that your representation has a bug in it. Otherwise, there
+    is probably a bug in the Herbie code, and you should file a bug report
+    on our <a href="https://github.com/uwplse/herbie/issues/new">github</a>
+    about it.
+  </p>
+
 
   <h2>Known bugs</h2>
 

--- a/www/doc/1.3/faq.html
+++ b/www/doc/1.3/faq.html
@@ -91,19 +91,6 @@
     with <code>--disable precision:fallback</code>.
   </p>
 
-  <h3 id="value-to-string">Could not find a unique string representation
-                           for value <var>val</var></h3>
-
-  <p>
-    Herbie will raise this warning when it has to use more than 10,000
-    bits to find a unique string representation for the given value.
-    If you are using non-herbie provided representation plugins, then it
-    could mean that your representation has a bug in it. Otherwise, there
-    is probably a bug in the Herbie code, and you should file a bug report
-    on our <a href="https://github.com/uwplse/herbie/issues/new">github</a>
-    about it.
-  </p>
-
 
   <h2>Known bugs</h2>
 

--- a/www/doc/1.4/faq.html
+++ b/www/doc/1.4/faq.html
@@ -91,6 +91,14 @@
     with <code>--disable precision:fallback</code>.
   </p>
 
+  <h3 id="value-to-string">Could uniquely print <var>val</var></h3>
+
+  <p>
+    Herbie will raise this warning when it needs more than 10,000 bits
+    to produce a string representation for a given value. This is
+    likely the result of a bug in a third-party plugin.
+  </p>
+
 
   <h2>Known bugs</h2>
 


### PR DESCRIPTION
When `value->string` was passed in an exact value, the function would infinite loop. This was because `=-or-nan?` would compare the exact value with the value that had been converted back from a bigfloat to the representation (which for exact values would be labelled as binary64 or binary32) and would then try to compare an inexact value to an exact value. This change will always compare the inexact values and adds in a check to make sure the function doesn't infinite loop in the case that the function can't find a unique string to represent the value.