### PR TITLE
Use `precision:double` Flag as Fallback Precision

### DIFF
--- a/src/formats/test.rkt
+++ b/src/formats/test.rkt
@@ -36,7 +36,10 @@
         ['() '()]
         [(list prop val rest ...) (cons (cons prop val) (loop rest))])))
 
-  (define default-prec (dict-ref prop-dict ':precision 'binary64))
+  (define default-prec (dict-ref prop-dict ':precision
+                                 (if (flag-set? 'precision 'double)
+                                   'binary64
+                                   'binary32)))
   (define var-precs (for/list ([arg args] [arg-name arg-names])
                       (if (and (list? arg) (set-member? args ':precision))
                         (cons arg-name


### PR DESCRIPTION
Previously, if a precision was not specified in the FPCore, then Herbie would assume `binary64` instead of using the `precision:double` flag. This change fixes that bug.