### PR TITLE
Fix an old simplify bug

### DIFF
--- a/src/core/egraph.rkt
+++ b/src/core/egraph.rkt
@@ -118,6 +118,8 @@
   (match expr
     [(list op args ...)
      (mk-enode! eg (cons op (map (curry mk-enode-rec! eg) args)))]
+    [(? enode?)
+     (pack-leader expr)]
     [_
      (mk-enode! eg expr)]))
 

--- a/src/core/ematch.rkt
+++ b/src/core/ematch.rkt
@@ -5,7 +5,7 @@
 (require "enode.rkt")
 (require "egraph.rkt")
 
-(provide match-e substitute-e)
+(provide match-e)
 
 ;;################################################################################;;
 ;;# The matcher module that allows us to match enode structure against patterns,
@@ -60,15 +60,3 @@
 		 '())))]
    [else
     (error "WTF" pat)]))
-
-(define (substitute-e eg pat bindings)
-  (cond
-   [(constant? pat)
-    (mk-enode! eg pat)]
-   [(variable? pat)
-    (let ([binden (cdr (assoc pat bindings))])
-      binden)]
-   [(list? pat)
-    (mk-enode! eg (cons (car pat)
-			(for/list ([subpat (cdr pat)])
-			  (substitute-e eg subpat bindings))))]))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -5,7 +5,7 @@
 
 (provide
  (all-from-out "../syntax/rules.rkt")
- pattern-match
+ pattern-match pattern-substitute
  rewrite-expression-head rewrite-expression
  (struct-out change) change-apply rule-rewrite)
 

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -2,7 +2,7 @@
 
 (require "../common.rkt" "../programs.rkt" "../float.rkt" "../timeline.rkt")
 (require "../syntax/rules.rkt" "../syntax/types.rkt")
-(require "egraph.rkt" "ematch.rkt" "extraction.rkt")
+(require "egraph.rkt" "ematch.rkt" "extraction.rkt" "matcher.rkt")
 (provide simplify-expr simplify-batch)
 (module+ test (require rackunit))
 
@@ -75,7 +75,9 @@
         #:break (>= (egraph-cnt eg) (*node-limit*)))
     (match-define (list rl en bindings ...) m)
     (for ([binding bindings] #:break (>= (egraph-cnt eg) (*node-limit*)))
-      (merge-egraph-nodes! eg en (substitute-e eg (rule-output rl) binding))))
+      (define expr* (pattern-substitute (rule-output rl) binding))
+      (define en* (mk-enode-rec! eg expr*))
+      (merge-egraph-nodes! eg en en*)))
   (for ([en (egraph-leaders eg)]
         #:break (>= (egraph-cnt eg) (*node-limit*)))
     (set-precompute! eg en))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -114,7 +114,9 @@
           [(/ (* x 3) x) . 3]
           [(- (* (sqrt (+ x 1)) (sqrt (+ x 1)))
               (* (sqrt x) (sqrt x))) . 1]
-          [(re (complex a b)) . a]))
+          [(re (complex a b)) . a]
+          [(/ 1 (- (/ (+ 1 (sqrt 5)) 2) (/ (- 1 (sqrt 5)) 2))) . (/ 1 (sqrt 5))]
+          ))
 
   (*timeline-disabled* true)
   (define outputs (simplify-batch (hash-keys test-exprs) #:rules (*simplify-rules*)))


### PR DESCRIPTION
The core issue is with not replacing enough expressions by their representative. In particular, the bug occurs during pattern substitution. In substitution, we might want to substitute into the pattern `(+ a b)` with `a` bound to some enode X and `b` bound to another Y. Before this bug, X and Y were used directly; in the new code, X and Y are first upgraded to their pack leaders. This fixes #255.

The reason this bug has such a large impact is that it creates many "useless" nodes in the e-graph, which are just copies of other nodes but not equal to them.

To reduce future maintenance, I've replaced the `substitute-e` procedure, for substituting e-nodes into a pattern, with the regular `pattern-substitute` procedure, which handles the e-nodes fine, plus `mk-enode-rec!` to create the final e-node. This makes the code more readable and deletes some lines of code.