### PR TITLE
Mention the right variable when there are no valid values

### DIFF
--- a/src/plot.rkt
+++ b/src/plot.rkt
@@ -255,6 +255,7 @@
     (define h (histogram-f x))
     (/ (apply + (vector->list h)) (vector-length h)))
   ;; TODO: This is a weird hack in several ways, and ideally wouldn't exist
+  ;; TODO: This doesn't work in single-precision
   (define-values (min max)
     (match* ((car (first eby)) (car (last eby)))
             [(x x) (values #f #f)]


### PR DESCRIPTION
Sometimes a precondition eliminates all possible values, like for `(< 2 x 1)`. In that case, Herbie produces the "no valid values" error message. That message mentions a variable; however, when there are multiple variables, it often mentions the wrong one. For example if you have variables `x` and `y`, and the precondition `(< 2 y 1)`, Herbie complains that there are no valid values of `x`. It is technically right, but substantially wrong: nothing is the problem with `x`, though there is something wrong with `y`.

The fix involves the two different ways of representing "no valid values" in the "range-table" structure. One is the range-table `#f`, which mentions no variables (and will raise an error with the first variable in the list). The other is the range-table `#hash([y . ()])`, which mentions `y` by name and describes it as not having any valid values. The fix basically involves biasing the range analysis method toward the second kind of range-table, which will allow `x` to be sampled without error and then throw an error when `y` is sampled.