### PR TITLE
No report columns for infinities

### DIFF
--- a/src/formats/datafile.rkt
+++ b/src/formats/datafile.rkt
@@ -10,7 +10,7 @@
 
 (struct table-row
   (name status pre precision vars input output spec target-prog
-        start result target inf- inf+ start-est result-est
+        start result target start-est result-est
         time bits link) #:prefab)
 
 (struct report-info
@@ -33,7 +33,7 @@
   (define (simplify-test test)
     (match test
       [(table-row name status pre prec vars input output spec target-prog
-                  start-bits end-bits target-bits inf- inf+ start-est end-est
+                  start-bits end-bits target-bits start-est end-est
                   time bits link)
        (make-hash
         `((name . ,name)
@@ -43,8 +43,6 @@
           (start . ,start-bits)
           (end . ,end-bits)
           (target . ,target-bits)
-          (ninf . ,inf-)
-          (pinf . ,inf+)
           (start-est . ,start-est)
           (end-est . ,end-est)
           (vars . ,(if vars (map symbol->string vars) #f))
@@ -106,6 +104,6 @@
                                 (parse-string (hash-ref test 'spec "#f"))
                                 (parse-string (hash-ref test 'target-prog "#f"))
                                 (get 'start) (get 'end) (get 'target)
-                                (get 'ninf) (get 'pinf) (hash-ref test 'start-est 0) (hash-ref test 'end-est 0)
+                                (hash-ref test 'start-est 0) (hash-ref test 'end-est 0)
                                 
                                 (get 'time) (get 'bits) (get 'link)))))))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -194,13 +194,9 @@
   (eval-errors baseline newpcontext repr))
 
 (define (errors-score e)
-  (define repr (get-representation 'binary64))
-  (let-values ([(reals unreals) (partition (curryr ordinary-value? repr) e)])
-    (if (flag-set? 'reduce 'avg-error)
-        (/ (+ (apply + (map ulps->bits reals))
-              (* (*bit-width*) (length unreals)))
-           (length e))
-        (apply max (map ulps->bits reals)))))
+  (if (flag-set? 'reduce 'avg-error)
+      (/ (apply + (map ulps->bits e)) (length e))
+      (apply max (map ulps->bits e))))
 
 (define (errors prog pcontext repr)
   (define fn (eval-prog prog 'fl repr))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -135,7 +135,7 @@
              (resugar-program (test-spec test) (test-output-prec test))
              (and (test-output test)
                   (resugar-program (test-output test) (test-output-prec test)))
-             #f #f #f #f #f #f #f (test-result-time result)
+             #f #f #f #f #f (test-result-time result)
              (test-result-bits result) link))
 
 (define (get-table-data result link)
@@ -173,7 +173,7 @@
                            (program-body (alt-program (test-success-end-alt result)))
                            (test-output-prec test))]
                  [start start-score] [result end-score] [target target-score]
-                 [start-est est-start-score] [result-est est-end-score] [inf- 0] [inf+ 0])]
+                 [start-est est-start-score] [result-est est-end-score])]
    [(test-failure? result)
     (define status (if (exn:fail:user:herbie? (test-failure-exn result)) "error" "crash"))
     (dummy-table-row result status link)]

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -154,12 +154,6 @@
     (define est-start-score (errors-score (test-success-start-est-error result)))
     (define est-end-score (errors-score (test-success-end-est-error result)))
 
-    (define binary64 (get-representation 'binary64))
-    ;; TODO: this is broken because errors are always ordinary values now!
-    (define-values (reals infs) (partition (curryr ordinary-value? binary64)
-                                           (map - end-errors start-errors)))
-    (define-values (good-inf bad-inf) (partition positive? infs))
-
     (define status
       (if target-score
           (cond
@@ -179,7 +173,7 @@
                            (program-body (alt-program (test-success-end-alt result)))
                            (test-output-prec test))]
                  [start start-score] [result end-score] [target target-score]
-                 [start-est est-start-score] [result-est est-end-score] [inf- (length good-inf)] [inf+ (length bad-inf)])]
+                 [start-est est-start-score] [result-est est-end-score] [inf- 0] [inf+ 0])]
    [(test-failure? result)
     (define status (if (exn:fail:user:herbie? (test-failure-exn result)) "error" "crash"))
     (dummy-table-row result status link)]

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -16,7 +16,7 @@
   (match-define (report-info date commit branch hostname seed flags points iterations bit-width note tests) info)
 
   (define table-labels
-    '("Test" "Start" "Result" "Target" "∞ ↔ ℝ" "Time"))
+    '("Test" "Start" "Result" "Target" "Time"))
 
   (define help-text
     #hash(("Result" . "Color key:\nGreen: improved accuracy\nLight green: no initial error\nOrange: no accuracy change\nRed: accuracy worsened")
@@ -43,19 +43,12 @@
   (define (round* x)
     (inexact->exact (round x)))
 
-  (define any-has-target? (ormap table-row-target tests))
-  (define any-has-inf+/-?
-    (for*/or ([test tests] [field (list table-row-inf- table-row-inf+)])
-      (and (field test) (> (field test) 0))))
-
   (define sorted-tests
     (sort (map cons tests (range (length tests))) >
           #:key (λ (x) (or (table-row-start (car x)) 0))))
 
   (define classes
-    (filter identity
-            (list (if any-has-target? #f 'no-target)
-                  (if any-has-inf+/-? #f 'no-inf))))
+    (if (ormap table-row-target tests) '(no-target) '()))
 
   ;; HTML cruft
   (fprintf out "<!doctype html>\n")
@@ -130,10 +123,6 @@
                 (td ,(format-bits (table-row-start result)))
                 (td ,(format-bits (table-row-result result)))
                 (td ,(format-bits (table-row-target result)))
-                (td ,(let ([inf- (table-row-inf- result)])
-                       (if (and inf- (> inf- 0)) (format "+~a" inf-) ""))
-                    ,(let ([inf+ (table-row-inf+ result)])
-                       (if (and inf+ (> inf+ 0)) (format "-~a" inf+) "")))
                 (td ,(format-time (table-row-time result)))
                 ,(if (table-row-link result)
                      `(td

--- a/src/web/report.css
+++ b/src/web/report.css
@@ -81,7 +81,7 @@ li.timeout    {background-color: #8e8e93; color: #f7f7f7;}
 }
 
 #results td:nth-child(1) { text-align: left; word-break: break-all; }
-#results td:nth-child(7) {width: 0;}
+#results td:nth-child(6) {width: 0;}
 
 tr.imp-start  td:nth-child(3) {background-color:#87fc70;}
 tr.apx-start  td:nth-child(3) {background-color:#ff9500;}
@@ -105,8 +105,6 @@ tr.timeout    td:nth-child(3) {background-color:#8e8e93;color:#f7f7f7;}
 
 #results.no-target td:nth-child(4) {display: none;}
 #results.no-target th:nth-child(4) {display: none;}
-#results.no-inf td:nth-child(5) {display: none;}
-#results.no-inf th:nth-child(5) {display: none;}
 
 /* Help button */
 


### PR DESCRIPTION
This is a truly ancient fix. Way back in the day, Herbie did not use bits of error as its error measure; instead it used relative error. This lead to a problem any time the exact answer was zero, or the inexact answer was infinity, or something like that. So the Herbie reports of the time showed both error (where that was possible to compute) and also the number of points that should be finite which were actually zero or infinity.

That column has been inactive for years (ever since we moved from relative error to bits error), but it is still in the code, carefully preserved. This commit strips it out.