### PR TITLE
No precompute in final simplify

### DIFF
--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -23,14 +23,18 @@
                                 #:rules rls
                                 #:precompute [precompute? false]
                                 #:prune [prune? false])
-  (-> expr? #:rules (listof rule?) #:precompute boolean? #:prune boolean? expr?)
+  (->* (expr? #:rules (listof rule?))
+       (#:precompute boolean? #:prune boolean?)
+       expr?)
   (first (simplify-batch (list expr) #:rules rls)))
 
 (define/contract (simplify-batch exprs
                                  #:rules rls
                                  #:precompute [precompute? false]
                                  #:prune [prune? false])
-  (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? #:prune boolean? (listof expr?))
+  (->* (expr? #:rules (listof rule?))
+       (#:precompute boolean? #:prune boolean?)
+       expr?)
   (debug #:from 'simplify (format "Simplifying:\n  ~a" (string-join (map ~a exprs) "\n  ")))
 
   (define start-time (current-inexact-milliseconds))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -21,8 +21,8 @@
 
 (define/contract (simplify-expr expr
                                 #:rules rls
-                                #:precompute [precompute? false]
-                                #:prune [prune? false])
+                                #:precompute [precompute? true]
+                                #:prune [prune? true])
   (->* (expr? #:rules (listof rule?))
        (#:precompute boolean? #:prune boolean?)
        expr?)
@@ -30,8 +30,8 @@
 
 (define/contract (simplify-batch exprs
                                  #:rules rls
-                                 #:precompute [precompute? false]
-                                 #:prune [prune? false])
+                                 #:precompute [precompute? true]
+                                 #:prune [prune? true])
   (->* (expr? #:rules (listof rule?))
        (#:precompute boolean? #:prune boolean?)
        expr?)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -383,7 +383,9 @@
   (timeline-event! 'simplify)
   (define cleaned-alt
     (alt `(λ ,(program-variables (alt-program joined-alt))
-            ,(simplify-expr (program-body (alt-program joined-alt)) #:rules (*fp-safe-simplify-rules*)))
+            ,(simplify-expr (program-body (alt-program joined-alt))
+                            #:rules (*fp-safe-simplify-rules*)
+                            #:precompute false))
          'final-simplify (list joined-alt)))
   (timeline-event! 'end)
   cleaned-alt)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -82,8 +82,9 @@
   (^precision^ precision)
   (*pcontext* context)
   (debug #:from 'progress #:depth 3 "[2/2] Setting up program.")
-  (^table^ (make-alt-table context (make-alt prog) precision))
-  (void))
+  (define alt (make-alt prog))
+  (^table^ (make-alt-table context alt precision))
+  alt)
 
 ;; Information
 (define (list-alts)
@@ -348,12 +349,13 @@
                      #:specification [specification #f])
   (debug #:from 'progress #:depth 1 "[Phase 1 of 3] Setting up.")
   (define repr (get-representation precision))
-  (setup-prog! prog #:specification specification #:precondition precondition #:precision precision)
+  (define alt
+    (setup-prog! prog #:specification specification #:precondition precondition #:precision precision))
   (cond
    [(and (flag-set? 'setup 'early-exit)
-         (< (errors-score (errors prog (*pcontext*) repr)) 0.1))
+         (< (errors-score (errors (alt-program alt) (*pcontext*) repr)) 0.1))
     (debug #:from 'progress #:depth 1 "Initial program already accurate, stopping.")
-    (first (atab-all-alts (^table^)))]
+    alt]
    [else
     (debug #:from 'progress #:depth 1 "[Phase 2 of 3] Improving.")
     (when (flag-set? 'setup 'simplify)

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -57,15 +57,16 @@
         (timeline-event! 'end)
         (define end-err (errors-score (errors (alt-program alt) newcontext output-repr)))
 
+        (define fns
+          (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr))
+               (remove-duplicates (*all-alts*))))
+
+        (define baseline-errs (baseline-error fns context newcontext output-repr))
+        (define oracle-errs (oracle-error fns newcontext output-repr))
+
         ;; The cells are stored in reverse order, so this finds last regimes invocation
         (for/first ([cell (unbox timeline)]
                     #:when (equal? (dict-ref cell 'type) 'regimes))
-          (define fns
-            (map (λ (alt) (eval-prog (alt-program alt) 'fl output-repr))
-                 (remove-duplicates (*all-alts*))))
-
-          (define baseline-errs (baseline-error fns context newcontext output-repr))
-          (define oracle-errs (oracle-error fns newcontext output-repr))
           
           (debug #:from 'regime-testing #:depth 1
                  "Baseline error score:" (errors-score baseline-errs))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -85,7 +85,7 @@
                                          (errors (test-target test) newcontext output-repr))))
         `(good ,(bf-precision) ,warning-log
                ,(make-alt (test-program test)) ,alt ,context ,newcontext
-               ,baseline-errs ,oracle-errs ,all-alts))))
+               ,baseline-errs ,oracle-errs ,(*all-alts*)))))
 
   (define (in-engine _)
     (set! timeline *timeline*)


### PR DESCRIPTION
The final simplify step is supposed to do only transformations that are provably valid in the floating-point numbers, to avoid showing users junk. However, it currently also applies precomputation, which in a few cases causes the result to be less accurate. (Because more-exact value in one part of the program may make the overall program less accurate.) Avoiding precomputation in final simplify seems like the right move.

This PR removes `one-iter` in `simplify.rkt`, replacing it was an abstraction called "phases". Each rewrite rule is a phase, as is precomputation and pruning. Each phase can also be turned on or off by command line flags.