### PR TITLE
Fix bug with constants in egg-herbie

### DIFF
--- a/src/core/eggmath.rkt
+++ b/src/core/eggmath.rkt
@@ -89,6 +89,8 @@
       #:after-last ")")]
     [(and (number? expr) (exact? expr) (real? expr))
      (number->string expr)]
+    [(constant? expr)
+     (symbol->string expr)]
     [(hash-has-key? herbie->egg-dict expr)
      (symbol->string (hash-ref herbie->egg-dict expr))]
     [else

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -115,6 +115,7 @@
               (* (sqrt x) (sqrt x))) . 1]
           [(re (complex a b)) . a]
           [(+ 1/5 3/10) . 1/2]
+          [(cos PI) . -1]
           ;; this test is problematic and runs out of nodes currently
           ;[(/ 1 (- (/ (+ 1 (sqrt 5)) 2) (/ (- 1 (sqrt 5)) 2))) . (/ 1 (sqrt 5))]
           ))


### PR DESCRIPTION
This bug was introduced during the refactor of PR #272 
`eggmath.rkt` was not checking if the expression is an fpcore constant when renaming variables to send to the rust side.