### PR TITLE
Overflow detection in interval evaluation

### DIFF
--- a/src/biginterval.rkt
+++ b/src/biginterval.rkt
@@ -482,7 +482,7 @@
   (ival (rnd 'down bferf (ival-lo x)) (rnd 'up bferf (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (ival-erfc x)
-  (ival (rnd 'down bferfc (ival-hi x)) (rnd 'up bferfc (ival-lo x)) (ival-err? x) (ival-err x)) (ival-must-overflow? x))
+  (ival (rnd 'down bferfc (ival-hi x)) (rnd 'up bferfc (ival-lo x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (ival-cmp x y)
   (define can-< (bflt? (ival-lo x) (ival-hi y)))

--- a/src/biginterval.rkt
+++ b/src/biginterval.rkt
@@ -3,10 +3,10 @@
 (require math/private/bigfloat/mpfr)
 (require "syntax/types.rkt")
 
-(struct ival (lo hi err? err) #:transparent)
+(struct ival (lo hi err? err must-overflow?) #:transparent)
 
 (provide (contract-out
-          [struct ival ([lo bigvalue?] [hi bigvalue?] [err? boolean?] [err boolean?])]
+          [struct ival ([lo bigvalue?] [hi bigvalue?] [err? boolean?] [err boolean?] [must-overflow? boolean?])]
           [mk-ival (-> (or/c real? boolean?) ival?)]
           [ival-pi (-> ival?)]
           [ival-e  (-> ival?)]
@@ -66,9 +66,9 @@
   (match x
     [(? real?)
      (define x* (bf x)) ;; TODO: Assuming that float precision < bigfloat precision
-     (ival x* x* #f #f)]
+     (ival x* x* #f #f #f)]
     [(? boolean?)
-     (ival x x #f #f)]))
+     (ival x x #f #f #f)]))
 
 (define -inf.bf (bf -inf.0))
 (define -1.bf (bf -1))
@@ -80,13 +80,13 @@
 (define +nan.bf (bf +nan.0))
 
 (define (ival-pi)
-  (ival (rnd 'down pi.bf) (rnd 'up pi.bf) #f #f))
+  (ival (rnd 'down pi.bf) (rnd 'up pi.bf) #f #f #f))
 
 (define (ival-e)
-  (ival (rnd 'down bfexp 1.bf) (rnd 'up bfexp 1.bf) #f #f))
+  (ival (rnd 'down bfexp 1.bf) (rnd 'up bfexp 1.bf) #f #f #f))
 
 (define (ival-bool b)
-  (ival b b #f #f))
+  (ival b b #f #f #f))
 
 (define ival-true (ival-bool #t))
 
@@ -96,19 +96,21 @@
 
 (define (ival-neg x)
   ;; No rounding, negation is exact
-  (ival (bfneg (ival-hi x)) (bfneg (ival-lo x)) (ival-err? x) (ival-err x)))
+  (ival (bfneg (ival-hi x)) (bfneg (ival-lo x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (ival-add x y)
   (ival (rnd 'down bfadd (ival-lo x) (ival-lo y))
         (rnd 'up bfadd (ival-hi x) (ival-hi y))
         (or (ival-err? x) (ival-err? y))
-        (or (ival-err x) (ival-err y))))
+        (or (ival-err x) (ival-err y))
+        (and (ival-must-overflow? x) (ival-must-overflow? y))))
 
 (define (ival-sub x y)
   (ival (rnd 'down bfsub (ival-lo x) (ival-hi y))
         (rnd 'up bfsub (ival-hi x) (ival-lo y))
         (or (ival-err? x) (ival-err? y))
-        (or (ival-err x) (ival-err y))))
+        (or (ival-err x) (ival-err y))
+        (and (ival-must-overflow? x) (ival-must-overflow? y))))
 
 (define (bfmin* a . as)
   (if (null? as) a (apply bfmin* (bfmin2 a (car as)) (cdr as))))
@@ -119,74 +121,76 @@
 (define (ival-mult x y)
   (define err? (or (ival-err? x) (ival-err? y)))
   (define err (or (ival-err x) (ival-err y)))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
   (match* ((classify-ival x) (classify-ival y))
    [(1 1)
     (ival (rnd 'down bfmul (ival-lo x) (ival-lo y))
-          (rnd 'up bfmul (ival-hi x) (ival-hi y)) err? err)]
+          (rnd 'up bfmul (ival-hi x) (ival-hi y)) err? err must-overflow?)]
    [(1 -1)
     (ival (rnd 'down bfmul (ival-hi x) (ival-lo y))
-          (rnd 'up bfmul (ival-lo x) (ival-hi y)) err? err)]
+          (rnd 'up bfmul (ival-lo x) (ival-hi y)) err? err must-overflow?)]
    [(1 0)
     (ival (rnd 'down bfmul (ival-hi x) (ival-lo y))
-          (rnd 'up bfmul (ival-hi x) (ival-hi y)) err? err)]
+          (rnd 'up bfmul (ival-hi x) (ival-hi y)) err? err must-overflow?)]
    [(-1 0)
     (ival (rnd 'down bfmul (ival-lo x) (ival-hi y))
-          (rnd 'up bfmul (ival-lo x) (ival-lo y)) err? err)]
+          (rnd 'up bfmul (ival-lo x) (ival-lo y)) err? err must-overflow?)]
    [(-1 1)
     (ival (rnd 'down bfmul (ival-lo x) (ival-hi y))
-          (rnd 'up bfmul (ival-hi x) (ival-lo y)) err? err)]
+          (rnd 'up bfmul (ival-hi x) (ival-lo y)) err? err must-overflow?)]
    [(-1 -1)
     (ival (rnd 'down bfmul (ival-hi x) (ival-hi y))
-          (rnd 'up bfmul (ival-lo x) (ival-lo y)) err? err)]
+          (rnd 'up bfmul (ival-lo x) (ival-lo y)) err? err must-overflow?)]
    [(0 1)
     (ival (rnd 'down bfmul (ival-lo x) (ival-hi y))
-          (rnd 'up bfmul (ival-hi x) (ival-hi y)) err? err)]
+          (rnd 'up bfmul (ival-hi x) (ival-hi y)) err? err must-overflow?)]
    [(0 -1)
     (ival (rnd 'down bfmul (ival-hi x) (ival-lo y))
-          (rnd 'up bfmul (ival-lo x) (ival-lo y)) err? err)]
+          (rnd 'up bfmul (ival-lo x) (ival-lo y)) err? err must-overflow?)]
    [(0 0) ; The "else" case is always correct, but is slow
     ;; We round only down, and approximate rounding up with bfnext below
     (define opts
       (rnd 'down list
            (bfmul (ival-lo x) (ival-lo y)) (bfmul (ival-hi x) (ival-lo y))
            (bfmul (ival-lo x) (ival-hi y)) (bfmul (ival-hi x) (ival-hi y))))
-    (ival (apply bfmin* opts) (bfnext (apply bfmax* opts)) err? err)]))
+    (ival (apply bfmin* opts) (bfnext (apply bfmax* opts)) err? err must-overflow?)]))
 
 (define (ival-div x y)
   (define err? (or (ival-err? x) (ival-err? y) (and (bflte? (ival-lo y) 0.bf) (bfgte? (ival-hi y) 0.bf))))
   (define err (or (ival-err x) (ival-err y) (and (bf=? (ival-lo y) 0.bf) (bf=? (ival-hi y) 0.bf))))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
     ;; We round only down, and approximate rounding up with bfnext below
   (match* ((classify-ival x) (classify-ival y))
     [(_ 0)
-     (ival -inf.bf +inf.bf err? err)]
+     (ival -inf.bf +inf.bf err? err must-overflow?)]
     [(1 1)
      (ival (rnd 'down bfdiv (ival-lo x) (ival-hi y))
-           (rnd 'up bfdiv (ival-hi x) (ival-lo y)) err? err)]
+           (rnd 'up bfdiv (ival-hi x) (ival-lo y)) err? err must-overflow?)]
     [(1 -1)
      (ival (rnd 'down bfdiv (ival-hi x) (ival-hi y))
-           (rnd 'up bfdiv (ival-lo x) (ival-lo y)) err? err)]
+           (rnd 'up bfdiv (ival-lo x) (ival-lo y)) err? err must-overflow?)]
     [(-1 1)
      (ival (rnd 'down bfdiv (ival-lo x) (ival-lo y))
-           (rnd 'up bfdiv (ival-hi x) (ival-hi y)) err? err)]
+           (rnd 'up bfdiv (ival-hi x) (ival-hi y)) err? err must-overflow?)]
     [(-1 -1)
      (ival (rnd 'down bfdiv (ival-hi x) (ival-lo y))
-           (rnd 'up bfdiv (ival-lo x) (ival-hi y)) err? err)]
+           (rnd 'up bfdiv (ival-lo x) (ival-hi y)) err? err must-overflow?)]
     [(0 1)
      (ival (rnd 'down bfdiv (ival-lo x) (ival-lo y))
-           (rnd 'up bfdiv (ival-hi x) (ival-lo y)) err? err)]
+           (rnd 'up bfdiv (ival-hi x) (ival-lo y)) err? err must-overflow?)]
     [(0 -1)
      (ival (rnd 'down bfdiv (ival-hi x) (ival-hi y))
-           (rnd 'up bfdiv (ival-lo x) (ival-hi y)) err? err)]
+           (rnd 'up bfdiv (ival-lo x) (ival-hi y)) err? err must-overflow?)]
     [(_ _)
      (define opts
        (rnd 'down list
             (bfdiv (ival-lo x) (ival-lo y)) (bfdiv (ival-hi x) (ival-lo y))
             (bfdiv (ival-lo x) (ival-hi y)) (bfdiv (ival-hi x) (ival-hi y))))
-     (ival (apply bfmin* opts) (bfnext (apply bfmax* opts)) err? err)]))
+     (ival (apply bfmin* opts) (bfnext (apply bfmax* opts)) err? err must-overflow?)]))
 
 (define-syntax-rule (define-monotonic name bffn)
   (define (name x)
-    (ival (rnd 'down bffn (ival-lo x)) (rnd 'up bffn (ival-hi x)) (ival-err? x) (ival-err x))))
+    (ival (rnd 'down bffn (ival-lo x)) (rnd 'up bffn (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x))))
 
 (define-monotonic ival-exp bfexp)
 (define-monotonic ival-exp2 bfexp2)
@@ -196,7 +200,8 @@
   (define (name x)
     (define err (or (ival-err x) (bflte? (ival-hi x) 0.bf)))
     (define err? (or err (ival-err? x) (bflte? (ival-lo x) 0.bf)))
-    (ival (rnd 'down bffn (ival-lo x)) (rnd 'up bffn (ival-hi x)) err? err)))
+    (define must-overflow? (ival-must-overflow? x))
+    (ival (rnd 'down bffn (ival-lo x)) (rnd 'up bffn (ival-hi x)) err? err must-overflow?)))
 
 (define-monotonic-positive ival-log bflog)
 (define-monotonic-positive ival-log2 bflog2)
@@ -205,30 +210,34 @@
 (define (ival-log1p x)
   (define err (or (ival-err x) (bflte? (ival-hi x) -1.bf)))
   (define err? (or err (ival-err? x) (bflte? (ival-lo x) -1.bf)))
+  (define must-overflow? (ival-must-overflow? x))
   (ival (rnd 'down bflog1p (ival-lo x)) (rnd 'up bflog1p (ival-hi x))
-        err? err))
+        err? err must-overflow?))
 
 (define (ival-sqrt x)
   (define err (or (ival-err x) (bflt? (ival-hi x) 0.bf)))
   (define err? (or err (ival-err? x) (bflt? (ival-lo x) 0.bf)))
+  (define must-overflow? (ival-must-overflow? x))
   (ival (rnd 'down bfsqrt (ival-lo x)) (rnd 'up bfsqrt (ival-hi x))
-        err? err))
+        err? err must-overflow?))
 
 (define (ival-cbrt x)
-  (ival (rnd 'down bfcbrt (ival-lo x)) (rnd 'up bfcbrt (ival-hi x)) (ival-err? x) (ival-err x)))
+  (ival (rnd 'down bfcbrt (ival-lo x)) (rnd 'up bfcbrt (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (ival-hypot x y)
   (define err? (or (ival-err? x) (ival-err? y)))
   (define err (or (ival-err x) (ival-err y)))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
   (define x* (ival-fabs x))
   (define y* (ival-fabs y))
   (ival (rnd 'down bfhypot (ival-lo x*) (ival-lo y*))
         (rnd 'up bfhypot (ival-hi x*) (ival-hi y*))
-        err? err))
+        err? err must-overflow?))
 
 (define (ival-pow x y)
   (define err? (or (ival-err? x) (ival-err? y)))
   (define err (or (ival-err x) (ival-err y)))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
   (cond
    [(bfgte? (ival-lo x) 0.bf)
     (let ([lo
@@ -239,11 +248,11 @@
            (if (bfgt? (ival-hi x) 1.bf)
                (rnd 'up bfexpt (ival-hi x) (ival-hi y))
                (rnd 'up bfexpt (ival-hi x) (ival-lo y)))])
-      (ival lo hi err? err))]
+      (ival lo hi err? err must-overflow?))]
    [(and (bf=? (ival-lo y) (ival-hi y)) (bfinteger? (ival-lo y)))
     (ival (rnd 'down bfexpt (ival-lo x) (ival-lo y))
           (rnd 'up bfexpt (ival-lo x) (ival-lo y))
-          err? err)]
+          err? err must-overflow?)]
    [else
     ;; In this case, the base range includes negatives and the exp range includes reals
     ;; Focus first on just the negatives in the base range
@@ -259,16 +268,16 @@
        [(bflt? b a)
         (ival +nan.bf +nan.bf #t #t)]
        [(bf=? a b)
-        (ival (rnd 'down bfexpt (ival-lo x) a) (rnd 'up bfexpt (ival-hi x) a) err? err)]
+        (ival (rnd 'down bfexpt (ival-lo x) a) (rnd 'up bfexpt (ival-hi x) a) err? err must-overflow?)]
        [(bfodd? b)
         (ival (rnd 'down bfexpt (ival-lo x) b)
-              (rnd 'up bfmax2 (bfexpt (ival-hi x) (bfsub b 1.bf)) (bfexpt (ival-lo x) (bfsub b 1.bf))) err? err)]
+              (rnd 'up bfmax2 (bfexpt (ival-hi x) (bfsub b 1.bf)) (bfexpt (ival-lo x) (bfsub b 1.bf))) err? err must-overflow?)]
        [(bfeven? b)
         (ival (rnd 'down bfexpt (ival-lo x) (bfsub b 1.bf))
-              (rnd 'up bfmax2 (bfexpt (ival-hi x) b) (bfexpt (ival-lo x) b)) err? err)]
+              (rnd 'up bfmax2 (bfexpt (ival-hi x) b) (bfexpt (ival-lo x) b)) err? err must-overflow?)]
        [else (ival +nan.bf +nan.bf #f #t)]))
     (if (bfgt? (ival-hi x) 0.bf)
-        (ival-union neg-range (ival-pow (ival 0.bf (ival-hi x) err? err) y))
+        (ival-union neg-range (ival-pow (ival 0.bf (ival-hi x) err? err must-overflow?) y))
         neg-range)]))
 
 (define (ival-fma a b c)
@@ -276,14 +285,17 @@
 
 (define (ival-and . as)
   (ival (andmap ival-lo as) (andmap ival-hi as)
-        (ormap ival-err? as) (ormap ival-err as)))
+        (ormap ival-err? as) (ormap ival-err as)
+        (andmap ival-must-overflow? as)))
 
 (define (ival-or . as)
   (ival (ormap ival-lo as) (ormap ival-hi as)
-        (ormap ival-err? as) (ormap ival-err as)))
+        (ormap ival-err? as) (ormap ival-err as)
+        (andmap ival-must-overflow? as)))
 
+;;TODO not sure what must-overflow should be
 (define (ival-not x)
-  (ival (not (ival-hi x)) (not (ival-lo x)) (ival-err? x) (ival-err x)))
+  (ival (not (ival-hi x)) (not (ival-lo x)) (ival-err? x) (ival-err x) #f))
 
 (define (ival-cos x)
   (define lopi (rnd 'down pi.bf))
@@ -292,15 +304,15 @@
   (define b (rnd 'up   bffloor (bfdiv (ival-hi x) (if (bflt? (ival-hi x) 0.bf) hipi lopi))))
   (cond
    [(and (bf=? a b) (bfeven? a))
-    (ival (rnd 'down bfcos (ival-hi x)) (rnd 'up bfcos (ival-lo x)) (ival-err? x) (ival-err x))]
+    (ival (rnd 'down bfcos (ival-hi x)) (rnd 'up bfcos (ival-lo x)) (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [(and (bf=? a b) (bfodd? a))
-    (ival (rnd 'down bfcos (ival-lo x)) (rnd 'up bfcos (ival-hi x)) (ival-err? x) (ival-err x))]
+    (ival (rnd 'down bfcos (ival-lo x)) (rnd 'up bfcos (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [(and (bf=? (bfsub b a) 1.bf) (bfeven? a))
-    (ival -1.bf (rnd 'up bfmax2 (bfcos (ival-lo x)) (bfcos (ival-hi x))) (ival-err? x) (ival-err x))]
+    (ival -1.bf (rnd 'up bfmax2 (bfcos (ival-lo x)) (bfcos (ival-hi x))) (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [(and (bf=? (bfsub b a) 1.bf) (bfodd? a))
-    (ival (rnd 'down bfmin2 (bfcos (ival-lo x)) (bfcos (ival-hi x))) 1.bf (ival-err? x) (ival-err x))]
+    (ival (rnd 'down bfmin2 (bfcos (ival-lo x)) (bfcos (ival-hi x))) 1.bf (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [else
-    (ival -1.bf 1.bf (ival-err? x) (ival-err x))]))
+    (ival -1.bf 1.bf (ival-err? x) (ival-err x) (ival-must-overflow? x))]))
 
 (define (ival-sin x)
   (define lopi (rnd 'down pi.bf))
@@ -309,21 +321,21 @@
   (define b (rnd 'up bffloor (bfsub (bfdiv (ival-hi x) (if (bflt? (ival-hi x) 0.bf) hipi lopi)) half.bf)))
   (cond
    [(and (bf=? a b) (bfeven? a))
-    (ival (rnd 'down bfsin (ival-hi x)) (rnd 'up bfsin (ival-lo x)) (ival-err? x) (ival-err x))]
+    (ival (rnd 'down bfsin (ival-hi x)) (rnd 'up bfsin (ival-lo x)) (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [(and (bf=? a b) (bfodd? a))
-    (ival (rnd 'down bfsin (ival-lo x)) (rnd 'up bfsin (ival-hi x)) (ival-err? x) (ival-err x))]
+    (ival (rnd 'down bfsin (ival-lo x)) (rnd 'up bfsin (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [(and (bf=? (bfsub b a) 1.bf) (bfeven? a))
-    (ival -1.bf (rnd 'up bfmax2 (bfsin (ival-lo x)) (bfsin (ival-hi x))) (ival-err? x) (ival-err x))]
+    (ival -1.bf (rnd 'up bfmax2 (bfsin (ival-lo x)) (bfsin (ival-hi x))) (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [(and (bf=? (bfsub b a) 1.bf) (bfodd? a))
-    (ival (rnd 'down bfmin2 (bfsin (ival-lo x)) (bfsin (ival-hi x))) 1.bf (ival-err? x) (ival-err x))]
+    (ival (rnd 'down bfmin2 (bfsin (ival-lo x)) (bfsin (ival-hi x))) 1.bf (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [else
-    (ival -1.bf 1.bf (ival-err? x) (ival-err x))]))
+    (ival -1.bf 1.bf (ival-err? x) (ival-err x) (ival-must-overflow? x))]))
 
 (define (ival-tan x)
   (ival-div (ival-sin x) (ival-cos x)))
 
 (define (ival-atan x)
-  (ival (rnd 'down bfatan (ival-lo x)) (rnd 'up bfatan (ival-hi x)) (ival-err? x) (ival-err x)))
+  (ival (rnd 'down bfatan (ival-lo x)) (rnd 'up bfatan (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (classify-ival x)
   (cond [(bfgte? (ival-lo x) 0.bf) 1] [(bflte? (ival-hi x) 0.bf) -1] [else 0]))
@@ -331,6 +343,7 @@
 (define (ival-atan2 y x)
   (define err? (or (ival-err? x) (ival-err? y)))
   (define err (or (ival-err x) (ival-err y)))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
 
   (define tl (list (ival-hi y) (ival-lo x)))
   (define tr (list (ival-hi y) (ival-hi x)))
@@ -349,48 +362,53 @@
       [( _  _) (values #f #f)]))
 
   (if a-lo
-      (ival (rnd 'down apply bfatan2 a-lo) (rnd 'up apply bfatan2 a-hi) err? err)
+      (ival (rnd 'down apply bfatan2 a-lo) (rnd 'up apply bfatan2 a-hi) err? err must-overflow?)
       (ival (rnd 'down bfneg (pi.bf)) (rnd 'up pi.bf)
             (or err? (bfgte? (ival-hi x) 0.bf))
-            (or err (and (bf=? (ival-lo x) 0.bf) (bf=? (ival-hi x) 0.bf) (bf=? (ival-lo y) 0.bf) (bf=? (ival-hi y) 0.bf))))))
+            (or err (and (bf=? (ival-lo x) 0.bf) (bf=? (ival-hi x) 0.bf) (bf=? (ival-lo y) 0.bf) (bf=? (ival-hi y) 0.bf)))
+            must-overflow?)))
 
 (define (ival-asin x)
   (ival (rnd 'down bfasin (ival-lo x)) (rnd 'up bfasin (ival-hi x))
         (or (ival-err? x) (bflt? (ival-lo x) -1.bf) (bfgt? (ival-hi x) 1.bf))
-        (or (ival-err x) (bflt? (ival-hi x) -1.bf) (bfgt? (ival-lo x) 1.bf))))
+        (or (ival-err x) (bflt? (ival-hi x) -1.bf) (bfgt? (ival-lo x) 1.bf))
+        (ival-must-overflow? x)))
 
 (define (ival-acos x)
   (ival (rnd 'down bfacos (ival-hi x)) (rnd 'up bfacos (ival-lo x))
         (or (ival-err? x) (bflt? (ival-lo x) -1.bf) (bfgt? (ival-hi x) 1.bf))
-        (or (ival-err x) (bflt? (ival-hi x) -1.bf) (bfgt? (ival-lo x) 1.bf))))
+        (or (ival-err x) (bflt? (ival-hi x) -1.bf) (bfgt? (ival-lo x) 1.bf))
+        (ival-must-overflow? x)))
 
 (define (ival-fabs x)
   (cond
    [(bfgt? (ival-lo x) 0.bf) x]
    [(bflt? (ival-hi x) 0.bf)
-    (ival (bfneg (ival-hi x)) (bfneg (ival-lo x)) (ival-err? x) (ival-err x))]
+    (ival (bfneg (ival-hi x)) (bfneg (ival-lo x)) (ival-err? x) (ival-err x) (ival-must-overflow? x))]
    [else ; interval stradles 0
-    (ival 0.bf (bfmax2 (bfneg (ival-lo x)) (ival-hi x)) (ival-err? x) (ival-err x))]))
+    (ival 0.bf (bfmax2 (bfneg (ival-lo x)) (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x))]))
 
 (define (ival-sinh x)
-  (ival (rnd 'down bfsinh (ival-lo x)) (rnd 'up bfsinh (ival-hi x)) (ival-err? x) (ival-err x)))
+  (ival (rnd 'down bfsinh (ival-lo x)) (rnd 'up bfsinh (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (ival-cosh x)
   (define y (ival-fabs x))
-  (ival (rnd 'down bfcosh (ival-lo y)) (rnd 'up bfcosh (ival-hi y)) (ival-err? y) (ival-err y)))
+  (ival (rnd 'down bfcosh (ival-lo y)) (rnd 'up bfcosh (ival-hi y)) (ival-err? y) (ival-err y) (ival-must-overflow? x)))
 
 (define (ival-tanh x)
-  (ival (rnd 'down bftanh (ival-lo x)) (rnd 'up bftanh (ival-hi x)) (ival-err? x) (ival-err x)))
+  (ival (rnd 'down bftanh (ival-lo x)) (rnd 'up bftanh (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (ival-asinh x)
-  (ival (rnd 'down bfasinh (ival-lo x)) (rnd 'up bfasinh (ival-hi x)) (ival-err? x) (ival-err x)))
+  (ival (rnd 'down bfasinh (ival-lo x)) (rnd 'up bfasinh (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (ival-acosh x)
   (ival (rnd 'down bfacosh (bfmax2 (ival-lo x) 1.bf)) (rnd 'up bfacosh (ival-hi x))
-        (or (bflte? (ival-lo x) 1.bf) (ival-err? x)) (or (bflt? (ival-hi x) 1.bf) (ival-err x))))
+        (or (bflte? (ival-lo x) 1.bf) (ival-err? x)) (or (bflt? (ival-hi x) 1.bf) (ival-err x))
+        (ival-must-overflow? x)))
 
 (define (ival-atanh x)
-  (ival (rnd 'down bfatanh (ival-lo x)) (rnd 'up bfatanh (ival-hi x)) (ival-err? x) (ival-err x)))
+  (ival (rnd 'down bfatanh (ival-lo x)) (rnd 'up bfatanh (ival-hi x)) (ival-err? x) (ival-err x)
+        (ival-must-overflow? x)))
 
 (define (ival-fmod x y)
   (define y* (ival-fabs y))
@@ -399,13 +417,14 @@
   (define b (rnd 'up bftruncate (ival-hi quot)))
   (define err? (or (ival-err? x) (ival-err? y) (bf=? (ival-lo y*) 0.bf)))
   (define err (or (ival-err x) (ival-err y) (bf=? (ival-hi y*) 0.bf)))
-  (define tquot (ival a b err? err))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
+  (define tquot (ival a b err? err must-overflow?))
 
   (cond
    [(bf=? a b) (ival-sub x (ival-mult tquot y*))]
-   [(bflte? b 0.bf) (ival (bfneg (ival-hi y*)) 0.bf err? err)]
-   [(bfgte? a 0.bf) (ival 0.bf (ival-hi y*) err? err)]
-   [else (ival (bfneg (ival-hi y*)) (ival-hi y*) err? err)]))
+   [(bflte? b 0.bf) (ival (bfneg (ival-hi y*)) 0.bf err? err must-overflow?)]
+   [(bfgte? a 0.bf) (ival 0.bf (ival-hi y*) err? err must-overflow?)]
+   [else (ival (bfneg (ival-hi y*)) (ival-hi y*) err? err must-overflow?)]))
 
 (define (ival-remainder x y)
   (define y* (ival-fabs y))
@@ -414,10 +433,11 @@
   (define b (rnd 'up bfround (ival-hi quot)))
   (define err? (or (ival-err? x) (ival-err? y) (bf=? (ival-lo y*) 0.bf)))
   (define err (or (ival-err x) (ival-err y) (bf=? (ival-hi y*) 0.bf)))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
 
   (if (bf=? a b)
-      (ival-sub x (ival-mult (ival a b err? err) y*))
-      (ival (bfneg (bfdiv (ival-hi y*) 2.bf)) (bfdiv (ival-hi y*) 2.bf) err? err)))
+      (ival-sub x (ival-mult (ival a b err? err must-overflow?) y*))
+      (ival (bfneg (bfdiv (ival-hi y*) 2.bf)) (bfdiv (ival-hi y*) 2.bf) err? err must-overflow?)))
 
 (define-monotonic ival-rint bfrint)
 (define-monotonic ival-round bfround)
@@ -426,10 +446,10 @@
 (define-monotonic ival-trunc bftruncate)
 
 (define (ival-erf x)
-  (ival (rnd 'down bferf (ival-lo x)) (rnd 'up bferf (ival-hi x)) (ival-err? x) (ival-err x)))
+  (ival (rnd 'down bferf (ival-lo x)) (rnd 'up bferf (ival-hi x)) (ival-err? x) (ival-err x) (ival-must-overflow? x)))
 
 (define (ival-erfc x)
-  (ival (rnd 'down bferfc (ival-hi x)) (rnd 'up bferfc (ival-lo x)) (ival-err? x) (ival-err x)))
+  (ival (rnd 'down bferfc (ival-hi x)) (rnd 'up bferfc (ival-lo x)) (ival-err? x) (ival-err x)) (ival-must-overflow? x))
 
 (define (ival-cmp x y)
   (define can-< (bflt? (ival-lo x) (ival-hi y)))
@@ -440,23 +460,28 @@
 
 (define (ival-<2 x y)
   (define-values (c< m< c> m>) (ival-cmp x y))
-  (ival m< c< (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
+  (ival m< c< (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y)) must-overflow?))
 
 (define (ival-<=2 x y)
   (define-values (c< m< c> m>) (ival-cmp x y))
-  (ival (not c>) (not m>) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
+  (ival (not c>) (not m>) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y)) must-overflow?))
 
 (define (ival->2 x y)
   (define-values (c< m< c> m>) (ival-cmp x y))
-  (ival m> c> (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
+  (ival m> c> (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y)) must-overflow?))
 
 (define (ival->=2 x y)
   (define-values (c< m< c> m>) (ival-cmp x y))
-  (ival (not c<) (not m<) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
+  (ival (not c<) (not m<) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y)) must-overflow?))
 
 (define (ival-==2 x y)
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
   (define-values (c< m< c> m>) (ival-cmp x y))
-  (ival (and (not c<) (not c>)) (or (not m<) (not m>)) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
+  (ival (and (not c<) (not c>)) (or (not m<) (not m>)) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y)) must-overflow?))
 
 (define (ival-comparator f name)
   (procedure-rename
@@ -477,8 +502,9 @@
 (define ival-== (ival-comparator ival-==2 'ival-==))
 
 (define (ival-!=2 x y)
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
   (define-values (c< m< c> m>) (ival-cmp x y))
-  (ival (or c< c>) (or m< m>) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
+  (ival (or c< c>) (or m< m>) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y)) must-overflow?))
 
 (define (ival-!= . as)
   (if (null? as)
@@ -491,18 +517,23 @@
              (loop (car tail) (cdr tail)))))))
 
 (define (ival-union x y)
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? y)))
   (match (ival-lo x)
    [(? bigfloat?)
     (ival (bfmin2 (ival-lo x) (ival-lo y)) (bfmax2 (ival-hi x) (ival-hi y))
-          (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y)))]
+          (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))
+          must-overflow?)]
    [(? boolean?)
     (ival (and (ival-lo x) (ival-lo y)) (or (ival-hi x) (ival-hi y))
-          (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y)))]))
+          (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))
+          must-overflow?)]))
 
 (define (propagate-err c x)
+  (define must-overflow? (and (ival-must-overflow? x) (ival-must-overflow? c)))
   (ival (ival-lo x) (ival-hi x)
         (or (ival-err? c) (ival-err? x))
-        (or (ival-err c) (ival-err x))))
+        (or (ival-err c) (ival-err x))
+        must-overflow?))
 
 (define (ival-if c x y)
   (cond
@@ -520,12 +551,12 @@
   (define (sample-interval)
     (if (= (random 0 2) 0)
         (let ([v1 (sample-double)] [v2 (sample-double)])
-          (ival (bf (min v1 v2)) (bf (max v1 v2)) (or (nan? v1) (nan? v2)) (and (nan? v1) (nan? v2))))
+          (ival (bf (min v1 v2)) (bf (max v1 v2)) (or (nan? v1) (nan? v2)) (and (nan? v1) (nan? v2)) #f))
         (let* ([v1 (bf (sample-double))] [exp (random 0 31)] [mantissa (random 0 (expt 2 exp))] [sign (- (* 2 (random 0 2)) 1)])
           (define v2 (bfstep v1 (* sign (+ exp mantissa))))
           (if (= sign -1)
-              (ival v2 v1 (or (bfnan? v1) (bfnan? v2)) (and (bfnan? v1) (bfnan? v2)))
-              (ival v1 v2 (or (bfnan? v1) (bfnan? v2)) (and (bfnan? v1) (bfnan? v2)))))))
+              (ival v2 v1 (or (bfnan? v1) (bfnan? v2)) (and (bfnan? v1) (bfnan? v2)) #f)
+              (ival v1 v2 (or (bfnan? v1) (bfnan? v2)) (and (bfnan? v1) (bfnan? v2)) #f)))))
 
   (define (sample-bf)
     (bf (sample-double)))
@@ -651,4 +682,17 @@
             (define iy (ival-fn i1 i2))
             (check-pred ival-valid? iy)
             (check ival-contains? iy y))))))
+
+
+  ;; must-overflow test
+  (for ([(ival-fn fn) (in-dict arg1)])
+    (test-case (~a (object-name ival-fn))
+       (for ([n (in-range num-tests)])
+         (define i (sample-interval))
+         (define x (sample-from i))
+         (with-check-info (['fn ival-fn] ['interval i] ['point x] ['number n])
+           ;;(println (ival-must-overflow? (ival-fn i)))
+           (check-pred ival-valid? (ival-fn i))
+           (check ival-contains? (ival-fn i) (fn x))))))
+
   )

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -81,8 +81,11 @@
     (parameterize ([bf-precision precision])
       (if (> precision (*max-mpfr-prec*))
           (begin (log! 'exit precision pt) +nan.0)
-          (match-let* ([(ival lo hi err? err) (fn pt)] [lo* (<-bf lo)] [hi* (<-bf hi)])
+          (match-let* ([(ival lo hi err? err must-overflow?) (fn pt)] [lo* (<-bf lo)] [hi* (<-bf hi)])
             (cond
+             [must-overflow?
+              (log! 'exit precision pt)
+              hi*]
              [err
               (log! 'nan precision pt)
               +nan.0]
@@ -301,7 +304,4 @@
       (loop (append pts* pts) (append exs* exs) (+ 1 num-loops))])))
 
 
-(module+ test
-  (define num 
-  (for/and ([iter (in-naturals 0)])
     

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -299,3 +299,9 @@
              "Filtering points with unrepresentable outputs")
       (define-values (pts* exs*) (filter-p&e pts1 exs1))
       (loop (append pts* pts) (append exs* exs) (+ 1 num-loops))])))
+
+
+(module+ test
+  (define num 
+  (for/and ([iter (in-naturals 0)])
+    

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -67,6 +67,8 @@
                #:extra (for/list ([var (program-variables prog)] [val pt])
                          (format "~a = ~a" var val)))
          key]
+        [`(overflowed ,prec ,pt)
+         (list name 'overflowed prec)]
         [`(sampled ,prec ,pt #f) (list name 'false prec)]
         [`(sampled ,prec ,pt #t) (list name 'true prec)]
         [`(sampled ,prec ,pt ,_) (list name 'valid prec)]
@@ -83,9 +85,6 @@
           (begin (log! 'exit precision pt) +nan.0)
           (match-let* ([(ival lo hi err? err must-overflow?) (fn pt)] [lo* (<-bf lo)] [hi* (<-bf hi)])
             (cond
-             [must-overflow?
-              (log! 'exit precision pt)
-              hi*]
              [err
               (log! 'nan precision pt)
               +nan.0]
@@ -94,6 +93,9 @@
                                   (and (equal? lo* -0.0f0) (equal? hi* +0.0f0))))
               (log! 'sampled precision pt hi*)
               hi*]
+             [must-overflow?
+              (log! 'overflowed precision pt)
+              +nan.0]
              [else
               (loop (inexact->exact (round (* precision 2))))]))))))
 

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -39,7 +39,6 @@
   (define hash (make-hash))
   (define (save expr loc)
     (hash-update! hash expr (curry cons loc) '()))
-
   (let loop ([expr prog] [loc '()])
     (match expr
       [(list (or 'lambda 'λ) (list vars ...) body)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -148,7 +148,7 @@
            ])) ;(2.4174342574957107e-18 -1.4150052601637869e-40 -1.1686799408259549e+57)
 
   (define (in-interval? iv pt)
-    (match-define (ival lo hi err? err) iv)
+    (match-define (ival lo hi err? err must-overflow?) iv)
     (and (bf<= lo pt) (bf<= pt hi)))
 
   (define-binary-check (check-in-interval? in-interval? interval point))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang errortrace racket
 
 (require rackunit math/bigfloat)
 (require "../common.rkt" "../programs.rkt" (submod "../points.rkt" internals))


### PR DESCRIPTION
Currently, Herbie is abnormally and disastrously slow when the given expression results in overflow across much of the domain. This is because when sampling points to find the ground truth of the expression's value at a given point, it uses high precision big floats before giving up due to overflow.

This PR adds a flag to the interval evaluation that allows it to exit early if it knows that the expression always results in overflow at a given point.
Future work: Ideally, it would be smarter about the points that it sampled for the function by inferring a precondition.
TODO:
- [ ] Investigate if anything can be done about Harley's example
- [ ] Ensure that Herbie performs just as well because it doesn't throw out extra points
- [x] Make tests more complete
- [ ] Clean up PR