### PR TITLE
Convert `*output-prec*` to `*output-repr*`

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -18,8 +18,7 @@
   (atab-completed? (alt-table? . -> . boolean?))
   (atab-context (alt-table? . -> . pcontext?))
   (atab-min-errors (alt-table? . -> . (listof real?)))
-  (split-atab (alt-table? (non-empty-listof any/c) . -> . (listof alt-table?)))
-  (atab-new-context (alt-table? pcontext? any/c . -> . alt-table?))))
+  (split-atab (alt-table? (non-empty-listof any/c) . -> . (listof alt-table?)))))
 
 ;; Public API
 
@@ -29,8 +28,7 @@
 
 (define in-atab-pcontext (compose in-pcontext atab-context))
 
-(define (make-alt-table context initial-alt prec)
-  (define repr (get-representation prec))
+(define (make-alt-table context initial-alt repr)
   (alt-table (make-immutable-hash
                (for/list ([(pt ex) (in-pcontext context)]
                           [err (errors (alt-program initial-alt) context repr)])
@@ -39,21 +37,14 @@
              (hash initial-alt #f)
              context))
 
-(define (atab-new-context atab ctx prec)
-  (let* ([old-done (alt-table-alt->done? atab)]
-         [alts (atab-all-alts atab)]
-         [table-init (make-alt-table ctx (car alts) prec)])
-    (struct-copy alt-table (atab-add-altns table-init (cdr alts) prec)
-                 [alt->done? old-done])))
-
-(define (atab-add-altns atab altns prec)
+(define (atab-add-altns atab altns repr)
   (define prog-set (map alt-program (hash-keys (alt-table-alt->points atab))))
   (define altns*
     (filter
      (negate (compose (curry set-member? prog-set) alt-program))
      (remove-duplicates altns #:key alt-program)))
   (for/fold ([atab atab]) ([altn altns*])
-    (atab-add-altn atab altn prec)))
+    (atab-add-altn atab altn repr)))
 
 (define (atab-pick-alt atab #:picking-func [pick car]
            #:only-fresh [only-fresh? #t])
@@ -200,8 +191,7 @@
              altns)])
     (alt-table pnts->alts* alts->pnts* alts->done?* (alt-table-context atab))))
 
-(define (atab-add-altn atab altn prec)
-  (define repr (get-representation prec))
+(define (atab-add-altn atab altn repr)
   (define errs (errors (alt-program altn) (alt-table-context atab) repr))
   (match-define (alt-table point->alts alt->points _ _) atab)
   (define-values (best-pnts tied-pnts) (best-and-tied-at-points atab altn errs))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -55,7 +55,7 @@
   (*analyze-context* (*pcontext*))
   (hash-clear! *analyze-cache*)))
 
-(define (localize-error prog prec)
+(define (localize-error prog repr)
   (define varmap (map cons (program-variables prog)
 		      (flip-lists (for/list ([(p e) (in-pcontext (*pcontext*))])
 				    p))))
@@ -65,7 +65,6 @@
         (make-hash)))
   (define expr->loc (location-hash prog))
 
-  (define repr (get-representation prec))
   (localize-on-expression (program-body prog) varmap cache repr)
 
   (define locs

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -13,11 +13,6 @@
 (define *analyze-context* (make-parameter #f))
 
 (define (localize-on-expression expr vars cache repr)
-  (define ctx
-    (for/hash ([(var vals) (in-dict vars)])
-      (values var (match (representation-name repr)
-                    [(or 'binary32 'binary64) 'real]
-                    [x x]))))
   (hash-ref! cache expr
              (λ ()
                 (match expr
@@ -28,7 +23,7 @@
                          (->bf expr repr)))
                    (cons (repeat bf) (repeat 1))]
                   [(? variable?)
-                   (cons (map (curryr ->bf (get-representation (dict-ref (*var-precs*) expr)))
+                   (cons (map (curryr ->bf (dict-ref (*var-reprs*) expr))
                               (dict-ref vars expr))
                          (repeat 1))]
                   [`(if ,c ,ift ,iff)
@@ -39,10 +34,10 @@
                      (cons (for/list ([c exact-cond] [t exact-ift] [f exact-iff]) (if c t f))
                            (repeat 1)))]
                   [`(,f ,args ...)
-                   (define <-bf (representation-bf->repr (get-representation* (type-of expr ctx))))
+                   (define <-bf (representation-bf->repr (get-representation* (type-of expr (*var-reprs*)))))
                    (define arg<-bfs
                      (for/list ([arg args])
-                       (representation-bf->repr (get-representation* (type-of arg ctx)))))
+                       (representation-bf->repr (get-representation* (type-of arg (*var-reprs*))))))
 
                    (define argexacts
                      (flip-lists (map (compose car (curryr localize-on-expression vars cache repr)) args)))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -75,7 +75,7 @@
 ;; The rewriter
 
 (define (rewrite-expression expr #:rules rules #:root [root-loc '()] #:destruct [destruct? #f])
-  (define type (type-of expr (*var-precs*)))
+  (define type (type-of expr (*var-reprs*)))
   (reap [sow]
     (for ([rule rules] #:when (equal? type (rule-otype rule)))
       (let* ([result (rule-apply rule expr)])
@@ -83,7 +83,7 @@
             (sow (list (change rule root-loc (cdr result)))))))))
 
 (define (rewrite-expression-head expr #:rules rules #:root [root-loc '()] #:depth [depth 1])
-  (define type (type-of expr (*var-precs*)))
+  (define type (type-of expr (*var-reprs*)))
   (define (rewriter sow expr ghead glen loc cdepth)
     ; expr _ _ _ _ -> (list (list change))
     (for ([rule rules] #:when (equal? type (rule-otype rule)))

--- a/src/core/periodicity.rkt
+++ b/src/core/periodicity.rkt
@@ -91,9 +91,8 @@
       [(list (or 'lambda 'λ) (list vars ...) body)
        `(λ ,vars ,(loop body (cons 2 loc)))]
       [(? constant? c)
-       (define repr (get-representation (*output-prec*)))
        ;; TODO : Do something more intelligent with 'PI
-       (let ([val (if (rational? c) c (->flonum c repr))])
+       (let ([val (if (rational? c) c (->flonum c (*output-repr*)))])
          (annotation val (reverse loc) 'constant val))]
       [(? variable? x)
        (annotation x (reverse loc) 'linear `((,x . 1)))]

--- a/src/core/periodicity.rkt
+++ b/src/core/periodicity.rkt
@@ -183,7 +183,8 @@
 				    (prepare-points
 				     program
                                      `(and ,@(for/list ([(var period) (lp-periods ploc)])
-                                               `(<= 0 ,var ,(* 2 pi var)))))])
+                                               `(<= 0 ,var ,(* 2 pi var))))
+                                     (*output-repr*))])
 			       (parameterize ([*pcontext* context])
 				 (improve-func (make-alt program)))))))
 		     plocs)]

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -18,7 +18,7 @@
   (let loop ([expr expr])
     (match expr
       [`(pow ,base ,(? real?))
-       (when (equal? (type-of base (*var-precs*)) 'complex)
+       (when (equal? (type-of base (*var-reprs*)) 'complex)
          (error "Bad pow!!!" expr*))]
       [(list f args ...)
        (for-each loop args)]
@@ -276,6 +276,6 @@
     [`(1/2 . ,x) `(sqrt ,x)]
     [`(-1/2 . ,x) `(/ 1 (sqrt ,x))]
     [`(,power . ,x)
-     (match (type-of x (*var-precs*))
+     (match (type-of x (*var-reprs*))
        [(or 'real 'binary64 'binary32) `(pow ,x ,power)]
        ['complex `(pow ,x (complex ,power 0))])]))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -61,7 +61,7 @@
   ;; We can only binary search if the branch expression is critical
   ;; for all of the alts and also for the start prgoram.
   (filter
-   (λ (e) (equal? (representation-type (get-representation* (type-of e (*var-precs*)))) 'real))
+   (λ (e) (equal? (representation-type (get-representation* (type-of e (*var-reprs*)))) 'real))
    (set-intersect start-critexprs (apply set-union alt-critexprs))))
   
 ;; Requires that expr is not a λ expression
@@ -152,8 +152,8 @@
 (module+ test
   (parameterize ([*start-prog* '(λ (x) 1)]
                  [*pcontext* (mk-pcontext '((0.5) (4.0)) '(1.0 1.0))]
-                 [*var-precs* '((x . binary64))]
-                 [*output-prec* 'binary64])
+                 [*var-reprs* (list (cons 'x (get-representation 'binary64)))]
+                 [*output-repr* (get-representation 'binary64)])
     (define alts (map (λ (body) (make-alt `(λ (x) ,body))) (list '(fmin x 1) '(fmax x 1))))
     (define repr (get-representation 'binary64))
 
@@ -207,7 +207,7 @@
       (set! iters (+ 1 iters))
       (parameterize ([*num-points* (*binary-search-test-points*)]
                      [*timeline-disabled* true]
-                     [*var-precs* (cons (cons var precision) (*var-precs*))])
+                     [*var-reprs* (dict-set (*var-reprs*) var repr)])
         (define ctx
           (prepare-points start-prog `(== ,(caadr start-prog) ,v) precision))
         (< (errors-score (errors prog1 ctx repr))
@@ -341,8 +341,8 @@
 
 (module+ test
   (parameterize ([*start-prog* '(λ (x y) (/ x y))]
-                 [*var-precs* '((x . binary64) (y . binary64))]
-                 [*output-prec* 'binary64])
+                 [*var-reprs* (map (curryr cons (get-representation 'binary64)) '(x y))]
+                 [*output-repr* (get-representation 'binary64)])
     (define sps
       (list (sp 0 '(/ y x) -inf.0)
             (sp 2 '(/ y x) 0.0)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -149,7 +149,7 @@
 
 (module+ test
   (require "../interface.rkt" (submod "../syntax/rules.rkt" internals))
-  (*var-precs* (map (curryr cons (get-representation 'binary64)) '(x a b c)))
+  (*var-reprs* (map (curryr cons (get-representation 'binary64)) '(x a b c)))
   
   (define all-simplify-rules
     (for/append ([rec (*rulesets*)])

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -149,7 +149,7 @@
 
 (module+ test
   (require "../interface.rkt" (submod "../syntax/rules.rkt" internals))
-  (*var-precs* '((x . binary64) (a . binary64) (b . binary64) (c . binary64)))
+  (*var-precs* (map (curryr cons (get-representation 'binary64)) '(x a b c)))
   
   (define all-simplify-rules
     (for/append ([rec (*rulesets*)])

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -9,8 +9,7 @@
          </total <=/total =-or-nan? nan?-all-types ordinary-value?
          exact-value? val-to-type flval
          ->flonum ->bf random-generate fl->repr repr->fl value->string
-         <-all-precisions mk-<= special-value?
-         get-representation* representation-type)
+         <-all-precisions mk-<= special-value? get-representation*)
 
 (define (get-representation* x)
   (match x
@@ -166,12 +165,6 @@
     (if (eq? (representation-name repr) 'complex)
       (bf x)
       ((representation-repr->bf repr) x))]))
-
-(define (representation-type repr)
-  (match (representation-name repr)
-    ['binary64 'real]
-    ['binary32 'real]
-    [x x]))
 
 (define (<-all-precisions x1 x2 repr)
   (cond

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -174,16 +174,15 @@
     (define ->ordinal (representation-repr->ordinal repr))
     (< (->ordinal x1) (->ordinal x2))]))
 
-(define (mk-<= precision var val)
-  (define repr (get-representation precision))
+(define (mk-<= repr var val)
   (define (cast x)
-    (match precision
+    (match (representation-name repr)
       ['posit8 `(real->posit8 ,x)] ['posit16 `(real->posit16 ,x)] ['posit32 `(real->posit32 ,x)]
       ['quire8 `(real->quire8 ,x)] ['quire16 `(real->quire16 ,x)] ['quire32 `(real->quire32 ,x)]
       [(or 'binary64 'binary32) x]))
   (define prec-point (cast (repr->fl val repr)))
   (define <=-operator
-    (match precision
+    (match (representation-name repr)
       [(or 'binary64 'binary32) '<=] 
       ['posit8 `<=.p8] ['posit16 `<=.p16] ['posit32 `<=.p32]
       ['quire8 `<=.p8] ['quire16 `<=.q16] ['quire32 `<=.q32]))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -2,12 +2,12 @@
 
 (require math/bigfloat math/flonum "bigcomplex.rkt")
 
-(provide (struct-out representation) get-representation *output-prec* *var-precs*)
+(provide (struct-out representation) get-representation *output-repr* *var-reprs* representation-type)
 (module+ internals (provide define-representation))
 
 ;; Global precision tacking
-(define *output-prec* (make-parameter '()))
-(define *var-precs* (make-parameter '()))
+(define *output-repr* (make-parameter '()))
+(define *var-reprs* (make-parameter '()))
 
 ;; Structs
 
@@ -23,6 +23,12 @@
 (define (get-representation name)
   (hash-ref representations name
             (λ () (error 'get-representation "Unknown representation ~a" name))))
+
+(define (representation-type repr)
+  (match (representation-name repr)
+    ['binary64 'real]
+    ['binary32 'real]
+    [x x]))
 
 (define-syntax-rule (define-representation name args ...)
   (begin

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -106,7 +106,7 @@
       (when (null? (range-table-ref range-table var))
         (raise-herbie-error "No valid values of variable ~a" var
                             #:url "faq.html#no-valid-values"))
-      (get-representation (dict-ref (*var-precs*) var))))
+      (dict-ref (*var-reprs*) var)))
   ;; TODO(interface): range tables do not handle representations right now
   ;; They produce +-inf endpoints, which aren't valid values in generic representations
   (if (set-member? '(binary32 binary64) precision)
@@ -264,10 +264,9 @@
 
 (define (filter-p&e pts exacts)
   "Take only the points and exacts for which the exact value and the point coords are ordinary"
-  (define repr (get-representation (*output-prec*)))
   (for/lists (ps es)
-      ([pt pts] [ex exacts] #:when (ordinary-value? ex repr)
-                            #:when (andmap (curryr ordinary-value? repr) pt))
+      ([pt pts] [ex exacts] #:when (ordinary-value? ex (*output-repr*))
+                            #:when (andmap (curryr ordinary-value? (*output-repr*)) pt))
     (values pt ex)))
 
 (define (extract-sampled-points allvars precondition)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -112,7 +112,7 @@
   (define fn
     `(λ ,(program-variables prog)
        (let (,@(for/list ([var (program-variables prog)])
-                 (define repr (get-representation (dict-ref (*var-precs*) var)))
+                 (define repr (dict-ref (*var-reprs*) var))
                  `[,var (,(curry real->precision repr) ,var)]))
          (,precision->real ,(compile body*)))))
   (common-eval fn))
@@ -141,7 +141,7 @@
   (check-equal? (eval-application 'exp 2) #f)) ; Not exact
 
 (module+ test
-  (*var-precs* '((a . binary64) (b . binary64) (c . binary64)))
+  (*var-reprs* (map (curryr cons (get-representation 'binary64)) '(a b c)))
   (require math/bigfloat)
   (define tests
     #hash([(λ (a b c) (/ (- (sqrt (- (* b b) (* a c))) b) a))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -54,7 +54,7 @@
         (timeline-event! 'sample)
         (define newcontext
           (parameterize ([*num-points* (*reeval-pts*)])
-            (prepare-points (test-specification test) (test-precondition test) output-prec)))
+            (prepare-points (test-specification test) (test-precondition test) output-repr)))
         (timeline-event! 'end)
         (define end-err (errors-score (errors (alt-program alt) newcontext output-repr)))
 

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -38,8 +38,9 @@
      (define-ruleset name groups #:type () [rname input output] ...)]
     [(define-ruleset name groups #:type ([var type] ...)
        [rname input output] ...)
-     (begin (define name (list (rule 'rname 'input 'output '((var . type) ...)
-                                     (type-of 'input `((var . ,(get-representation* type)) ...))) ...))
+     (begin
+       (define name (list (rule 'rname 'input 'output '((var . type) ...)
+                                     (type-of 'input `((var . type) ...))) ...))
             (*rulesets* (cons (list name 'groups '((var . type) ...)) (*rulesets*))))]))
 
 ; Commutativity

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -39,7 +39,7 @@
     [(define-ruleset name groups #:type ([var type] ...)
        [rname input output] ...)
      (begin (define name (list (rule 'rname 'input 'output '((var . type) ...)
-                                     (type-of 'input '((var . type) ...))) ...))
+                                     (type-of 'input `((var . ,(get-representation* type)) ...))) ...))
             (*rulesets* (cons (list name 'groups '((var . type) ...)) (*rulesets*))))]))
 
 ; Commutativity

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -36,7 +36,7 @@
 (define (check-rule-correct test-rule ground-truth)
   (match-define (rule name p1 p2 itypes otype) test-rule)
   (define fv (dict-keys itypes))
-  (*var-precs* (for/list ([(v t) (in-dict itypes)]) (cons v (match t ['real 'binary64] [x x]))))
+  (*var-reprs* (for/list ([(v t) (in-dict itypes)]) (cons v (get-representation* t))))
   (define repr (get-representation (match otype ['real 'binary64] [x x])))
 
   (define make-point
@@ -70,7 +70,7 @@
 (define (check-rule-fp-safe test-rule)
   (match-define (rule name p1 p2 itypes otype) test-rule)
   (define fv (dict-keys itypes))
-  (*var-precs* (for/list ([(v t) (in-dict itypes)]) (cons v (match t ['real 'binary64] [x x]))))
+  (*var-reprs* (for/list ([(v t) (in-dict itypes)]) (cons v (get-representation* t))))
   (define repr (get-representation (match otype ['real 'binary64] [x x])))
   (define (make-point)
     (for/list ([v fv])

--- a/src/type-check.rkt
+++ b/src/type-check.rkt
@@ -38,9 +38,9 @@
     [(? complex?) 'complex]
     ;; TODO(interface): Once we update the syntax checker to FPCore 1.1
     ;; standards, this will have to have more information passed in
-    [(? value?) (*output-prec*)]
+    [(? value?) (representation-type (*output-repr*))]
     [(? constant?) (constant-info expr 'type)]
-    [(? variable?) (dict-ref env expr)]
+    [(? variable?) (representation-type (dict-ref env expr))]
     [(list 'if cond ift iff)
      (type-of ift env)]
     [(list op args ...)

--- a/src/type-check.rkt
+++ b/src/type-check.rkt
@@ -31,6 +31,8 @@
   (unless (null? errs)
     (raise-herbie-syntax-error "Program has type errors" #:locations errs)))
 
+;; `env` is in an indeterminate state, where it's a mapping from
+;; variables to *either* types or reprs.
 (define (type-of expr env)
   ;; Fast version does not recurse into functions applications
   (match expr
@@ -40,7 +42,10 @@
     ;; standards, this will have to have more information passed in
     [(? value?) (representation-type (*output-repr*))]
     [(? constant?) (constant-info expr 'type)]
-    [(? variable?) (representation-type (dict-ref env expr))]
+    [(? variable?)
+     (match (dict-ref env expr)
+       [(? symbol? t) t]
+       [(? representation? r) (representation-type r)])]
     [(list 'if cond ift iff)
      (type-of ift env)]
     [(list op args ...)

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -247,6 +247,7 @@
                  baseline-error oracle-error all-alts)
    result)
    (define precision (test-output-prec test))
+   (define repr (get-representation precision))
    ;; render-history expects the precision to be 'real rather than 'binary64 or 'binary32
    ;; remove this when the number system interface is added
 
@@ -334,7 +335,7 @@
        (section ([id "history"])
         (h1 "Derivation")
         (ol ([class "history"])
-         ,@(parameterize ([*output-prec* precision] [*var-precs* (map (curryr cons precision) (test-vars test))])
+         ,@(parameterize ([*output-repr* repr] [*var-reprs* (map (curryr cons repr) (test-vars test))])
              (render-history end-alt (mk-pcontext newpoints newexacts) (mk-pcontext points exacts) precision))))
 
        ,(render-reproduction test)))


### PR DESCRIPTION
This PR converts the two global variables `*output-prec*` and `*var-precs*` to store representations (a struct), not precisions (a name). It furthermore changes a variety of functions throughout Herbie to expect representations, not precisions, as arguments. In doing so it removes a little bit of redundant code.

It thereby also merges the branch `interface2`, DavidThien@ac3682e.