### PR TITLE
Better pruning statistics

### DIFF
--- a/src/biginterval.rkt
+++ b/src/biginterval.rkt
@@ -523,7 +523,7 @@
 
 (define (ival-==2 x y)
   (define-values (c< m< c> m>) (ival-cmp x y))
-  (ival (and (not c<) (not c>)) (or (not m<) (not m>)) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
+  (ival (and (not c<) (not c>)) (and (not m<) (not m>)) (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
 
 (define (ival-comparator f name)
   (procedure-rename

--- a/src/web/report.css
+++ b/src/web/report.css
@@ -247,6 +247,8 @@ table.times { border-spacing: 15px 5px; }
 table th { text-align: left; }
 table.times td { text-align: right; min-width: 8ex; vertical-align: baseline; }
 table.times td:last-child { text-align: left; }
+table.states { min-width: 50%; }
+table.states td:last-child, table.states tfoot { font-weight: bold; }
 table pre { padding: 0; margin: 0; text-align: left; font-size: 110%; }
 
 /* Timeline colors */


### PR DESCRIPTION
The pruning block in the metrics now shows four initial states (new alts, fresh alts, the picked alt, and done alts) and whether each was kept or pruned.

Also fixes a problem in the `==` interval method.