### PR TITLE
Turn better-rr on by default

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -13,7 +13,7 @@
 (define default-flags
   #hash([precision . (double fallback)]
         [setup . (simplify)]
-        [generate . (rr taylor simplify)]
+        [generate . (rr taylor simplify better-rr)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic complex special bools branches)]))
 

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -189,11 +189,16 @@
      (negate (compose (curry set-member? prog-set) alt-program))
      (remove-duplicates altns #:key alt-program)))
   (timeline-log! 'filtered (list (length altns*) (length altns)))
-  (for/fold ([atab atab]) ([altn altns*])
-    (atab-add-altn atab altn repr)))
+  (cond
+   [(null? altns*)
+    atab]
+   [else
+    (define progs (map alt-program altns*))
+    (define errss (apply vector-map list (batch-errors progs (alt-table-context atab) repr)))
+    (for/fold ([atab atab]) ([altn (in-list altns*)] [errs (in-vector errss)])
+      (atab-add-altn atab altn errs repr))]))
 
-(define (atab-add-altn atab altn repr)
-  (define errs (errors (alt-program altn) (alt-table-context atab) repr))
+(define (atab-add-altn atab altn errs repr)
   (match-define (alt-table point->alts alt->points _ _) atab)
   (define-values (best-pnts tied-pnts) (best-and-tied-at-points atab altn errs))
   (cond

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -84,8 +84,7 @@
   (define type (type-of expr (*var-reprs*)))
   (define (rewriter sow expr ghead glen loc cdepth)
     ; expr _ _ _ _ -> (list (list change))
-    (for ([rule rules] #:when (equal? type (rule-otype rule))
-          #:when (list? (rule-input rule)))
+    (for ([rule rules] #:when (equal? type (rule-otype rule)))
       (when (or
              (not ghead) ; Any results work for me
              (and

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -84,7 +84,8 @@
   (define type (type-of expr (*var-reprs*)))
   (define (rewriter sow expr ghead glen loc cdepth)
     ; expr _ _ _ _ -> (list (list change))
-    (for ([rule rules] #:when (equal? type (rule-otype rule)))
+    (for ([rule rules] #:when (equal? type (rule-otype rule))
+          #:when (list? (rule-input rule)))
       (when (or
              (not ghead) ; Any results work for me
              (and

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -4,8 +4,8 @@
 (require "float.rkt" "common.rkt" "programs.rkt" "config.rkt" "errors.rkt" "timeline.rkt"
          "biginterval.rkt" "interface.rkt")
 
-(provide *pcontext* in-pcontext mk-pcontext pcontext?
-         prepare-points errors errors-score
+(provide *pcontext* in-pcontext mk-pcontext pcontext? prepare-points
+         errors batch-errors errors-score
          oracle-error baseline-error oracle-error-idx)
 
 (module+ test (require rackunit))
@@ -194,6 +194,13 @@
   (for/list ([(point exact) (in-pcontext pcontext)])
     (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" prog point) (raise e))])
       (point-error (apply fn point) exact repr))))
+
+(define (batch-errors progs pcontext repr)
+  (define fn (compose vector (batch-eval-progs progs 'fl repr)))
+  (for/list ([(point exact) (in-pcontext pcontext)])
+    (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" progs point) (raise e))])
+      (for/vector ([out (apply fn point)])
+        (point-error out exact repr)))))
 
 ;; Old, halfpoints method of sampling points
 

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -261,12 +261,6 @@
   [rem-cbrt-cube     (cbrt (pow x 3)) x]
   [cube-neg          (pow (- x) 3)    (- (pow x 3))])
 
-(define-ruleset cubes-distribute (arithmetic simplify)
-  #:type ([x real] [y real])
-  [cube-prod       (pow (* x y) 3) (* (pow x 3) (pow y 3))]
-  [cube-div        (pow (/ x y) 3) (/ (pow x 3) (pow y 3))]
-  [cube-mult       (pow x 3)       (* x (* x x))])
-
 (define-ruleset cubes-transform (arithmetic)
   #:type ([x real] [y real])
   [cbrt-prod         (cbrt (* x y))           (* (cbrt x) (cbrt y))]

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -172,7 +172,7 @@
   (match-define (list to from) filtered)
   (if (> from 0)
       `((dt "Filtered") (dd ,(~a from) " candidates to " ,(~a to) " candidates"
-                            " (" ,(~r (* (/ to from) 100) #:precision '(= 1)) "%)"))
+                            " (" ,(~r (* (- 1 (/ to from)) 100) #:precision '(= 1)) "%)"))
       '()))
 
 (define (render-phase-outcomes outcomes)
@@ -350,7 +350,7 @@
   (define to (apply + tos))
   (if (> from 0)
       `((dt "Filtered") (dd ,(~a (apply + froms)) " candidates to " ,(~a to) " candidates"
-                            " (" ,(~r (* (/ to from) 100) #:precision '(= 1)) "%)"))
+                            " (" ,(~r (* (- 1 (/ to from)) 100) #:precision '(= 1)) "%)"))
       '()))
 
 


### PR DESCRIPTION
Now that recursive rewrite is fast, and also now that simplification is fast, we can turn on better-rr, leading to slightly better results without significant downside.

I tested this change on the full Herbie suite and found no significant downsides. Discounting a timeout that didn't happen with the flag on, there was an improvement of 21 bits of accuracy (0.34%) with no downsides anywhere in the process.

On `master`, without and then with the `better-rr` flag:
- 1.4hr → 1.2hr
- 3856/6031b → 3880/6034b
- 279/337 passed

Timing:
- Sampling 27m (12m sampling unsampleable points)
- Series 19m
- Prune 14m → 12m
- Rewrite 10m → 2m

Accuracy:
- Regimes 21.8%

