### PR TITLE
Fix use of NAN as the failure value in ival-eval

### DIFF
--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -122,11 +122,11 @@
        (cons (apply * (map car terms)) (apply append (map cdr terms))))]
     [`(/ ,arg)
      (let ([terms (gather-multiplicative-terms arg)])
-       (cons (if (= (car terms) 0) +nan.0 (/ (car terms))) (map negate-term (cdr terms))))]
+       (cons (if (= (car terms) 0) 'NAN (/ (car terms))) (map negate-term (cdr terms))))]
     [`(/ ,arg ,args ...)
      (let ([num (gather-multiplicative-terms arg)]
            [dens (map gather-multiplicative-terms args)])
-       (cons (if (ormap (compose (curry = 0) car) dens) +nan.0 (apply / (car num) (map car dens)))
+       (cons (if (ormap (compose (curry = 0) car) dens) 'NAN (apply / (car num) (map car dens)))
              (append (cdr num)
                      (map negate-term (append-map cdr dens)))))]
     [`(sqrt ,arg)

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -16,6 +16,8 @@
            (write (option-split-indices opt) port)
            (display ">" port))])
 
+;; TODO: splitpoint lists sp ends with +nan.0. These is suspect, for multi-precision, but I think is sound.
+
 ;; Struct representing a splitpoint
 ;; cidx = Candidate index: the index of the candidate program that should be used to the left of this splitpoint
 ;; bexpr = Branch Expression: The expression that this splitpoint should split on
@@ -322,7 +324,7 @@
 
 (define (splitpoints->point-preds splitpoints alts repr)
   (assert (= (set-count (list->set (map sp-bexpr splitpoints))) 1))
-  (assert (nan? (sp-point (last splitpoints))))
+  (assert (equal? (sp-point (last splitpoints)) +nan.0))
 
   (define vars (program-variables (alt-program (first alts))))
   (define expr `(λ ,vars ,(sp-bexpr (car splitpoints))))
@@ -332,7 +334,7 @@
     (λ (pt)
       (define val (apply prog pt))
       (for/first ([right splitpoints]
-                  #:when (or (nan?-all-types (sp-point right) repr)
+                  #:when (or (equal? (sp-point right) +nan.0)
                              (<=/total val (sp-point right) repr)))
         ;; Note that the last splitpoint has an sp-point of +nan.0, so we always find one
         (equal? (sp-cidx right) i)))))

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -152,8 +152,12 @@
       (define ex
         (and pre (ival-eval body-fn pt repr #:log (point-logger 'body log prog))))
 
+      (define success
+        ;; +nan.0 is the "error" return code for ival-eval
+        (and (not (equal? pre +nan.0)) (not (equal? ex +nan.0))))
+
       (cond
-       [(and (andmap (curryr ordinary-value? repr) pt) pre (ordinary-value? ex repr))
+       [(and success (andmap (curryr ordinary-value? repr) pt) pre (ordinary-value? ex repr))
         (if (>= sampled (- (*num-points*) 1))
             (values points exacts)
             (loop (+ 1 sampled) 0 (cons pt points) (cons ex exacts)))]

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -58,9 +58,11 @@
   (define ex2 (map prog2 points))
   (define errs
     (for/list ([pt points] [v1 ex1] [v2 ex2]
+               ;; Error code from ival-eval
                #:unless (or (eq? v1 +nan.0) (eq? v2 +nan.0))
-               #:when (and (ordinary-value? v1 repr)
-                           (ordinary-value? v2 repr)))
+               ;; Ignore rules that compute to bad values
+               #:when (ordinary-value? v1 repr)
+               #:when (ordinary-value? v2 repr))
       (with-check-info (['point (map cons fv pt)] ['method (object-name ground-truth)]
                         ['input v1] ['output v2])
         (check-eq? (ulp-difference v1 v2 repr) 0))))


### PR DESCRIPTION
Our use of NAN as a failure value currently breaks `posit` support. This should fix that.