### PR TITLE
Batch eval-prog

### DIFF
--- a/src/points.rkt
+++ b/src/points.rkt
@@ -5,8 +5,8 @@
 (require "float.rkt" "common.rkt" "programs.rkt" "config.rkt" "errors.rkt" "timeline.rkt"
          "interface.rkt")
 
-(provide *pcontext* in-pcontext mk-pcontext pcontext?
-         prepare-points errors errors-score
+(provide *pcontext* in-pcontext mk-pcontext pcontext? prepare-points
+         errors batch-errors errors-score
          oracle-error baseline-error oracle-error-idx)
 
 (module+ test (require rackunit))
@@ -212,6 +212,13 @@
   (for/list ([(point exact) (in-pcontext pcontext)])
     (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" prog point) (raise e))])
       (point-error (apply fn point) exact repr))))
+
+(define (batch-errors progs pcontext repr)
+  (define fn (compose vector (batch-eval-progs progs 'fl repr)))
+  (for/list ([(point exact) (in-pcontext pcontext)])
+    (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" progs point) (raise e))])
+      (for/vector ([out (apply fn point)])
+        (point-error out exact repr)))))
 
 ;; Old, halfpoints method of sampling points
 

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -217,7 +217,7 @@
   (define fn (batch-eval-progs progs 'fl repr))
   (for/list ([(point exact) (in-pcontext pcontext)])
     (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" progs point) (raise e))])
-      (for/vector ([out (apply fn point)])
+      (for/vector ([out (in-vector (apply fn point))])
         (point-error out exact repr)))))
 
 ;; Old, halfpoints method of sampling points

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -214,7 +214,7 @@
       (point-error (apply fn point) exact repr))))
 
 (define (batch-errors progs pcontext repr)
-  (define fn (compose vector (batch-eval-progs progs 'fl repr)))
+  (define fn (batch-eval-progs progs 'fl repr))
   (for/list ([(point exact) (in-pcontext pcontext)])
     (with-handlers ([exn:fail? (λ (e) (eprintf "Error when evaluating ~a on ~a\n" progs point) (raise e))])
       (for/vector ([out (apply fn point)])

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -140,9 +140,10 @@
        (let (,@(for/list ([var (in-list vars)])
                  (define repr (dict-ref (*var-reprs*) var))
                  `[,var (,(curry real->precision repr) ,var)]))
-         (values
-          ,@(for/list ([prog (in-list progs)])
-              `(,precision->real ,(compile (munge prog))))))))
+         ,(compile
+           (values
+            ,@(for/list ([prog (in-list progs)])
+                `(,precision->real ,(munge prog))))))))
   (common-eval fn))
 
 (define (eval-application op . args)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -141,9 +141,9 @@
                  (define repr (dict-ref (*var-reprs*) var))
                  `[,var (,(curry real->precision repr) ,var)]))
          ,(compile
-           (values
-            ,@(for/list ([prog (in-list progs)])
-                `(,precision->real ,(munge prog))))))))
+           (cons 'values
+                 (for/list ([prog (in-list progs)])
+                   `(,precision->real ,(munge prog))))))))
   (common-eval fn))
 
 (define (eval-application op . args)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -101,7 +101,8 @@
     (location-do loc prog return)))
 
 (define (eval-prog prog mode repr)
-  (vector-ref (batch-eval-progs (list prog) mode repr) 0))
+  (define f (batch-eval-progs (list prog) mode repr))
+  (λ (x) (vector-ref (f x) 0)))
 
 (define (batch-eval-progs progs mode repr)
   ; Keep exact numbers exact

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -12,8 +12,7 @@
          location-hash
          location? expr?
          location-do location-get
-         eval-prog eval-application
-         compile
+         batch-eval-prog eval-prog eval-application
          free-variables replace-expression
          desugar-program resugar-program)
 
@@ -102,6 +101,9 @@
     (location-do loc prog return)))
 
 (define (eval-prog prog mode repr)
+  (batch-eval-progs (list prog) mode repr))
+
+(define (batch-eval-progs progs mode repr)
   ; Keep exact numbers exact
   ;; TODO(interface): Right now, real->precision and precision->real are
   ;; mixed up for bf and fl because there is a mismatch between the fpbench
@@ -121,7 +123,7 @@
     ['ival identity]
     ['nonffi identity]))
 
-  (define body*
+  (define (munge prog)
     (let inductor ([prog (program-body prog)])
       (match prog
         [(? value?) (real->precision repr prog)]
@@ -131,12 +133,16 @@
          (cons (operator-info op mode) (map inductor args))]
         [_ (error (format "Invalid program ~a" prog))])))
 
+  (define vars (program-variables (first progs)))
+
   (define fn
-    `(λ ,(program-variables prog)
-       (let (,@(for/list ([var (program-variables prog)])
+    `(λ ,vars
+       (let (,@(for/list ([var (in-list vars)])
                  (define repr (dict-ref (*var-reprs*) var))
                  `[,var (,(curry real->precision repr) ,var)]))
-         (,precision->real ,(compile body*)))))
+         (values
+          ,@(for/list ([prog (in-list progs)])
+              `(,precision->real ,(compile (munge prog))))))))
   (common-eval fn))
 
 (define (eval-application op . args)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -101,7 +101,7 @@
     (location-do loc prog return)))
 
 (define (eval-prog prog mode repr)
-  (batch-eval-progs (list prog) mode repr))
+  (vector-ref (batch-eval-progs (list prog) mode repr) 0))
 
 (define (batch-eval-progs progs mode repr)
   ; Keep exact numbers exact
@@ -141,7 +141,7 @@
                  (define repr (dict-ref (*var-reprs*) var))
                  `[,var (,(curry real->precision repr) ,var)]))
          ,(compile
-           (cons 'values
+           (cons 'vector
                  (for/list ([prog (in-list progs)])
                    `(,precision->real ,(munge prog))))))))
   (common-eval fn))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -102,7 +102,7 @@
 
 (define (eval-prog prog mode repr)
   (define f (batch-eval-progs (list prog) mode repr))
-  (λ (x) (vector-ref (f x) 0)))
+  (λ args (vector-ref (apply f args) 0)))
 
 (define (batch-eval-progs progs mode repr)
   ; Keep exact numbers exact

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -12,7 +12,7 @@
          location-hash
          location? expr?
          location-do location-get
-         batch-eval-prog eval-prog eval-application
+         batch-eval-progs eval-prog eval-application
          free-variables replace-expression
          desugar-program resugar-program)
 

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -176,7 +176,7 @@
   (match-define (list to from) filtered)
   (if (> from 0)
       `((dt "Filtered") (dd ,(~a from) " candidates to " ,(~a to) " candidates"
-                            " (" ,(~r (* (/ to from) 100) #:precision '(= 1)) "%)"))
+                            " (" ,(~r (* (- 1 (/ to from)) 100) #:precision '(= 1)) "%)"))
       '()))
 
 (define (render-phase-outcomes outcomes)
@@ -355,7 +355,7 @@
   (define to (apply + tos))
   (if (> from 0)
       `((dt "Filtered") (dd ,(~a (apply + froms)) " candidates to " ,(~a to) " candidates"
-                            " (" ,(~r (* (/ to from) 100) #:precision '(= 1)) "%)"))
+                            " (" ,(~r (* (- 1 (/ to from)) 100) #:precision '(= 1)) "%)"))
       '()))
 
 


### PR DESCRIPTION
I often find that `eval-prog` is between 10% and 20% of Herbie's runtime. Almost all of that happens in `atab-add-altns`, because we have to evaluate each `alt` to decide which ones to keep. In extreme cases, that means evaluating 20,000 expressions to figure out which one expression to keep.

This PR speeds this up by adding a `batch-eval-prog` function that evaluates multiple expressions on the same point. Since candidates are mostly quite similar, they'll have a lot of shared subexpressions, and `batch-eval-prog` can avoid recomputing them.