### PR TITLE
Test single-precision mode

### DIFF
--- a/.github/workflows/hamming.yml
+++ b/.github/workflows/hamming.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         racket-version: [ '7.5', '7.6', '7.7' ]
+        precision: [ 'binary32', 'binary64' ]
     steps:
       - name: "Install Packages"
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
@@ -18,4 +19,4 @@ jobs:
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: raco pkg install --name herbie --no-cache --auto src/
-      - run: racket infra/travis.rkt --seed 0 bench/hamming/
+      - run: racket infra/travis.rkt --precision ${{ matrix.precision }} --seed 0 bench/hamming/

--- a/infra/travis.rkt
+++ b/infra/travis.rkt
@@ -8,6 +8,8 @@
 ;; Load all the plugins
 (load-herbie-plugins)
 
+(define *precision* (make-parameter 'binary64))
+
 (define (test-successful? test input-bits target-bits output-bits)
   (match* ((test-output test) (test-expected test))
     [(_ #f) #t]
@@ -19,9 +21,14 @@
   (define tests (append-map load-tests bench-dirs))
   (define seed (pseudo-random-generator->vector (current-pseudo-random-generator)))
   (printf "Running Herbie on ~a tests, seed: ~a\n" (length tests) seed)
-  (for/and ([test tests] [i (in-naturals)])
+  (for/and ([the-test tests] [i (in-naturals)])
     (printf "~a/~a\t" (~a (+ 1 i) #:width 3 #:align 'right) (length tests))
-    (match (get-test-result test #:seed seed)
+    (define the-test* (struct-copy test the-test
+                                   [output-prec (*precision*)]
+                                   [var-precs
+                                    (for/list ([(var prec) (in-dict (test-var-precs the-test))])
+                                      (cons var (*precision*)))]))
+    (match (get-test-result the-test* #:seed seed)
       [(test-success test bits time timeline warnings
                      start-alt end-alt points exacts start-est-error end-est-error
                      newpoints newexacts start-error end-error target-error
@@ -64,5 +71,7 @@
    [("--seed") rs "The random seed to use in point generation. If false (#f), a random seed is used'"
     (define given-seed (read (open-input-string rs)))
     (when given-seed (set-seed! given-seed))]
+   [("--precision") prec "Which precision to use for tests"
+    (*precision* (string->symbol prec))]
    #:args bench-dir
    (exit (if (apply run-tests bench-dir) 0 1))))


### PR DESCRIPTION
This adds a matrix of tests to run both `binary32` and `binary64` for the Hamming tests. A nice side benefit is that the single-precision tests run really fast (presumably because there just isn't much to do).

The `:herbie-expected` flags are weaker than intended, but on the other hand we only have two of them. We might want to totally kill this at some point and just use targets.