### PR TITLE
Important fixes to single-precision support

### DIFF
--- a/bench/hamming/quadratic.fpcore
+++ b/bench/hamming/quadratic.fpcore
@@ -2,6 +2,7 @@
 
 (FPCore (a b c)
  :name "quadp (p42, positive)"
+ :herbie-expected #f ; Fails in single precision due to bad samples
  :herbie-target
  (let ([d (sqrt (- (* b b) (* 4 (* a c))))])
    (let ([r1 (/ (+ (- b) d) (* 2 a))]
@@ -13,6 +14,7 @@
 
 (FPCore (a b c)
  :name "quadm (p42, negative)"
+ :herbie-expected #f ; Fails in single precision due to bad samples
  :herbie-target
  (let ((d (sqrt (- (* b b) (* 4 (* a c))))))
    (let ([r1 (/ (+ (- b) d) (* 2 a))] [r2 (/ (- (- b) d) (* 2 a))])

--- a/bench/hamming/rearrangement.fpcore
+++ b/bench/hamming/rearrangement.fpcore
@@ -68,6 +68,7 @@
 
 (FPCore (x)
  :name "exp2 (problem 3.3.7)"
+ :herbie-expected 1.5 ; Fails in single-precision due to regimes threshold
  :herbie-target
  (* 4 (pow (sinh (/ x 2)) 2))
 

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -43,7 +43,9 @@
   ((representation-ordinal->repr repr) (random-bits (representation-total-bits repr))))
 
 (define (special-value? x repr)
-  (set-member? (representation-special-values repr) x))
+  (if (set-member? '(binary32 binary64) (representation-name repr))
+      (ormap (curry = x) (representation-special-values repr))
+      (set-member? (representation-special-values repr) x)))
 
 (define (ordinary-value? x repr)
   (if (and (complex? x) (not (real? x)))

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -44,7 +44,7 @@
 
 (define (special-value? x repr)
   (if (set-member? '(binary32 binary64) (representation-name repr))
-      (ormap (curry = x) (representation-special-values repr))
+      (or (infinite? x) (nan? x))
       (set-member? (representation-special-values repr) x)))
 
 (define (ordinary-value? x repr)
@@ -59,7 +59,11 @@
   (define binary64 (get-representation 'binary64))
   (check-true (ordinary-value? 2.5 binary64))
   (check-false (ordinary-value? +nan.0 binary64))
-  (check-false (ordinary-value? -inf.0 binary64)))
+  (check-false (ordinary-value? -inf.0 binary64))
+  (define binary32 (get-representation 'binary32))
+  (check-true (ordinary-value? 2.5f0 binary32))
+  (check-false (ordinary-value? +nan.f binary32))
+  (check-false (ordinary-value? -inf.f binary32)))
 
 (define (=-or-nan? x1 x2 repr)
   (define ->ordinal (representation-repr->ordinal repr))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -168,7 +168,8 @@
   [clear-num         (/ a b)               (/ 1 (/ b a))])
 
 
-(define-ruleset id-transform-fp-safe (arithmetic simplify fp-safe)
+(define-ruleset id-transform-fp-safe (arithmetic fp-safe)
+  #:type ([a real])
   [*-un-lft-identity a                     (* 1 a)])
 
 ; Difference of cubes

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -160,7 +160,7 @@
   [un-div-inv        (* a (/ 1 b))         (/ a b)]
   [clear-num         (/ a b)               (/ 1 (/ b a))])
 
-(define-ruleset id-transform-fp-safe (arithmetic fp-safe)
+(define-ruleset id-transform-fp-safe (arithmetic simplify fp-safe)
   #:type ([a real] [b real])
   [sub-neg           (- a b)               (+ a (neg b))]
   [unsub-neg         (+ a (neg b))           (- a b)]
@@ -486,8 +486,8 @@
 
 (define-ruleset htrig-expand (hyperbolic)
   #:type ([x real] [y real])
-  [sinh-undef  (/ (- (exp x) (exp (neg x))) 2)                       (sinh x)]
-  [cosh-undef  (/ (+ (exp x) (exp (neg x))) 2)                       (cosh x)]
+  [sinh-undef  (- (exp x) (exp (neg x)))                       (* 2 (sinh x))]
+  [cosh-undef  (+ (exp x) (exp (neg x)))                       (* 2 (cosh x))]
   [tanh-undef  (/ (- (exp x) (exp (neg x))) (+ (exp x) (exp (neg x)))) (tanh x)]
   [cosh-sum    (cosh (+ x y))         (+ (* (cosh x) (cosh y)) (* (sinh x) (sinh y)))]
   [cosh-diff   (cosh (- x y))         (- (* (cosh x) (cosh y)) (* (sinh x) (sinh y)))]

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -154,19 +154,22 @@
   [/-rgt-identity    (/ a 1)               a]
   [mul-1-neg         (* -1 a)              (neg a)])
 
+(define-ruleset nan-transform-fp-safe (arithmetic simplify fp-safe)
+  #:type ([a real] [b real])
+  [sub-neg           (- a b)               (+ a (neg b))]
+  [unsub-neg         (+ a (neg b))           (- a b)]
+  [neg-sub0          (neg b)                 (- 0 b)]
+  [neg-mul-1         (neg a)                 (* -1 a)])
+
 (define-ruleset id-transform (arithmetic)
   #:type ([a real] [b real])
   [div-inv           (/ a b)               (* a (/ 1 b))]
   [un-div-inv        (* a (/ 1 b))         (/ a b)]
   [clear-num         (/ a b)               (/ 1 (/ b a))])
 
+
 (define-ruleset id-transform-fp-safe (arithmetic simplify fp-safe)
-  #:type ([a real] [b real])
-  [sub-neg           (- a b)               (+ a (neg b))]
-  [unsub-neg         (+ a (neg b))           (- a b)]
-  [neg-sub0          (neg b)                 (- 0 b)]
-  [*-un-lft-identity a                     (* 1 a)]
-  [neg-mul-1         (neg a)                 (* -1 a)])
+  [*-un-lft-identity a                     (* 1 a)])
 
 ; Difference of cubes
 (define-ruleset difference-of-cubes (polynomials)


### PR DESCRIPTION
Single-precision was broken because, for some reason, `equal?` doesn't work for `+inf.f` and friends. I tweaked `special-value?` so that it now uses `=` in those cases. This caused some expressions to break, and I looked into them, adding `herbie-expected` where necessary.