### PR TITLE
Update type/repr infrastructure for better plugins

### DIFF
--- a/src/float.rkt
+++ b/src/float.rkt
@@ -35,11 +35,6 @@
 (define (random-generate repr)
   ((representation-ordinal->repr repr) (random-bits (representation-total-bits repr))))
 
-(define (special-value? x repr)
-  (if (set-member? '(binary32 binary64) (representation-name repr))
-      (or (infinite? x) (nan? x))
-      (set-member? (representation-special-values repr) x)))
-
 (define (ordinary-value? x repr)
   (if (and (complex? x) (not (real? x)))
       ;; TODO: Once complex is a separate type rather than a repr, check to see
@@ -87,8 +82,8 @@
     (cond [(nan? x1) #f] [(nan? x2) #t] [else (< x1 x2)])]
    [else
     (cond
-     [(set-member? (representation-special-values repr) x1) #f]
-     [(set-member? (representation-special-values repr) x2) #t]
+     [(special-value? x1 repr) #f]
+     [(special-value? x2 repr) #t]
      [else (< ((representation-repr->ordinal repr) x1)
               ((representation-repr->ordinal repr) x2))])]))
 

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -13,8 +13,7 @@
  </total <=/total =-or-nan?
  exact-value? value->code
  value->string value->json
- ->flonum ->bf
- fl->repr repr->fl)
+ ->bf fl->repr repr->fl)
 
 (define (ulp-difference x y repr)
   (if (and (complex? x) (complex? y) (not (real? x)) (not (real? y)))
@@ -119,15 +118,6 @@
     [(? complex?) (hash 'type "complex" 'real (real-part x) 'imag (imag-part x))]
     [_ (hash 'type (~a repr) 'ordinal (~a ((representation-repr->ordinal repr) x)))]))
 
-(define/contract (->flonum x repr)
-  (-> any/c representation? value?)
-  (define type (representation-type repr))
-  (match x
-   [(? (type-exact? type))
-    ((type-inexact->exact type) ((type-exact->inexact type) x))]
-   [(? (type-inexact? type))
-    ((type-inexact->exact type) x)]))
-
 (define (fl->repr x repr)
   ((representation-bf->repr repr) (bf x)))
 
@@ -160,7 +150,7 @@
   (-> any/c representation? bigvalue?)
   (define type (representation-type repr))
   (cond
-   [(and ((type-exact? type) x) (equal? (type-name type) 'complex)) ;; HACK
+   [(and (equal? (type-name type) 'complex) (complex? x)) ;; HACK
     ((type-exact->inexact type) x)]
    [else
     ;; TODO(interface): ->bf is used to convert syntactic numbers to

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -11,9 +11,8 @@
  ulp-difference ulps->bits
  midpoint random-generate
  </total <=/total =-or-nan?
- exact-value? value->code
  value->string value->json
- ->bf fl->repr repr->fl)
+ ->bf)
 
 (define (ulp-difference x y repr)
   (if (and (complex? x) (complex? y) (not (real? x)) (not (real? y)))
@@ -90,18 +89,6 @@
 (define (<=/total x1 x2 repr)
   (or (</total x1 x2 repr) (=-or-nan? x1 x2 repr)))
 
-(define (exact-value? type val)
-  (match type
-    [(or 'real 'complex) (exact? val)]
-    ['boolean true]
-    [_ false]))
-
-(define (value->code type val)
-  (match type
-    ['real val]
-    ['complex (list 'complex (real-part val) (imag-part val))]
-    ['boolean (if val 'TRUE 'FALSE)]))
-
 (define (value->json x repr)
   (match x
     [(? real?)
@@ -112,12 +99,6 @@
        [(or +nan.0 +nan.f) (hash 'type "real" 'value "NaN")])]
     [(? complex?) (hash 'type "complex" 'real (real-part x) 'imag (imag-part x))]
     [_ (hash 'type (~a repr) 'ordinal (~a ((representation-repr->ordinal repr) x)))]))
-
-(define (fl->repr x repr)
-  ((representation-bf->repr repr) (bf x)))
-
-(define (repr->fl x repr)
-  (bigfloat->flonum ((representation-repr->bf repr) x)))
 
 (define (value->string n repr)
   ;; Prints a number with relatively few digits
@@ -143,6 +124,7 @@
 
 (define/contract (->bf x repr)
   (-> any/c representation? bigvalue?)
+  (printf "->bf ~a with ~a\n" x repr)
   (define type (representation-type repr))
   (cond
    [(and (equal? (type-name type) 'complex) (complex? x)) ;; HACK

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -124,7 +124,6 @@
 
 (define/contract (->bf x repr)
   (-> any/c representation? bigvalue?)
-  (printf "->bf ~a with ~a\n" x repr)
   (define type (representation-type repr))
   (cond
    [(and (equal? (type-name type) 'complex) (complex? x)) ;; HACK

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -5,7 +5,8 @@
 
 (provide (struct-out representation) get-representation
           *output-repr* *var-reprs*
-          real->repr repr->real value?)
+          real->repr repr->real
+          value? special-value?)
 (module+ internals (provide define-representation))
 
 ;; Structs
@@ -34,7 +35,7 @@
   (λ (x) (= x 0))
   (λ (x) (if x 1 0))
   1
-  null)
+  (const #f))
 
 (define (shift bits fn)
   (define shift-val (expt 2 bits))
@@ -50,7 +51,7 @@
   (shift 63 ordinal->flonum)
   (unshift 63 flonum->ordinal)
   64
-  '(+nan.0 +inf.0 -inf.0))
+  (disjoin nan? infinite?))
 
 (define (single-flonum->bit-field x)
   (integer-bytes->integer (real->floating-point-bytes x 4) #f))
@@ -89,7 +90,9 @@
   ordinal->single-flonum
   single-flonum->ordinal
   32
-  '(+nan.f +inf.f -inf.f))
+  (disjoin nan? infinite?))
+
+;; repr <==> real
 
 (define (real->repr x repr)
   (if (real? x)
@@ -101,7 +104,11 @@
 
 ;; Predicates
 
-(define (value? x) (for/or ([(name repr) (in-hash representations)]) ((representation-repr? repr) x)))
+(define (value? x)
+  (for/or ([(name repr) (in-hash representations)]) ((representation-repr? repr) x)))
+
+(define (special-value? x repr)
+  ((representation-special-values repr) x))
 
 ;; Global precision tacking
 (define *output-repr* (make-parameter (get-representation 'binary64)))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -95,9 +95,7 @@
 ;; repr <==> real
 
 (define (real->repr x repr)
-  (if (real? x)
-      ((representation-bf->repr repr) (bf x))
-      ((representation-bf->repr repr) ((representation-repr->bf repr) x))))
+  ((representation-bf->repr repr) ((representation-repr->bf repr) x)))
 
 (define (repr->real x repr)
   (bigfloat->real ((representation-repr->bf repr) x)))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -95,7 +95,9 @@
 ;; repr <==> real
 
 (define (real->repr x repr)
-  ((representation-bf->repr repr) ((representation-repr->bf repr) x)))
+  (match x
+   [(? (representation-repr? repr)) x] ; identity function if x is already a value in the repr
+   [(? real?) ((representation-bf->repr repr) (bf x))]))
 
 (define (repr->real x repr)
   (bigfloat->real ((representation-repr->bf repr) x)))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -96,8 +96,13 @@
 
 (define (real->repr x repr)
   (match x
+   [(? real?) ((representation-bf->repr repr) (bf x))]
    [(? (representation-repr? repr)) x] ; identity function if x is already a value in the repr
-   [(? real?) ((representation-bf->repr repr) (bf x))]))
+   [(? value?) ; value in another repr, convert to new repr through bf
+    (for/first ([(name repr*) (in-hash representations)]
+               #:when ((representation-repr? repr*) x))
+      ((representation-bf->repr repr) ((representation-repr->bf repr*) x)))]
+   [_ (error 'real->repr "Unknown value ~a" x)]))
 
 (define (repr->real x repr)
   (bigfloat->real ((representation-repr->bf repr) x)))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -141,9 +141,9 @@
 (define (taylor-alt altn loc)
   (define expr (location-get loc (alt-program altn)))
   (define vars (free-variables expr))
-  ; breaks with posits
   (if (or (null? vars) ;; `approximate` cannot be called with a null vars list
-          (not (set-member? '(binary64 binary32) (repr-of expr (*output-repr*) (*var-reprs*)))))
+          (not (set-member? '(binary64 binary32) ; currently taylor/reduce breaks with posits
+                            (repr-of expr (*output-repr*) (*var-reprs*)))))
       (list altn)
       (for/list ([transform-type transforms-to-try])
         (match-define (list name f finv) transform-type)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -141,8 +141,9 @@
 (define (taylor-alt altn loc)
   (define expr (location-get loc (alt-program altn)))
   (define vars (free-variables expr))
+  ; breaks with posits
   (if (or (null? vars) ;; `approximate` cannot be called with a null vars list
-          (not (equal? (type-of expr (*output-repr*) (*var-reprs*)) 'real)))
+          (not (set-member? '(binary64 binary32) (repr-of expr (*output-repr*) (*var-reprs*)))))
       (list altn)
       (for/list ([transform-type transforms-to-try])
         (match-define (list name f finv) transform-type)

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -201,7 +201,7 @@
       (let ([curr (map (compose <-bf (call f)) pts)]
             [good? (map (call pre) pts)])
         (if (and prev (andmap (λ (good? old new) (or (not good?) (=-or-nan? old new repr))) good? prev curr))
-            (map (λ (good? x) (if good? x +nan.0)) good? curr)
+            (map (λ (good? x) (if good? x (real->repr +nan.0 repr))) good? curr)
             (loop (+ prec (*precision-step*)) curr))))))
 
 ; warning: this will start at whatever precision exacts happens to be at

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -201,7 +201,7 @@
       (let ([curr (map (compose <-bf (call f)) pts)]
             [good? (map (call pre) pts)])
         (if (and prev (andmap (λ (good? old new) (or (not good?) (=-or-nan? old new repr))) good? prev curr))
-            (map (λ (good? x) (if good? x (real->repr +nan.0 repr))) good? curr)
+            (map (λ (good? x) (if good? x +nan.0)) good? curr)
             (loop (+ prec (*precision-step*)) curr))))))
 
 ; warning: this will start at whatever precision exacts happens to be at

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -292,6 +292,13 @@
          (define-values (ift* rtype) (loop ift prec))
          (define-values (iff* _b) (loop iff prec))
          (values (list 'if cond* ift* iff*) rtype)]
+        [(list '! props ... body)
+         (define props* (apply hash-set* (hash) props))
+         (cond
+           [(hash-has-key? props* ':precision)
+            (define-values (body* _) (loop body (hash-ref props* ':precision)))
+            (values body* prec)]
+           [else (loop body prec)])]
         [(list (or 'neg '-) arg) ; unary minus
          (define-values (arg* atype) (loop arg prec))
          (define op* (get-parametric-operator '- atype))
@@ -333,7 +340,11 @@
          (define prec* (if (set-member? '(TRUE FALSE) expr) 'bool prec))
          (define constant* (get-parametric-constant expr prec*))
          (values constant* (constant-info constant* 'type))]
-        [(? variable?) (values expr (representation-name (dict-ref var-reprs expr)))])))
+        [(? variable?) 
+         (values 
+           expr 
+           (if (equal? (representation-name (dict-ref var-reprs expr)) 'bool) 
+               'bool prec))])))
   expr*)
 
 ;; TODO(interface): This needs to be changed once the syntax checker is updated

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -362,7 +362,7 @@
      (define repr* (get-representation (string->symbol iprec)))
      (define body* (expand-parametric-reverse body repr* full?))
      (if full? 
-        `(! :precision ,(string->symbol iprec) ,body*)
+        `(cast (! :precision ,(string->symbol iprec) ,body*))
         `(,op ,body*))]
     [(list op args ...)
      (define op* (hash-ref parametric-operators-reverse op op))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -6,7 +6,7 @@
 (module+ test (require rackunit))
 
 (provide (all-from-out "syntax/syntax.rkt")
-         program-body program-variables ->flonum ->bf
+         program-body program-variables
          type-of repr-of
          expr-supports?
          location-hash
@@ -120,14 +120,9 @@
   ;; additional check to see if the repr is complex.
   (define real->precision (match mode
     ['bf (λ (repr x) (->bf x repr))]
-    ['fl (λ (repr x) (->flonum x repr))]
+    ['fl (λ (repr x) (real->repr x repr))]
     ['ival (λ (repr x) (if (ival? x) x (mk-ival (->bf x repr))))]
     ['nonffi (λ (repr x) x)]))
-  (define precision->real (match mode
-    ['bf identity]
-    ['fl (curryr ->flonum repr)]
-    ['ival identity]
-    ['nonffi identity]))
   
   (define vars (program-variables (first progs)))
   (define var-reprs (map (curry dict-ref (*var-reprs*)) vars))
@@ -141,7 +136,8 @@
   (define (munge prog repr)
     (define expr
       (match prog
-        [(? value?) (list (const (real->precision repr prog)))]
+        [(? value?) 
+          (list (const (real->precision repr prog)))]
         [(? constant?) (list (constant-info prog mode))]
         [(? variable?) prog]
         [`(if ,c ,t ,f)
@@ -183,7 +179,7 @@
           (vector-ref v arg)))
       (vector-set! v n (apply (car expr) tl)))
     (for/vector ([n (in-list names)])
-      (precision->real (vector-ref v n)))))
+      (vector-ref v n))))
 
 (module+ test
   (*var-reprs* (map (curryr cons (get-representation 'binary64)) '(a b c)))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -38,6 +38,14 @@
     [#`(if #,args ...)
      (error! stx "Invalid `if` expression with ~a arguments (expects 3)" (length args))
      (unless (null? args) (check-expression* (last args) vars error!))]
+    [#`(! #,props ... #,body)
+     (let loop ([props props])
+       (match props
+         [(list) (void)]
+         [(list prop) (error! stx "Expected a value for property ~a" prop)]
+         [(list (app syntax-e (? symbol? prop)) value rest ...) (loop rest)]
+         [(list prop value rest ...) (error! stx "Invalid property ~a" prop)]))
+     (check-expression* body vars error!)]
     [#`(,(? (curry set-member? '(+ - * /))) #,args ...)
      ;; These expand associativity so we don't check the number of arguments
      (for ([arg args]) (check-expression* arg vars error!))]

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -39,12 +39,7 @@
      (error! stx "Invalid `if` expression with ~a arguments (expects 3)" (length args))
      (unless (null? args) (check-expression* (last args) vars error!))]
     [#`(! #,props ... #,body)
-     (let loop ([props props])
-       (match props
-         [(list) (void)]
-         [(list prop) (error! stx "Expected a value for property ~a" prop)]
-         [(list (app syntax-e (? symbol? prop)) value rest ...) (loop rest)]
-         [(list prop value rest ...) (error! stx "Invalid property ~a" prop)]))
+     (check-properties* props '() body)
      (check-expression* body vars error!)]
     [#`(,(? (curry set-member? '(+ - * /))) #,args ...)
      ;; These expand associativity so we don't check the number of arguments

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require math/flonum math/base math/bigfloat math/special-functions)
-(require "../common.rkt" "../errors.rkt" "types.rkt" rival)
+(require "../common.rkt" "../interface.rkt" "../errors.rkt" "types.rkt" rival)
 
 (provide constant? variable? operator? operator-info constant-info get-operator-itype
          get-parametric-operator parametric-operators parametric-operators-reverse

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -549,14 +549,17 @@
 
 ;; Miscellaneous operators ;;
 
+; convert real (or value in another repr) to this repr
+(define (->repr prec)
+  (curry real->repr (get-representation prec)))
+
 (define-operator (cast cast.f64 binary64) binary64
-  [fl identity] [bf identity] [ival #f]
-  [nonffi (curry repr->real (get-representation 'binary64))])
+  [fl (->repr 'binary64)] [bf identity] [ival #f]
+  [nonffi identity])
 
 (define-operator (cast cast.f32 binary32) binary32
-  [fl (curry repr->real (get-representation 'binary32))]
-  [bf identity] [ival #f]
-  [nonffi (curry repr->real (get-representation 'binary32))])
+  [fl (->repr 'binary32)] [bf identity] [ival #f]
+  [nonffi identity])
 
 (define (operator? op)
   (and (symbol? op) (not (equal? op 'if)) (or (hash-has-key? parametric-operators op) (dict-has-key? (cdr operators) op))))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -554,7 +554,7 @@
   [nonffi identity])
 
 (define-operator (cast cast.f32 binary32) binary32
-  [fl identity [bf identity] [ival #f]
+  [fl identity] [bf identity] [ival #f]
   [nonffi identity])
 
 (define (operator? op)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -549,16 +549,12 @@
 
 ;; Miscellaneous operators ;;
 
-; convert real (or value in another repr) to this repr
-(define (->repr prec)
-  (curry real->repr (get-representation prec)))
-
 (define-operator (cast cast.f64 binary64) binary64
-  [fl (->repr 'binary64)] [bf identity] [ival #f]
+  [fl identity] [bf identity] [ival #f]
   [nonffi identity])
 
 (define-operator (cast cast.f32 binary32) binary32
-  [fl (->repr 'binary32)] [bf identity] [ival #f]
+  [fl identity [bf identity] [ival #f]
   [nonffi identity])
 
 (define (operator? op)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -547,6 +547,17 @@
   [fl or-fn] [bf or-fn] [ival ival-or]
   [nonffi or-fn])
 
+;; Miscellaneous operators ;;
+
+(define-operator (cast cast.f64 binary64) binary64
+  [fl identity] [bf identity] [ival #f]
+  [nonffi (curry repr->real (get-representation 'binary64))])
+
+(define-operator (cast cast.f32 binary32) binary32
+  [fl (curry repr->real (get-representation 'binary32))]
+  [bf identity] [ival #f]
+  [nonffi (curry repr->real (get-representation 'binary32))])
+
 (define (operator? op)
   (and (symbol? op) (not (equal? op 'if)) (or (hash-has-key? parametric-operators op) (dict-has-key? (cdr operators) op))))
 

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "../common.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt")
+(require "../common.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt" "types.rkt")
 (provide assert-program-typed!)
 
 (define (assert-program-typed! stx)
@@ -33,11 +33,12 @@
          (constant-info x 'type)
          (constant-info (get-parametric-constant x type) 'type))]
     [#`,(? variable? x)
-     (define etype (representation-type (get-representation type)))
-     (define vtype (representation-type (get-representation (dict-ref env x))))
-     (unless (equal? etype vtype)
-       (error! stx "Expected a variable of type ~a, but got ~a" etype vtype))
-     type]
+     (define etype (type-name (representation-type (get-representation type))))
+     (define vtype (type-name (representation-type (get-representation (dict-ref env x)))))
+     (cond
+      [(equal? vtype 'bool) 'bool]
+      [(equal? etype vtype) type]
+      [else (error! stx "Expected a variable of type ~a, but got ~a" etype vtype)])]
     [#`(let ((,id #,expr) ...) #,body)
      (define env2
        (for/fold ([env2 env]) ([var id] [val expr])

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -76,6 +76,21 @@
        (unless (equal? t actual-type)
          (error! stx "~a expects argument ~a of type ~a (not ~a)" op (+ i 1) t actual-type)))
      t]
+    [#`(,(and (or 're 'im) op) #,arg)
+     ; TODO: this special case can be removed when complex-herbie is moved to a composite type
+     ; re, im : complex -> binary64
+     (define atype (expression->type arg env 'complex error!)) 
+     (unless (equal? atype 'complex)
+       (error! stx "~a expects argument of type complex (not ~a)" op atype))
+     'binary64]
+    [#`(complex #,re #,im)
+     ; TODO: this special case can be removed when complex-herbie is moved to a composite type
+     ; complex : binary64, binary64 -> complex
+     (define re-type (expression->type re env 'binary64 error!))
+     (define im-type (expression->type im env 'binary64 error!))
+     (unless (and (equal? re-type 'binary64) (equal? im-type 'binary64))
+       (error! stx "complex expects arguments of type binary64, binary64 (not ~a, ~a)" re-type im-type))
+     'complex]
     [#`(,(? (curry hash-has-key? parametric-operators) op) #,exprs ...)
      (define actual-types (for/list ([arg exprs]) (expression->type arg env type error!)))
      (define op* (apply get-parametric-operator op actual-types))

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -1,8 +1,8 @@
 #lang racket
 
-(require math/bigfloat)
+(require math/bigfloat ffi/unsafe)
 
-(provide (struct-out type) get-type type-name? value? bigvalue? value-of bigvalue-of)
+(provide (struct-out type) get-type type-name? bigvalue? value-of bigvalue-of)
 (module+ internals (provide define-type))
 
 (struct type (name exact? inexact? exact->inexact inexact->exact))
@@ -20,8 +20,10 @@
 (define-type bool (boolean? boolean?)
   identity identity)
 
-(define (value-of type) (type-exact? (hash-ref type-dict type)))
-(define (bigvalue-of type) (type-inexact? (hash-ref type-dict type)))
+(define (value-of type) (type-exact? (hash-ref type-dict type))) ; used once (eval-application in src/programs.rkt)
+(define (bigvalue-of type) (type-inexact? (hash-ref type-dict type))) ; not used
 
-(define (value? x) (for/or ([(type rec) (in-hash type-dict)]) ((type-exact? rec) x)))
+; used 3 times (src/float.rkt and src/syntax/syntax.rkt)
+; counterpart value? is in src/interface.rkt since the definition of what is a value is
+; now repr specific
 (define (bigvalue? x) (for/or ([(type rec) (in-hash type-dict)]) ((type-inexact? rec) x)))

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require math/bigfloat ffi/unsafe)
+(require math/bigfloat)
 
 (provide (struct-out type) get-type type-name? bigvalue? value-of bigvalue-of)
 (module+ internals (provide define-type))

--- a/src/web/plot.rkt
+++ b/src/web/plot.rkt
@@ -15,14 +15,11 @@
 
 ;;  Repr conversions
 
-(define (repr->real x repr)
-  (bigfloat->real ((representation-repr->bf repr) x)))
-
 (define (ordinal->real x repr)
   (repr->real ((representation-ordinal->repr repr) x) repr))
 
 (define (real->ordinal x repr) 
-  ((representation-repr->ordinal repr) (fl->repr x repr))) 
+  ((representation-repr->ordinal repr) (real->repr x repr))) 
 
 (define (repr-transform repr)
   (invertible-function 
@@ -33,16 +30,12 @@
   (make-axis-transform (repr-transform repr)))
 
 (define (first-power10 min max repr)
-  (define ->fl-in-repr ; will be bad if repr > double
-    (compose (curryr repr->real repr) (curryr fl->repr repr)))
   (define value
     (cond
      [(negative? max) 
-      (define power (ceiling (/ (log (- max)) (log 10))))
-      (- (->fl-in-repr (expt 10.0 power)))]
+      (- (expt 10 (ceiling (/ (log (- max)) (log 10)))))]
     [else
-      (define power (floor (/ (log max) (log 10))))
-      (->fl-in-repr (expt 10.0 power))]))
+      (expt 10 (floor (/ (log max) (log 10))))]))
   (if (<= value min) #f value))
 
 (define (choose-between min max number repr)


### PR DESCRIPTION
This PR continues the cleaner separation of types and representations in preparation for MPMF Herbie, focusing this time on posit and complex plugins. Posit representations previously used their own types since the old `real` type assumed all values satisfied Racket's `real?` predicate. Now, posit reprs are of type `real` and certain complex operations are handled better.
- [x] real/repr conversions replaces float/repr conversions
- [x] each representation defines a `repr?` predicate
- [x] `value?` predicate takes reprs instead of types (since the underlying Racket type changes depending on the repr)
- [x] `special-value` field is a procedure rather than a list (much saner)
- [x] special cases for operations `complex`, `re`, `im`
- [x] added reading/desugaring support for `cast` and `!`