### PR TITLE
Better plugin interface and templated representations

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -9,7 +9,7 @@
          take-up-to flip-lists list/true find-duplicates all-partitions
          argmins argmaxs index-of set-disjoint? comparator sample-double sample-single
          parse-flag get-seed set-seed!
-         quasisyntax sym-append
+         quasisyntax syntax-e*
          format-time format-bits in-sorted-dict web-resource
          (all-from-out "config.rkt") (all-from-out "debug.rkt"))
 
@@ -239,4 +239,7 @@
 (define (sample-single)
   (floating-point-bytes->real (integer->integer-bytes (random-bits 32) 4 #f)))
 
-(define (sym-append . args) (string->symbol (apply string-append (map symbol->string args))))
+(define (syntax-e* stx)
+  (match (syntax-e stx)
+    [(list elems ...) (map syntax-e* elems)]
+    [stx* stx*]))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -36,10 +36,10 @@
                    (define repr (get-representation (operator-info f 'otype)))
                    (define argreprs
                      (match (operator-info f 'itype)
+                       [(? representation-name? type)
+                        (map (const (get-representation type)) args)]
                        [(list arg-types ...)
-                        (map get-representation arg-types)]
-                       [(? symbol? type)
-                        (map (const (get-representation type)) args)]))
+                        (map get-representation arg-types)]))
                    (define <-bf (representation-bf->repr repr))
                    (define arg<-bfs (map representation-bf->repr argreprs))
 

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -100,7 +100,7 @@
           ([splitpoint (cdr (reverse splitpoints))])
         (define name (representation-name repr))
         (define <=-operator (get-parametric-operator '<= name name))
-        `(if (,<=-operator ,(sp-bexpr splitpoint) ,(repr->real (sp-point splitpoint) repr)) 
+        `(if (,<=-operator ,(sp-bexpr splitpoint) ,(repr->real (sp-point splitpoint) repr))
              ,(program-body (alt-program (list-ref alts (sp-cidx splitpoint))))
              ,expr)))
 
@@ -142,7 +142,7 @@
   (option split-indices alts pts expr (pick-errors split-indices pts err-lsts)))
 
 (define/contract (pick-errors split-indices pts err-lsts)
-  (-> (listof si?) (listof (listof value?)) (listof (listof value?))
+  (-> (listof si?) (listof (listof value?)) (listof (listof real?))
       (listof nonnegative-integer?))
   (for/list ([i (in-naturals)] [pt pts] [errs (flip-lists err-lsts)])
     (for/first ([si split-indices] #:when (< i (si-pidx si)))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -100,7 +100,7 @@
           ([splitpoint (cdr (reverse splitpoints))])
         (define name (representation-name repr))
         (define <=-operator (get-parametric-operator '<= name name))
-        `(if (,<=-operator ,(sp-bexpr splitpoint) ,(sp-point splitpoint))
+        `(if (,<=-operator ,(sp-bexpr splitpoint) ,(repr->real (sp-point splitpoint) repr)) 
              ,(program-body (alt-program (list-ref alts (sp-cidx splitpoint))))
              ,expr)))
 

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -152,6 +152,8 @@
 (module+ test
   (require "../interface.rkt" (submod "../syntax/rules.rkt" internals))
   (*var-reprs* (map (curryr cons (get-representation 'binary64)) '(x a b c)))
+  (*needed-reprs* (list (get-representation 'binary64)))
+  (generate-rules-for 'real 'binary64)
   
   (define all-simplify-rules
     (for/append ([rec (*rulesets*)])

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -152,7 +152,6 @@
 (module+ test
   (require "../interface.rkt" (submod "../syntax/rules.rkt" internals))
   (*var-reprs* (map (curryr cons (get-representation 'binary64)) '(x a b c)))
-  (*needed-reprs* (list (get-representation 'binary64)))
   (generate-rules-for 'real 'binary64)
   
   (define all-simplify-rules

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -153,6 +153,7 @@
   (require "../interface.rkt" (submod "../syntax/rules.rkt" internals))
   (*var-reprs* (map (curryr cons (get-representation 'binary64)) '(x a b c)))
   (generate-rules-for 'real 'binary64)
+  (generate-rules-for 'real 'binary32)
   
   (define all-simplify-rules
     (for/append ([rec (*rulesets*)])

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -37,7 +37,7 @@
        (make-hash
         `((name . ,name)
           (pre . ,(~s pre))
-          (prec . ,(symbol->string prec))
+          (prec . ,(~s prec))
           (status . ,status)
           (start . ,start-bits)
           (end . ,end-bits)

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -133,4 +133,4 @@
     ;; reals, so we need to call `bf` here
    [(eq? (representation-name repr) 'complex) (bf x)]
    [((representation-repr? repr) x) ((representation-repr->bf repr) x)]
-   [else ((representation-repr->bf repr) (real->repr x repr))]))
+   [else (bf x)])) ; assume real

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -134,4 +134,4 @@
     ;; reals, so we need to call `bf` here
     (if (eq? (representation-name repr) 'complex)
       (bf x)
-      ((representation-repr->bf repr) x))]))
+      ((representation-repr->bf repr) (real->repr x repr)))]))

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -128,10 +128,9 @@
   (cond
    [(and (equal? (type-name type) 'complex) (complex? x)) ;; HACK
     ((type-exact->inexact type) x)]
-   [else
     ;; TODO(interface): ->bf is used to convert syntactic numbers to
     ;; bf values. For 'complex' type, syntactic numbers are still
     ;; reals, so we need to call `bf` here
-    (if (eq? (representation-name repr) 'complex)
-      (bf x)
-      ((representation-repr->bf repr) (real->repr x repr)))]))
+   [(eq? (representation-name repr) 'complex) (bf x)]
+   [((representation-repr? repr) x) ((representation-repr->bf repr) x)]
+   [else ((representation-repr->bf repr) (real->repr x repr))]))

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -14,20 +14,20 @@
  value->string value->json
  ->bf)
 
+(define (real->ordinal x repr)
+  ((representation-repr->ordinal repr) (real->repr x repr)))
+
 (define (ulp-difference x y repr)
   (if (and (complex? x) (complex? y) (not (real? x)) (not (real? y)))
     (+ (ulp-difference (real-part x) (real-part y) (get-representation 'binary64))
        (ulp-difference (imag-part x) (imag-part y) (get-representation 'binary64)))
-    (let ([->ordinal (representation-repr->ordinal repr)])
-      (+ 1 (abs (- (->ordinal y) (->ordinal x)))))))
+    (+ 1 (abs (- (real->ordinal y repr) (real->ordinal x repr))))))
 
 ;; Returns the midpoint of the representation's ordinal values,
 ;; not the real-valued midpoint
 (define (midpoint p1 p2 repr)
   ((representation-ordinal->repr repr)
-   (floor (/ (+ ((representation-repr->ordinal repr) p1)
-                ((representation-repr->ordinal repr) p2))
-             2))))
+   (floor (/ (+ (real->ordinal p1 repr) (real->ordinal p2 repr)) 2))))
 
 (define (ulps->bits x) (log x 2))
 
@@ -40,7 +40,7 @@
       ;; what repr the complex implementation is using
       (and (ordinary-value? (real-part x) (get-representation 'binary64))
            (ordinary-value? (imag-part x) (get-representation 'binary64)))
-      (not (special-value? x repr))))
+      (not (special-value? (real->repr x repr) repr))))
 
 
 (define (largest-ordinary-value repr)
@@ -67,11 +67,11 @@
   (check-false (ordinary-value? -inf.f binary32)))
 
 (define (=-or-nan? x1 x2 repr)
-  (define ->ordinal (representation-repr->ordinal repr))
-  (or (= (->ordinal x1) (->ordinal x2))
+  (or (= (real->ordinal x1 repr) (real->ordinal x2 repr))
       (if (real? x1) ; Infinities are considered special values for real reprs for some reason
           (and (nan? x1) (nan? x2))
-          (and (special-value? x1 repr) (special-value? x2 repr)))))
+          (and (special-value? (real->repr x1 repr) repr) 
+               (special-value? (real->repr x2 repr) repr)))))
 
 (define (</total x1 x2 repr)
   (cond
@@ -80,29 +80,34 @@
    [(and (real? x1) (real? x2))
     (cond [(nan? x1) #f] [(nan? x2) #t] [else (< x1 x2)])]
    [else
+    (define x1* (real->repr x1 repr))
+    (define x2* (real->repr x2 repr))
     (cond
-     [(special-value? x1 repr) #f]
-     [(special-value? x2 repr) #t]
-     [else (< ((representation-repr->ordinal repr) x1)
-              ((representation-repr->ordinal repr) x2))])]))
+     [(special-value? x1* repr) #f]
+     [(special-value? x2* repr) #t]
+     [else (< ((representation-repr->ordinal repr) x1*)
+              ((representation-repr->ordinal repr) x2*))])]))
 
 (define (<=/total x1 x2 repr)
   (or (</total x1 x2 repr) (=-or-nan? x1 x2 repr)))
 
 (define (value->json x repr)
-  (match x
+  (define x* (real->repr x repr))
+  (match x*
     [(? real?)
-     (match x
-       [(? rational?) x]
+     (match x*
+       [(? rational?) x*]
        [(or -inf.0 -inf.f) (hash 'type "real" 'value "-inf")]
        [(or +inf.0 +inf.f) (hash 'type "real" 'value "+inf")]
        [(or +nan.0 +nan.f) (hash 'type "real" 'value "NaN")])]
     [(? complex?) (hash 'type "complex" 'real (real-part x) 'imag (imag-part x))]
-    [_ (hash 'type (~a repr) 'ordinal (~a ((representation-repr->ordinal repr) x)))]))
+    [_ (hash 'type (~a repr) 'ordinal (~a ((representation-repr->ordinal repr) x*)))]))
 
 (define (value->string n repr)
   ;; Prints a number with relatively few digits
-  (define n* (if (and (number? n) (exact? n)) (exact->inexact n) n))
+  (define n* 
+    (let ([n* (real->repr n repr)]) 
+      (if (and (number? n*) (exact? n*)) (exact->inexact n*) n*)))
   (define ->bf (representation-repr->bf repr))
   (define <-bf (representation-bf->repr repr))
   ;; Linear search because speed not an issue

--- a/src/function-definitions.rkt
+++ b/src/function-definitions.rkt
@@ -28,13 +28,14 @@
   (define known-function? (curry dict-has-key? known-functions))
 
   (define definition-rules ; these rules are unparameterized
-    (map 
-      (λ (r)
-        (rule (rule-name r)
-              (resugar-program (rule-input r) (get-representation (rule-otype r)) #:full #f)
-              (resugar-program (rule-output r) (get-representation (rule-otype r)) #:full #f)
-              (rule-itypes r) (rule-otype r)))
-      (filter definition-rule? (*rules*))))
+    (remove-duplicates
+      (map 
+        (λ (r)
+          (rule (rule-name r)
+                (resugar-program (rule-input r) (get-representation (rule-otype r)) #:full #f)
+                (resugar-program (rule-output r) (get-representation (rule-otype r)) #:full #f)
+                (rule-itypes r) (rule-otype r)))
+        (filter definition-rule? (*rules*)))))
 
   (let loop ()
     (define continue? #f)

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -9,6 +9,9 @@
           value? special-value?)
 (module+ internals (provide define-representation))
 
+(define *reprs-with-rules* (make-parameter '()))
+(define *needed-reprs* (make-parameter '()))
+
 ;; Structs
 
 (struct representation
@@ -117,8 +120,3 @@
 ;; Global precision tacking
 (define *output-repr* (make-parameter (get-representation 'binary64)))
 (define *var-reprs* (make-parameter '()))
-
-(define *needed-reprs* (make-parameter '()))
-
-; TODO: this parameter gets reset every test. fix?
-(define *reprs-with-rules* (make-parameter '()))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -138,6 +138,7 @@
 
 (define (real->repr x repr)
   (match x
+   [(? boolean?) x]
    [(? real?) ((representation-bf->repr repr) (bf x))] ; put this first, important
    [(? (representation-repr? repr)) x] ; identity function if x is already a value in the repr
    [(? value?) ; value in another repr, convert to new repr through bf
@@ -147,7 +148,9 @@
    [_ (error 'real->repr "Unknown value ~a" x)]))
 
 (define (repr->real x repr)
-  (bigfloat->real ((representation-repr->bf repr) x)))
+  (match x
+    [(? boolean?) x]
+    [_ (bigfloat->real ((representation-repr->bf repr) x))]))
 
 ;; Predicates
 

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -87,7 +87,7 @@
   (define shift-val (expt 2 bits))
   (λ (x) (+ (fn x) shift-val)))
 
-(define-representation (binary64 real real?)
+(define-representation (binary64 real flonum?)
   bigfloat->flonum
   bf
   (shift 63 ordinal->flonum)
@@ -126,7 +126,7 @@
                (if (bf< x2 x) (single-flonum-step y 1) y)
                (if (bf> x2 x) (single-flonum-step y -1) y))]))
 
-(define-representation (binary32 real real?)
+(define-representation (binary32 real single-flonum?)
   bigfloat->single-flonum
   bf
   ordinal->single-flonum
@@ -138,13 +138,8 @@
 
 (define (real->repr x repr)
   (match x
-   [(? boolean?) x]
-   [(? real?) ((representation-bf->repr repr) (bf x))] ; put this first, important
    [(? (representation-repr? repr)) x] ; identity function if x is already a value in the repr
-   [(? value?) ; value in another repr, convert to new repr through bf
-    (for/first ([(name repr*) (in-hash representations)]
-               #:when ((representation-repr? repr*) x))
-      ((representation-bf->repr repr) ((representation-repr->bf repr*) x)))]
+   [(? real?) ((representation-bf->repr repr) (bf x))]
    [_ (error 'real->repr "Unknown value ~a" x)]))
 
 (define (repr->real x repr)

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -46,16 +46,11 @@
 
 (define (get-representation name)
   (cond
-   [(hash-has-key? representations name)
-    (define repr (hash-ref representations name))
-    (unless (equal? name 'bool)
-      (*needed-reprs* (cons repr (*needed-reprs*))))
-    repr]
-   [(generate-repr name)
-    (define repr (hash-ref representations name))
-    (*needed-reprs* (cons repr (*needed-reprs*)))
-    repr]
-   [else (error 'get-representation "Unknown representation ~a" name)]))
+   [(hash-has-key? representations name) ; check existing
+    (hash-ref representations name)]
+   [(generate-repr name)  ; ask plugins to try generating this repr
+    (hash-ref representations name)]
+   [else (error 'get-representation "Unknown representation ~a" name)])) ; else, fail
 
 (define (register-representation! name type repr? . args)
   (hash-set! representations name

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -3,7 +3,7 @@
 (require math/bigfloat math/flonum)
 (require "syntax/types.rkt")
 
-(provide (struct-out representation) get-representation
+(provide (struct-out representation) get-representation representation-name?
           *output-repr* *var-reprs* *needed-reprs* *reprs-with-rules*
           real->repr repr->real
           value? special-value?)
@@ -63,6 +63,11 @@
 
 (define-syntax-rule (define-representation (name type repr?) args ...)
   (register-representation! 'name 'type repr? args ...))
+
+(define (representation-name? x)
+  (with-handlers ([exn:fail? (const #f)])
+    (get-representation x)
+    true))
 
 (define-representation (bool bool boolean?)
   identity

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -4,7 +4,7 @@
 (require "syntax/types.rkt")
 
 (provide (struct-out representation) get-representation
-          *output-repr* *var-reprs*
+          *output-repr* *var-reprs* *needed-reprs* *reprs-with-rules*
           real->repr repr->real
           value? special-value?)
 (module+ internals (provide define-representation))
@@ -117,3 +117,8 @@
 ;; Global precision tacking
 (define *output-repr* (make-parameter (get-representation 'binary64)))
 (define *var-reprs* (make-parameter '()))
+
+(define *needed-reprs* (make-parameter '()))
+
+; TODO: this parameter gets reset every test. fix?
+(define *reprs-with-rules* (make-parameter '()))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -25,9 +25,8 @@
             (λ () (error 'get-representation "Unknown representation ~a" name))))
 
 (define-syntax-rule (define-representation (name type repr?) args ...)
-  (begin
-    (define name (representation 'name (get-type 'type) repr? args ...))
-    (hash-set! representations 'name name)))
+  (hash-set! representations 'name
+            (representation 'name (get-type 'type) repr? args ...)))
 
 (define-representation (bool bool boolean?)
   identity

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -44,12 +44,19 @@
   (for/or ([proc repr-generators])
     (proc repr-name)))
 
+;; The set of reprs that Herbie comes across is collected here. This is the best place to guarantee 
+;; that all the correct rules are generated but it'll collect more reprs than is necessary.
+;; TODO: Find a better place to put this. Watch out for problems with multithreading / parameters. 
 (define (get-representation name)
   (cond
    [(hash-has-key? representations name) ; check existing
-    (hash-ref representations name)]
+    (define repr (hash-ref representations name))
+    (*needed-reprs* (set-add (*needed-reprs*) repr))
+    repr]
    [(generate-repr name)  ; ask plugins to try generating this repr
-    (hash-ref representations name)]
+    (define repr (hash-ref representations name))
+    (*needed-reprs* (set-add (*needed-reprs*) repr))
+    repr]
    [else (error 'get-representation "Unknown representation ~a" name)])) ; else, fail
 
 (define (register-representation! name type repr? . args)

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -98,7 +98,7 @@
 
 (define (real->repr x repr)
   (match x
-   [(? real?) ((representation-bf->repr repr) (bf x))]
+   [(? real?) ((representation-bf->repr repr) (bf x))] ; put this first, important
    [(? (representation-repr? repr)) x] ; identity function if x is already a value in the repr
    [(? value?) ; value in another repr, convert to new repr through bf
     (for/first ([(name repr*) (in-hash representations)]

--- a/src/plugin.rkt
+++ b/src/plugin.rkt
@@ -3,7 +3,7 @@
 (require (submod "syntax/types.rkt" internals) (submod "interface.rkt" internals)
          (submod "syntax/rules.rkt" internals) (submod "syntax/syntax.rkt" internals))
 (provide define-type define-representation define-constant define-operator
-         define-ruleset define-ruleset* 
+         define-ruleset define-ruleset* register-ruleset!
          register-generator! register-representation! register-constant! register-operator!
          load-herbie-plugins)
 

--- a/src/plugin.rkt
+++ b/src/plugin.rkt
@@ -2,7 +2,10 @@
 (require setup/getinfo)
 (require (submod "syntax/types.rkt" internals) (submod "interface.rkt" internals)
          (submod "syntax/rules.rkt" internals) (submod "syntax/syntax.rkt" internals))
-(provide define-type define-representation define-constant define-operator define-ruleset load-herbie-plugins)
+(provide define-type define-representation define-constant define-operator
+         define-ruleset define-ruleset* 
+         register-generator! register-representation! register-constant! register-operator!
+         load-herbie-plugins)
 
 (define (module-exists? module)
   (with-handlers ([exn:fail:filesystem:missing-module? (const false)])

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -326,11 +326,9 @@
          (values (cons op* args*) (operator-info op* 'otype))]
         [(? real?) 
          (values
-           (if (and full? (not (set-member? '(binary64 binary32) prec)))
-               (real->repr expr (get-representation prec))
-               (match expr
-                 [(or +inf.0 -inf.0 +nan.0) expr]
-                 [_ (inexact->exact expr)]))
+           (match expr
+             [(or +inf.0 -inf.0 +nan.0) expr]
+             [_ (inexact->exact expr)])
            prec)]
         [(? value?) (values expr prec)]
         [(? constant?) 
@@ -383,7 +381,7 @@
             [+nan.0 'NAN]
             [x 
              (if (set-member? '(binary64 binary32) (representation-name repr))
-                 x ; convert to flonum if binary64 or binary32
+                 (bigfloat->flonum bf) ; convert to flonum if binary64 or binary32
                  (bigfloat->real bf))]))
         expr)]
     [(? constant?) (hash-ref parametric-constants-reverse expr expr)]

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -147,8 +147,8 @@
         [(list op args ...)
          (define atypes
            (match (operator-info op 'itype)
-             [(? list? as) as]
-             [(? symbol? a) (map (const a) args)]))
+             [(? representation-name? a) (map (const a) args)] ; must be first
+             [(? list? as) as]))
          (unless (= (length atypes) (length args))
            (raise-argument-error 'eval-prog "expr?" prog))
          (cons (operator-info op mode)
@@ -362,8 +362,8 @@
      (define op* (hash-ref parametric-operators-reverse op op))
      (define atypes
        (match (operator-info op 'itype)
-         [(? list? as) as]
-         [(? symbol? a) (map (const a) args)]))
+         [(? representation-name? a) (map (const a) args)] ; some repr names are lists
+         [(? list? as) as]))   
      (define args*
        (for/list ([arg args] [type atypes])
          (expand-parametric-reverse arg (get-representation type) full?)))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -326,9 +326,11 @@
          (values (cons op* args*) (operator-info op* 'otype))]
         [(? real?) 
          (values
-           (match expr
-             [(or +inf.0 -inf.0 +nan.0) expr]
-             [_ (inexact->exact expr)])
+           (if (and full? (not (set-member? '(binary64 binary32) prec)))
+               (real->repr expr (get-representation prec))
+               (match expr
+                 [(or +inf.0 -inf.0 +nan.0) expr]
+                 [_ (inexact->exact expr)]))
            prec)]
         [(? value?) (values expr prec)]
         [(? constant?) 
@@ -381,7 +383,7 @@
             [+nan.0 'NAN]
             [x 
              (if (set-member? '(binary64 binary32) (representation-name repr))
-                 (bigfloat->flonum bf) ; convert to flonum if binary64 or binary32
+                 x ; convert to flonum if binary64 or binary32
                  (bigfloat->real bf))]))
         expr)]
     [(? constant?) (hash-ref parametric-constants-reverse expr expr)]

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -27,10 +27,10 @@
       ([(pt ex) (in-pcontext context)])
     (values pt ex)))
 
-;; Here's the dilemma: A few parameters involving rules are updated when 'run-improve' is called. 
-;; Currently, a new thread is created to call 'run-improve' meaning these parameters will be restored.
-;; This is a messy fix to save such updates and save it once execution returns to this thread
-;; Is it better not to use parameters? What happens if reports / improve is run with multithreading?
+;; Here's the dilemma: The mainloop is run within a new thread meaning any rules added will be forgotten after
+;; every run. This is a messy fix to save the generated rules and update the same parameters in this thread, but
+;; it seems to defeat the purpose of parameters. Is it better to not to use parameters? What happens if Herbie
+;; is run with multithreading?
 ;; TODO: someone with beter knowledge of Racket threads / parameters, please fix
 (define (update-rules all simplify fp-safe)
   (*rules* all)

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -699,9 +699,8 @@
 ;; Generate rules for new reprs
 
 (define (generate-missing-rules)
-  (for/fold ([new-reprs '()]) 
-            ([repr (*needed-reprs*)] #:unless (set-member? (*reprs-with-rules*) repr))
-    (printf "Generating rules for ~a ...\n" (representation-name repr))
+  (for/fold ([new-reprs '()]) ([repr (*needed-reprs*)] 
+                              #:unless (set-member? (*reprs-with-rules*) repr))
     (generate-rules-for (type-name (representation-type repr)) (representation-name repr))
     (*reprs-with-rules* (cons repr (*reprs-with-rules*)))
     (cons (representation-name repr) new-reprs)))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -160,7 +160,8 @@
   (define repr (get-representation repr-name))
   (*reprs-with-rules* (set-add (*reprs-with-rules*) repr)) ; update
   (for ([set templated-rulesets]
-       #:when (ormap (λ (p) (equal? (cdr p) type)) (third set)))
+       #:when (or (empty? (third set)) ; no type ctx
+                  (ormap (λ (p) (equal? (cdr p) type)) (third set))))
     (match-define (list (list rules ...) (list groups ...) (list (cons vars types) ...)) set)
     (define ctx (for/list ([v vars] [t types]) (cons v (if (equal? t type) repr-name t))))
     (define var-reprs (for/list ([(var prec) (in-dict ctx)]) (cons var (get-representation prec))))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -7,12 +7,34 @@
 (provide (struct-out rule) *rules* *simplify-rules* *fp-safe-simplify-rules*)
 (module+ internals (provide define-ruleset define-ruleset* *rulesets* generate-rules-for))
 
+;; Rulesets
+(define *rulesets* (make-parameter '()))
+
+;; Cached rules
+(define all-rules (make-parameter '()))
+(define simplify-rules (make-parameter '()))
+(define fp-safe-simplify-rules (make-parameter '()))
+
+;; Exported parameters to update and access rules
+(define *rules*
+  (make-derived-parameter all-rules 
+                          identity 
+                          (λ (_) (update-cached-rules) (all-rules))))
+
+(define *simplify-rules*
+  (make-derived-parameter simplify-rules 
+                          identity 
+                          (λ (_) (update-cached-rules) (simplify-rules))))
+
+(define *fp-safe-simplify-rules*
+  (make-derived-parameter fp-safe-simplify-rules 
+                          identity 
+                          (λ (_) (update-cached-rules) (fp-safe-simplify-rules))))
+
 (struct rule (name input output itypes otype) ; Input and output are patterns
         #:methods gen:custom-write
         [(define (write-proc rule port mode)
            (fprintf port "#<rule ~a>" (rule-name rule)))])
-
-(define *rulesets* (make-parameter '()))
 
 (define (rule-ops-supported? rule)
   (define (ops-in-expr expr)
@@ -74,6 +96,7 @@
                ...))
        (*rulesets* (cons (list name 'groups '((var . type) ...)) (*rulesets*))))]))
 
+;; Boolean
 (define-ruleset bool-reduce (bools simplify fp-safe)
   #:type ([a bool] [b bool])
   [not-true     (not TRUE)       FALSE]
@@ -672,29 +695,6 @@
   [erf-odd          (erf (neg x))        (neg (erf x))]
   [erf-erfc         (erfc x)             (- 1 (erf x))]
   [erfc-erf         (erf x)              (- 1 (erfc x))])
-
-;; Cached rules
-
-(define all-rules (make-parameter '()))
-(define simplify-rules (make-parameter '()))
-(define fp-safe-simplify-rules (make-parameter '()))
-
-;; Exported parameters to update and access rules
-
-(define *rules*
-  (make-derived-parameter all-rules 
-                          identity 
-                          (λ (_) (update-cached-rules) (all-rules))))
-
-(define *simplify-rules*
-  (make-derived-parameter simplify-rules 
-                          identity 
-                          (λ (_) (update-cached-rules) (simplify-rules))))
-
-(define *fp-safe-simplify-rules*
-  (make-derived-parameter fp-safe-simplify-rules 
-                          identity 
-                          (λ (_) (update-cached-rules) (fp-safe-simplify-rules))))
 
 ;; Generate rules for new reprs
 

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -60,6 +60,9 @@
     (set-add! rule-names name)
     name]))
 
+(define (sym-append . args)
+  (string->symbol (apply string-append (map symbol->string args))))
+
 ;; Expects repr names (no 'real types) and parameterized operators
 (define-syntax define-ruleset
   (syntax-rules ()

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -36,16 +36,16 @@
 
 (define (update-rules rules groups)
   (when (ormap (curry flag-set? 'rules) groups)
-    (all-rules (append rules (all-rules)))))
+    (all-rules (append (all-rules) rules))))
 
 (define (update-simplify-rules rules groups)
   (when (and (ormap (curry flag-set? 'rules) groups) (set-member? groups 'simplify))
-    (simplify-rules (append rules (simplify-rules)))))
+    (simplify-rules (append (simplify-rules) rules))))
 
 (define (update-fp-safe-simplify-rules rules groups)
   (when (and (ormap (curry flag-set? 'rules) groups)
              (set-member? groups 'fp-safe) (set-member? groups 'simplify))
-    (fp-safe-simplify-rules (append rules (fp-safe-simplify-rules)))))
+    (fp-safe-simplify-rules (append (fp-safe-simplify-rules) rules))))
 
 (struct rule (name input output itypes otype) ; Input and output are patterns
         #:methods gen:custom-write
@@ -178,7 +178,6 @@
                     rules*)
               rules*))))      ; else, assume the expression(s) are not supported in the repr
     (unless (empty? rules*)   ; only add the ruleset if it contains one
-      (*rulesets* (cons (list rules* groups ctx) (*rulesets*)))
       (update-rules rules* groups)
       (update-simplify-rules rules* groups)
       (update-fp-safe-simplify-rules rules* groups))))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -131,7 +131,7 @@
                                   (*templated-rulesets*))))]))
 
 (define (sym-append . args)
-  (string->symbol (apply string-append (map symbol->string args))))
+  (string->symbol (apply string-append (map ~s args))))
 
 ;; Generate a set of rules by replacing a generic type with a repr
 (define (generate-rules-for type repr-name)
@@ -699,10 +699,9 @@
 ;; Generate rules for new reprs
 
 (define (generate-missing-rules)
-  (when (empty? (*needed-reprs*))
-    (*needed-reprs* (list (get-representation 'binary64))))
   (for/fold ([new-reprs '()]) 
             ([repr (*needed-reprs*)] #:unless (set-member? (*reprs-with-rules*) repr))
+    (printf "Generating rules for ~a ...\n" (representation-name repr))
     (generate-rules-for (type-name (representation-type repr)) (representation-name repr))
     (*reprs-with-rules* (cons repr (*reprs-with-rules*)))
     (cons (representation-name repr) new-reprs)))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -158,7 +158,7 @@
 ;; Generate a set of rules by replacing a generic type with a repr
 (define (generate-rules-for type repr-name)
   (define repr (get-representation repr-name))
-  (*reprs-with-rules* (cons repr (*reprs-with-rules*))) ; update
+  (*reprs-with-rules* (set-add (*reprs-with-rules*) repr)) ; update
   (for ([set templated-rulesets]
        #:when (ormap (λ (p) (equal? (cdr p) type)) (third set)))
     (match-define (list (list rules ...) (list groups ...) (list (cons vars types) ...)) set)
@@ -186,7 +186,8 @@
 
 (define (generate-missing-rules)
   (for ([repr (*needed-reprs*)] 
-       #:unless (set-member? (*reprs-with-rules*) repr))
+       #:unless (or (set-member? (*reprs-with-rules*) repr)
+                    (equal? (representation-name repr) 'bool)))
     (generate-rules-for (type-name (representation-type repr))
                         (representation-name repr))))
 

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -90,10 +90,10 @@
     (define prec (dict-ref prop-dict ':precision))
     (define known-repr?
       (with-handlers ([exn:fail? (const false)])
-        (get-representation (syntax-e* prec))))
+        (get-representation (syntax-e* prec))
+        true))
     (unless known-repr?
-      (error! prec "Unknown :precision ~a" prec))
-    (*needed-reprs* (cons known-repr? (*needed-reprs*))))
+      (error! prec "Unknown :precision ~a" prec)))
 
   (when (dict-has-key? prop-dict ':cite)
     (define cite (dict-ref prop-dict ':cite))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -91,9 +91,12 @@
              [repr (with-handlers ([exn:fail? (const false)])
                      (get-representation (syntax-e* prec)))])
         (if repr
-            (*needed-reprs* (cons repr (*needed-reprs*)))
+            (unless (set-member? (*needed-reprs*) repr)
+              (*needed-reprs* (cons repr (*needed-reprs*))))
             (error! prec "Unknown :precision ~a" prec)))
-      (*needed-reprs* (cons (get-representation 'binary64) (*needed-reprs*))))
+      (let ([default (get-representation 'binary64)])
+        (unless (set-member? (*needed-reprs*) default)
+          (*needed-reprs* (cons default (*needed-reprs*))))))
 
   (when (dict-has-key? prop-dict ':cite)
     (define cite (dict-ref prop-dict ':cite))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -86,17 +86,14 @@
     (unless (string? (syntax-e desc))
       (error! desc "Invalid :description ~a; must be a string" desc)))
 
-  (if (dict-has-key? prop-dict ':precision)
-      (let* ([prec (dict-ref prop-dict ':precision)]
-             [repr (with-handlers ([exn:fail? (const false)])
-                     (get-representation (syntax-e* prec)))])
-        (if repr
-            (unless (set-member? (*needed-reprs*) repr)
-              (*needed-reprs* (cons repr (*needed-reprs*))))
-            (error! prec "Unknown :precision ~a" prec)))
-      (let ([default (get-representation 'binary64)])
-        (unless (set-member? (*needed-reprs*) default)
-          (*needed-reprs* (cons default (*needed-reprs*))))))
+  (when (dict-has-key? prop-dict ':precision)
+    (define prec (dict-ref prop-dict ':precision))
+    (define known-repr? 
+      (with-handlers ([exn:fail? (const false)])
+        (get-representation (syntax-e* prec))
+        true))
+    (unless known-repr?
+      (error! prec "Unknown :precision ~a" prec)))
 
   (when (dict-has-key? prop-dict ':cite)
     (define cite (dict-ref prop-dict ':cite))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -90,7 +90,7 @@
     (define prec (dict-ref prop-dict ':precision))
     (define known-prec?
       (with-handlers ([exn:fail? (const false)])
-        (get-representation (syntax-e prec))
+        (get-representation (syntax-e* prec))
         true))
     (unless known-prec?
       (error! prec "Unknown :precision ~a" prec)))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -86,14 +86,14 @@
     (unless (string? (syntax-e desc))
       (error! desc "Invalid :description ~a; must be a string" desc)))
 
-  (when (dict-has-key? prop-dict ':precision)
-    (define prec (dict-ref prop-dict ':precision))
-    (define known-repr?
-      (with-handlers ([exn:fail? (const false)])
-        (get-representation (syntax-e* prec))
-        true))
-    (unless known-repr?
-      (error! prec "Unknown :precision ~a" prec)))
+  (if (dict-has-key? prop-dict ':precision)
+      (let* ([prec (dict-ref prop-dict ':precision)]
+             [repr (with-handlers ([exn:fail? (const false)])
+                     (get-representation (syntax-e* prec)))])
+        (if repr
+            (*needed-reprs* (cons repr (*needed-reprs*)))
+            (error! prec "Unknown :precision ~a" prec)))
+      (*needed-reprs* (cons (get-representation 'binary64) (*needed-reprs*))))
 
   (when (dict-has-key? prop-dict ':cite)
     (define cite (dict-ref prop-dict ':cite))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -88,12 +88,12 @@
 
   (when (dict-has-key? prop-dict ':precision)
     (define prec (dict-ref prop-dict ':precision))
-    (define known-prec?
+    (define known-repr?
       (with-handlers ([exn:fail? (const false)])
-        (get-representation (syntax-e* prec))
-        true))
-    (unless known-prec?
-      (error! prec "Unknown :precision ~a" prec)))
+        (get-representation (syntax-e* prec))))
+    (unless known-repr?
+      (error! prec "Unknown :precision ~a" prec))
+    (*needed-reprs* (cons known-repr? (*needed-reprs*))))
 
   (when (dict-has-key? prop-dict ':cite)
     (define cite (dict-ref prop-dict ':cite))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -566,8 +566,8 @@
   (and (symbol? op) (not (equal? op 'if)) (or (hash-has-key? parametric-operators op) (dict-has-key? (cdr operators) op))))
 
 (define (constant? var)
-  (or (value? var) (and (symbol? var) (or (hash-has-key? parametric-constants var) 
-                                          (dict-has-key? (cdr constants) var)))))
+  (or (real? var) (value? var) (and (symbol? var) (or (hash-has-key? parametric-constants var) 
+                                                      (dict-has-key? (cdr constants) var)))))
 
 (define (variable? var)
   (and (symbol? var) (not (constant? var))))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -166,7 +166,7 @@
   (for/or ([sig (hash-ref parametric-operators name)])
     (match-define (list* true-name rtype atypes) sig)
     (and
-      (if (symbol? atypes)
+      (if (representation-name? atypes)
           (andmap (curry equal? atypes) actual-types)
           (equal? atypes actual-types))
       true-name)))

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -99,7 +99,9 @@
    (for ([name names])
      (eprintf "Checking ~a...\n" name)
      (define rule (first (filter (λ (x) (equal? (~a (rule-name x)) name)) (*rules*))))
-     (check-rule-correct rule ival-ground-truth))))
+     (check-rule-correct rule ival-ground-truth)
+     (when (set-member? (*fp-safe-simplify-rules*) rule)
+      (check-rule-fp-safe rule)))))
 
 (module+ test
   (generate-rules-for 'real 'binary64)

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -92,6 +92,7 @@
        [else (check-equal? v1 v2)]))))
 
 (module+ main
+  (*needed-reprs* (list (get-representation 'binary64) (get-representation 'binary32)))
   (command-line
    #:args names
    (for ([name names])
@@ -100,6 +101,9 @@
      (check-rule-correct rule ival-ground-truth))))
 
 (module+ test
+  (generate-rules-for 'real 'binary64)
+  (generate-rules-for 'real 'binary32)
+
   (for* ([test-ruleset (*rulesets*)] [test-rule (first test-ruleset)])
 
     (define ground-truth

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -92,7 +92,8 @@
        [else (check-equal? v1 v2)]))))
 
 (module+ main
-  (*needed-reprs* (list (get-representation 'binary64) (get-representation 'binary32)))
+  (generate-rules-for 'real 'binary64)
+  (generate-rules-for 'real 'binary32)
   (command-line
    #:args names
    (for ([name names])
@@ -103,7 +104,6 @@
 (module+ test
   (generate-rules-for 'real 'binary64)
   (generate-rules-for 'real 'binary32)
-
   (for* ([test-ruleset (*rulesets*)] [test-rule (first test-ruleset)])
 
     (define ground-truth

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -9,8 +9,8 @@
     (let loop ([props props])
       (match props
        [(list) (list)]
-       [(list (app syntax-e prop) (app syntax-e value) rest ...)
-        (cons (cons prop value) (loop rest))])))
+       [(list (app syntax-e prop) value rest ...)
+        (cons (cons prop (syntax-e* value)) (loop rest))])))
   (define type (dict-ref props* ':precision 'binary64))
   (assert-expression-type! body type #:env (for/hash ([var vars]) (values (syntax-e var) type))))
 

--- a/src/web/plot.rkt
+++ b/src/web/plot.rkt
@@ -252,9 +252,15 @@
 
   ; max and min finite values (works for ieee754 and posit)
   (define-values (maxbound minbound) 
-    (let ([ord (sub1 (abs (real->ordinal +inf.0 repr)))])
-      (values ((representation-ordinal->repr repr) ord)
-              (neg ((representation-ordinal->repr repr) ord)))))
+    (let ([pinf (real->ordinal +inf.0 repr)]
+          [minf (real->ordinal -inf.0 repr)])
+      (cond
+       [(= pinf minf) ; posit
+        (values ((representation-ordinal->repr repr) (sub1 (expt 2 (representation-total-bits repr))))
+                ((representation-ordinal->repr repr) (add1 minf)))]
+       [else 
+        (values ((representation-ordinal->repr repr) (sub1 pinf))
+                ((representation-ordinal->repr repr) (add1 minf)))])))
 
   (define eby (errors-by get-coord errs pts lt))
   (define histogram-f (histogram-function eby #:bin-size bin-size))

--- a/src/web/thread-pool.rkt
+++ b/src/web/thread-pool.rkt
@@ -1,7 +1,8 @@
 #lang racket
 
 (require racket/place)
-(require "../common.rkt" "../sandbox.rkt" "pages.rkt" "../syntax/read.rkt" "../datafile.rkt")
+(require "../common.rkt" "../sandbox.rkt" "../plugin.rkt" "pages.rkt"
+         "../syntax/read.rkt" "../datafile.rkt")
 
 (provide get-test-results)
 
@@ -45,6 +46,8 @@
 
 (define (make-worker seed profile? debug? dir)
   (place/context* ch #:parameters (*flags* *num-iterations* *num-points* *timeout* *reeval-pts*)
+    (parameterize ([current-error-port (open-output-nowhere)]) ; hide output
+      (load-herbie-plugins))
     (for ([_ (in-naturals)])
       (match-define (list 'apply self id test) (place-channel-get ch))
       (define result (run-test id test #:seed seed #:profile profile? #:debug debug? #:dir dir))

--- a/src/web/thread-pool.rkt
+++ b/src/web/thread-pool.rkt
@@ -1,33 +1,10 @@
 #lang racket
 
-(require racket/place (only-in ffi/unsafe cpointer? cpointer-tag))
+(require racket/place)
 (require "../common.rkt" "../sandbox.rkt" "../plugin.rkt" "pages.rkt"
-         "../syntax/read.rkt" "../datafile.rkt" "../interface.rkt")
+         "../syntax/read.rkt" "../datafile.rkt")
 
 (provide get-test-results)
-
-;; Place messages do not allow C-pointers, but documentation says they're supported (?).
-;; Assume the C-pointers are values in a representation and convert them to a 
-;; prefab struct
-(struct place-cpointer (value repr) #:prefab)
-
-(define (expr->place-expr expr) 
-  (match expr
-    [(list subexprs ...) (map expr->place-expr subexprs)]
-    [_
-      (if (and (cpointer? expr) expr) ; #f is considered a C-pointer
-          (let ([prec (first (cpointer-tag expr))]) ; assuming #<cpointer:prec>
-            (place-cpointer (repr->real expr (get-representation prec))
-                            prec))
-          expr)]))
-
-(define (place-expr->expr expr)
-  (match expr
-    [(list subexprs ...) (map place-expr->expr subexprs)]
-    [(? place-cpointer?) 
-     (real->repr (place-cpointer-value expr) 
-                 (get-representation (place-cpointer-repr expr)))]
-    [_ expr]))
 
 (define (graph-folder-path tname index)
   (format "~a-~a" index (string-prefix (string-replace tname #px"\\W+" "") 50)))
@@ -72,22 +49,9 @@
     (parameterize ([current-error-port (open-output-nowhere)]) ; hide output
       (load-herbie-plugins))
     (for ([_ (in-naturals)])
-      (match-define (list 'apply self id prog) (place-channel-get ch))
-      (define test*
-        (struct-copy test prog
-          [input     (place-expr->expr (test-input prog))]
-          [output    (place-expr->expr (test-output prog))]
-          [pre       (place-expr->expr (test-pre prog))]
-          [spec      (place-expr->expr (test-spec prog))]))
-      (define result (run-test id test* #:seed seed #:profile profile? #:debug debug? #:dir dir))
-      (define result*
-        (struct-copy table-row result
-          [input     (expr->place-expr (table-row-input result))]
-          [output    (expr->place-expr (table-row-output result))]
-          [pre       (expr->place-expr (table-row-pre result))]
-          [spec      (expr->place-expr (table-row-spec result))]
-          [target    (expr->place-expr (table-row-target result))]))
-      (place-channel-put ch `(done ,id ,self ,result*)))))
+      (match-define (list 'apply self id test) (place-channel-get ch))
+      (define result (run-test id test #:seed seed #:profile profile? #:debug debug? #:dir dir))
+      (place-channel-put ch `(done ,id ,self ,result)))))
 
 (define (print-test-result i n data)
   (eprintf "~a/~a\t" (~a i #:width 3 #:align 'right) n)
@@ -112,13 +76,7 @@
 
   (define work
     (for/list ([id (in-naturals)] [prog progs])
-      (list 
-        id
-        (struct-copy test prog
-          [input     (expr->place-expr (test-input prog))]
-          [output    (expr->place-expr (test-output prog))]
-          [pre       (expr->place-expr (test-pre prog))]
-          [spec      (expr->place-expr (test-spec prog))]))))
+      (list id prog)))
 
   (eprintf "Starting ~a Herbie workers on ~a problems (seed: ~a)...\n" threads (length progs) seed)
   (for ([worker workers])
@@ -138,16 +96,10 @@
           (place-channel-put more `(apply ,more ,@(car work)))
           (set! work (cdr work)))
 
-        (define tr*
-          (struct-copy table-row tr
-          [input     (place-expr->expr (table-row-input tr))]
-          [output    (place-expr->expr (table-row-output tr))]
-          [pre       (place-expr->expr (table-row-pre tr))]
-          [spec      (place-expr->expr (table-row-spec tr))]
-          [target    (place-expr->expr (table-row-target tr))]))
+        (define out* (cons (cons id tr) out))
 
-        (define out* (cons (cons id tr*) out))
-        (print-test-result (length out*) (length progs) tr*)
+        (print-test-result (length out*) (length progs) tr)
+
         (if (= (length out*) (length progs))
             out*
             (loop out*)))))


### PR DESCRIPTION
It makes sense to define a general representation for certain number systems such as fixed-point numbers. To actually use an instance of this representation, one must specify certain parameters, e.g. `(fixed 3 4)`, but these parameters will only be known after FPCores are read in. 

This PR improves the current plugin interface by adding the ability to generate representations, operators, and rules during runtime. This will allow plugins to define 'templated' representations and rules.
- [x] `define-ruleset*` to define a ruleset for a type (`real`, `integer`, etc.) of representation
- [x] rule generation from rulesets only occurs once when a new representation is encountered
- [x] alternate procedures to add representations during runtime: `register-representation!`, `register-operator!`, etc.
- [x] procedure to add a representation generator in plugins: `register-generator!`
- [x] various fixes for integer and fixed-point plugins (under development)