### PR TITLE
Fix crashes

### DIFF
--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -68,13 +68,7 @@
           (note . ,note)
           (tests . ,(map simplify-test tests))))]))
 
-  ; 'write-json' possibly segfaults. Extremely hard to recreate. Happens sometime after the
-  ; tests finish and before 'results.html' is generated. Since 'read-json' has issues, the best
-  ; bet is here. Bypassing just in case.
-  ; See: 'read-json-files' in 'src/web/run.rkt'
-  (define out (open-output-file file #:mode 'binary #:exists 'replace))
-  (write-bytes (jsexpr->bytes data) out)
-  (close-output-port out))
+  (call-with-output-file file (curry write-json data) #:exists 'replace))
 
 (define (flags->list flags)
   (for*/list ([rec (hash->list flags)] [fl (cdr rec)])

--- a/src/datafile.rkt
+++ b/src/datafile.rkt
@@ -68,7 +68,13 @@
           (note . ,note)
           (tests . ,(map simplify-test tests))))]))
 
-  (call-with-output-file file (curry write-json data) #:exists 'replace))
+  ; 'write-json' possibly segfaults. Extremely hard to recreate. Happens sometime after the
+  ; tests finish and before 'results.html' is generated. Since 'read-json' has issues, the best
+  ; bet is here. Bypassing just in case.
+  ; See: 'read-json-files' in 'src/web/run.rkt'
+  (define out (open-output-file file #:mode 'binary #:exists 'replace))
+  (write-bytes (jsexpr->bytes data) out)
+  (close-output-port out))
 
 (define (flags->list flags)
   (for*/list ([rec (hash->list flags)] [fl (cdr rec)])

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -308,9 +308,8 @@
          (define op* (get-parametric-operator '- atype))
          (values (list op* arg*) (operator-info op* 'otype))]
         [(list (? repr-conv? op) body) ; conversion (e.g. posit16->f64)
-         (define-values (iprec oprec)
-           (let ([split (string-split (symbol->string op) "->")])
-             (values (first split) (last split))))
+         (define iprec (first (operator-info op 'itype)))
+         (define oprec (operator-info op 'otype))
          (define-values (body* rtype) (loop body iprec))
          (values (list op body*) oprec)]
         [(list (and (or 're 'im) op) arg)
@@ -341,11 +340,8 @@
          (define prec* (if (set-member? '(TRUE FALSE) expr) 'bool prec))
          (define constant* (get-parametric-constant expr prec*))
          (values constant* (constant-info constant* 'type))]
-        [(? variable?) 
-         (values 
-           expr 
-           (if (equal? (representation-name (dict-ref var-reprs expr)) 'bool) 
-               'bool prec))])))
+        [(? variable?)
+         (values expr (representation-name (dict-ref var-reprs expr)))])))
   expr*)
 
 ;; TODO(interface): This needs to be changed once the syntax checker is updated
@@ -358,11 +354,11 @@
      (define iff* (expand-parametric-reverse iff repr full?))
      (list 'if cond* ift* iff*)]
     [(list (? repr-conv? op) body) ; conversion (e.g. posit16->f64)
-     (define iprec (first (string-split (symbol->string op) "->")))
-     (define repr* (get-representation (string->symbol iprec)))
+     (define iprec (first (operator-info op 'itype)))
+     (define repr* (get-representation iprec))
      (define body* (expand-parametric-reverse body repr* full?))
      (if full? 
-        `(cast (! :precision ,(string->symbol iprec) ,body*))
+        `(cast (! :precision ,iprec ,body*))
         `(,op ,body*))]
     [(list op args ...)
      (define op* (hash-ref parametric-operators-reverse op op))

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -43,7 +43,7 @@
    [(? constant?) 
     (type-name (representation-type (get-representation (constant-info expr 'type))))]
    [(? variable?) (type-name (representation-type (dict-ref env expr)))]
-   [(list 'if cond ift iff) (type-of ift env)]
+   [(list 'if cond ift iff) (type-of ift repr env)]
    [(list op args ...) ; repr-name -> repr -> type
     (type-name (representation-type (get-representation (operator-info op 'otype))))]))
 
@@ -55,7 +55,7 @@
    [(? value?) (representation-name repr)]
    [(? constant?) (constant-info expr 'type)]
    [(? variable?) (representation-name (dict-ref env expr))]
-   [(list 'if cond ift iff) (repr-of ift env)]
+   [(list 'if cond ift iff) (repr-of ift repr env)]
    [(list op args ...) (operator-info op 'otype)]))
 
 ;; Converting constants

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -129,6 +129,11 @@
                       (*all-alts*)))))
 
   (define (on-exception start-time e)
+    (set! reprs-encountered (*reprs-with-rules*))
+    (set! rulesets (*rulesets*))
+    (set! all-rules (*rules*))
+    (set! simplify-rules (*simplify-rules*))
+    (set! fp-safe-rules (*fp-safe-simplify-rules*))
     (test-failure test (bf-precision)
                   (- (current-inexact-milliseconds) start-time) (timeline-extract output-repr)
                   warning-log e))
@@ -150,6 +155,7 @@
         (engine-result eng))
       (parameterize ([*timeline-disabled* false])
         (timeline-load! timeline)
+        (update-rules reprs-encountered rulesets all-rules simplify-rules fp-safe-rules)
         (test-timeout test (bf-precision) (*timeout*) (timeline-extract output-repr) '()))))
 
 (define (dummy-table-row result status link)

--- a/src/web/run.rkt
+++ b/src/web/run.rkt
@@ -76,17 +76,13 @@
             #:exists 'replace
             (λ (out) (make-page page out result #f))))))))
 
-; As of 9/25/20 on Racket 7.8, 'read-json' segfaults for unknown reasons.
-; Solution: Read the file into a byte string and convert to a jsexpr using bytes->jsexpr
-; TODO: check this again at a later time.
 (define (read-json-files info dir name)
   (filter
    identity
    (for/list ([res (report-info-tests info)])
      (define out
-       (with-handlers ([exn? (const #f)])
-         (let ([path (build-path dir (table-row-link res) name)])
-            (bytes->jsexpr (port->bytes (open-input-file path) #:close #t)))))
+      (with-handlers ([exn? (const #f)])
+        (call-with-input-file (build-path dir (table-row-link res) name) read-json)))
      (and out (not (eof-object? out)) (cons (table-row-link res) out)))))
 
 (define (merge-timeline-jsons tl)

--- a/src/web/run.rkt
+++ b/src/web/run.rkt
@@ -76,13 +76,17 @@
             #:exists 'replace
             (λ (out) (make-page page out result #f))))))))
 
+; As of 9/25/20 on Racket 7.8, 'read-json' segfaults for unknown reasons.
+; Solution: Read the file into a byte string and convert to a jsexpr using bytes->jsexpr
+; TODO: check this again at a later time.
 (define (read-json-files info dir name)
   (filter
    identity
    (for/list ([res (report-info-tests info)])
      (define out
-       (with-handlers ([(const #t) (const #f)])
-         (call-with-input-file (build-path dir (table-row-link res) name) read-json)))
+       (with-handlers ([exn? (const #f)])
+         (let ([path (build-path dir (table-row-link res) name)])
+            (bytes->jsexpr (port->bytes (open-input-file path) #:close #t)))))
      (and out (not (eof-object? out)) (cons (table-row-link res) out)))))
 
 (define (merge-timeline-jsons tl)

--- a/src/web/thread-pool.rkt
+++ b/src/web/thread-pool.rkt
@@ -104,6 +104,9 @@
             out*
             (loop out*)))))
 
+  ;; 9/29/20: warfa segfaults when killing worker threads. Can't recreate locally.
+  ;; Cause unknown. Seems to disappear in a later branch. Weird stuff
+  ;; TODO: Check on this later.
   (for-each place-kill workers)
 
   (map cdr (sort outs < #:key car)))

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -221,9 +221,10 @@
   (match-define (list (list sizes compileds) ...) compiler)
   (define size (apply + sizes))
   (define compiled (apply + compileds))
+  (define ratio (if (zero? size) 0 (- 1 (/ compiled size))))  ; 0/0 means 0% improvement
   `((dt "Compiler")
     (dd (p "Compiled " ,(~a size) " to " ,(~a compiled) " computations "
-           "(" ,(format-percent (- 1 (/ compiled size))) " saved)"))))
+           "(" ,(format-percent ratio) " saved)"))))
 
 (define (render-phase-outcomes outcomes)
   `((dt "Results")


### PR DESCRIPTION
Herbie has accumulated a few crashing bugs in recent months. This PR fixes all but one. For certain benchmark suites, Herbie may segfault unexpectedly. The cause of this bug is unknown. Hopefully, this gets fixed in the next Racket version.