### PR TITLE
Keep alts removed from alt table for regimes

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -7,6 +7,7 @@
 (provide
  (contract-out
   (make-alt-table (pcontext? alt? any/c . -> . alt-table?))
+  (atab-active-alts (alt-table? . -> . (listof alt?)))
   (atab-all-alts (alt-table? . -> . (listof alt?)))
   (atab-not-done-alts (alt-table? . -> . (listof alt?)))
   (atab-add-altns (alt-table? (listof alt?) any/c . -> . alt-table?))
@@ -23,7 +24,7 @@
 
 ;; Public API
 
-(struct alt-table (point->alts alt->points alt->done? context) #:prefab)
+(struct alt-table (point->alts alt->points alt->done? context all) #:prefab)
 
 (define atab-context alt-table-context)
 
@@ -36,7 +37,8 @@
                  (cons pt (point-rec err (alt-cost initial-alt) (list initial-alt)))))
              (hash initial-alt (for/list ([(pt ex) (in-pcontext context)]) pt))
              (hash initial-alt #f)
-             context))
+             context
+             (mutable-set initial-alt)))
 
 (define (atab-pick-alt atab #:picking-func [pick car]
            #:only-fresh [only-fresh? #t])
@@ -49,10 +51,13 @@
 (define (atab-peek-alt atab #:picking-func [pick car] #:only-fresh [only-fresh? #f])
   (pick (if only-fresh?
       (atab-not-done-alts atab)
-      (atab-all-alts atab))))
+      (atab-active-alts atab))))
+
+(define (atab-active-alts atab)
+  (hash-keys (alt-table-alt->points atab)))
 
 (define (atab-all-alts atab)
-  (hash-keys (alt-table-alt->points atab)))
+  (set->list (alt-table-all atab)))
 
 (define (atab-completed? atab)
   (andmap identity (hash-values (alt-table-alt->done? atab))))
@@ -76,7 +81,8 @@
            #:when (pred pt))
         (values pt ex)))
           mk-pcontext)])
-      (minimize-alts (alt-table point->alts alt->points alt->done? context)))))
+      (minimize-alts (alt-table point->alts alt->points alt->done?
+                                context (alt-table-all atab))))))
 
 ;; Helper Functions
 
@@ -170,7 +176,7 @@
       (loop atab*))))))
 
 (define (rm-alts atab . altns)
-  (match-define (alt-table point->alts alt->points alt->done? _) atab)
+  (match-define (alt-table point->alts alt->points alt->done? _ _) atab)
   (define rel-points
     (remove-duplicates
      (apply append (map (curry hash-ref (alt-table-alt->points atab)) altns))))
@@ -199,7 +205,7 @@
 
 (define (atab-add-altn atab altn errs repr)
   (define cost (alt-cost altn))
-  (match-define (alt-table point->alts alt->points _ _) atab)
+  (match-define (alt-table point->alts alt->points _ _ all-alts) atab)
   (define-values (best-pnts tied-pnts) (best-and-tied-at-points atab altn errs))
   (cond
    [(and (null? best-pnts)
@@ -212,7 +218,9 @@
     (define pnts->alts*1 (override-at-pnts point->alts best-pnts altn errs))
     (define pnts->alts*2 (append-at-pnts pnts->alts*1 tied-pnts altn))
     (define alts->done?* (hash-set (alt-table-alt->done? atab) altn #f))
-    (minimize-alts (alt-table pnts->alts*2 alts->pnts*2 alts->done?* (alt-table-context atab)))]))
+    (set-add! all-alts altn)
+    (minimize-alts (alt-table pnts->alts*2 alts->pnts*2 alts->done?*
+                              (alt-table-context atab) all-alts))]))
 
 (define (atab-not-done-alts atab)
   (filter (negate (curry hash-ref (alt-table-alt->done? atab)))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -136,13 +136,8 @@
      (values pnt (point-rec berr (min (alt-cost altn) cost) (cons altn altns))))
    #:combine (λ (a b) b)))
 
-(define (expr-cost expr)
-  (if (list? expr)
-      (apply + 1 (map expr-cost (cdr expr)))
-      1))
-
-(define (alt-cost prog)
-  (expr-cost (program-body (alt-program prog))))
+(define (alt-cost altn)
+  (program-cost (alt-program altn)))
 
 (define (minimize-alts atab)
   (define (get-essential pnts->alts)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -89,7 +89,7 @@
 (define (list-alts)
   (printf "Key: [.] = done, [>] = chosen\n")
   (let ([ndone-alts (atab-not-done-alts (^table^))])
-    (for ([alt (atab-all-alts (^table^))]
+    (for ([alt (atab-active-alts (^table^))]
 	  [n (in-naturals)])
       (printf "~a ~a ~a\n"
        (cond [(equal? alt (^next-alt^)) ">"]
@@ -105,9 +105,9 @@
 
 ;; Begin iteration
 (define (choose-alt! n)
-  (unless (< n (length (atab-all-alts (^table^))))
+  (unless (< n (length (atab-active-alts (^table^))))
     (raise-user-error 'choose-alt! "Couldn't select the ~ath alt of ~a (not enough alts)"
-                      n (length (atab-all-alts (^table^)))))
+                      n (length (atab-active-alts (^table^)))))
   (define-values (picked table*)
     (atab-pick-alt (^table^) #:picking-func (curryr list-ref n) #:only-fresh #f))
   (^next-alt^ picked)
@@ -312,10 +312,10 @@
   (timeline-event! 'prune)
   (define new-alts (^children^))
   (define orig-fresh-alts (atab-not-done-alts (^table^)))
-  (define orig-done-alts (set-subtract (atab-all-alts (^table^)) (atab-not-done-alts (^table^))))
+  (define orig-done-alts (set-subtract (atab-active-alts (^table^)) (atab-not-done-alts (^table^))))
   (^table^ (atab-add-altns (^table^) (^children^) (*output-repr*)))
   (define final-fresh-alts (atab-not-done-alts (^table^)))
-  (define final-done-alts (set-subtract (atab-all-alts (^table^)) (atab-not-done-alts (^table^))))
+  (define final-done-alts (set-subtract (atab-active-alts (^table^)) (atab-not-done-alts (^table^))))
 
   (timeline-log! 'inputs (+ (length new-alts) (length orig-fresh-alts) (length orig-done-alts)))
   (timeline-log! 'outputs (+ (length final-fresh-alts) (length final-done-alts)))
@@ -404,7 +404,7 @@
                #:precision precision)
   (debug #:from 'progress #:depth 1 "[Phase 2 of 3] Improving.")
   (when (flag-set? 'setup 'simplify)
-    (^children^ (atab-all-alts (^table^)))
+    (^children^ (atab-active-alts (^table^)))
     (simplify!)
     (finalize-iter!))
   (for ([iter (in-range iters)] #:break (atab-completed? (^table^)))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -420,7 +420,8 @@
   (define joined-alt
     (cond
      [(and (flag-set? 'reduce 'regimes) (> (length all-alts) 1)
-           (equal? (type-name (representation-type repr)) 'real))
+           (equal? (type-name (representation-type repr)) 'real)
+           (not (null? (program-variables (alt-program (car all-alts))))))
       (timeline-event! 'regimes)
       (define option (infer-splitpoints all-alts repr))
       (timeline-event! 'bsearch)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -7,6 +7,7 @@
 
 (provide (all-from-out "syntax/syntax.rkt")
          program-body program-variables
+         program-cost expr-cost
          type-of repr-of
          expr-supports?
          location-hash
@@ -32,6 +33,15 @@
   (-> expr? (listof symbol?))
   (match-define (list (or 'lambda 'λ 'FPCore) (list vars ...) body) prog)
   vars)
+
+(define (program-cost prog)
+  (match-define (list (or 'lambda 'λ 'FPCore) (list vars ...) body) prog)
+  (expr-cost body))
+
+(define/match (expr-cost expr)
+  [((list 'if cond ift iff)) (+ 1 (expr-cost cond) (max (expr-cost ift) (expr-cost iff)))]
+  [((list op args ...)) (apply + 1 (map expr-cost args))]
+  [(_) 1])
 
 ;; Returns type name
 ;; Fast version does not recurse into functions applications

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -269,6 +269,11 @@
   [distribute-frac-neg    (/ (neg a) b)           (neg (/ a b))]
   [distribute-neg-frac    (neg (/ a b))           (/ (neg a) b)])
 
+(define-ruleset* cancel-sign-fp-safe (arithmetic simplify fp-safe)
+  #:type ([a real] [b real] [c real])
+  [cancel-sign-sub      (- a (* (neg b) c))     (+ a (* b c))]
+  [cancel-sign-sub-inv  (- a (* b c))           (+ a (* (neg b) c))])
+
 ; Difference of squares
 (define-ruleset* difference-of-squares-canonicalize (polynomials simplify)
   #:type ([a real] [b real])
@@ -365,7 +370,8 @@
 
 (define-ruleset* squares-reduce-fp-sound (arithmetic simplify fp-sound)
   #:type ([x real])
-  [sqr-neg           (* (neg x) (neg x))        (* x x)])
+  [sqr-neg           (* (neg x) (neg x))        (* x x)]
+  [sqr-abs           (* (fabs x) (fabs x))      (* x x)])
 
 (define-ruleset* squares-transform (arithmetic)
   #:type ([x real] [y real])
@@ -380,9 +386,11 @@
 ; Cube root
 (define-ruleset* cubes-reduce (arithmetic simplify)
   #:type ([x real])
-  [rem-cube-cbrt     (pow (cbrt x) 3) x]
-  [rem-cbrt-cube     (cbrt (pow x 3)) x]
-  [cube-neg          (pow (neg x) 3)    (neg (pow x 3))])
+  [rem-cube-cbrt    (pow (cbrt x) 3)                    x]
+  [rem-cbrt-cube    (cbrt (pow x 3))                    x]
+  [rem-3cbrt-lft    (* (* (cbrt x) (cbrt x)) (cbrt x))  x]
+  [rem-3cbrt-rft    (* (cbrt x) (* (cbrt x) (cbrt x)))  x]
+  [cube-neg         (pow (neg x) 3)                     (neg (pow x 3))])
 
 (define-ruleset* cubes-distribute (arithmetic simplify)
   #:type ([x real] [y real])

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -35,12 +35,11 @@
 ;; Update parameters
 
 ;; Note on rules
-;; fp-safe-nan-simplify ⊂ fp-safe-simplify ⊂ simplify ⊂ all
+;; fp-safe-simplify ⊂ simplify ⊂ all
 ;;
 ;; all                    requires at least one tag of an active group of rules
 ;; simplify               same req. as all + 'simplify' tag
 ;; fp-safe-simplify       same req. as simplify + 'fp-safe' tag       ('fp-safe' does not imply 'simplify')
-;; fp-safe-nan-simplify   same req. as simplify + 'fp-safe-nan' tag   ('fp-safe-nan' does imply 'fp-safe' but not 'simplify')
 ;;
 
 (define (update-rules rules groups)
@@ -48,7 +47,7 @@
     (all-rules (append (all-rules) rules))
     (when (set-member? groups 'simplify) ; update simplify
       (simplify-rules (append (simplify-rules) rules))  
-      (when (not (set-empty? (set-intersect groups (list 'fp-safe 'fp-safe-nan))))  ; update fp-safe
+      (when (set-member? groups 'fp-safe) ; update fp-safe
         (fp-safe-simplify-rules (append (fp-safe-simplify-rules) rules))))))
 
 (struct rule (name input output itypes otype) ; Input and output are patterns


### PR DESCRIPTION
This PR introduces the 'retired alts' idea. Any alts removed from the alt table are designated 'retired' and will not be actively used in further iterations. However, they will now be available when regimes chooses branch expressions. This idea improves accuracy by a small bit. Other changes include a new cost metric, a few rules, and cleaner rules groups.