### PR TITLE
The "install Herbie" link on the demo page is broken

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -116,7 +116,7 @@
         `(p "To handle the high volume of requests, web requests are queued; "
             "there are " (span ([id "num-jobs"]) ,(~a (hash-count *jobs*))) " jobs in the queue right now. "
             "Web demo requests may also time out and cap the number of improvement iterations. "
-            "To avoid these limitations, " (a ([href "/installing.html"]) "install Herbie")
+            "To avoid these limitations, " (a ([href "/doc/latest/installing.html"]) "install Herbie")
             " on your own computer.")
         "")
 


### PR DESCRIPTION
This PR fixes is. h/t @chandrakananandi 