### PR TITLE
Many Small Fixes

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -7,7 +7,7 @@
 (provide reap define-table table-ref table-set! table-remove!
          string-prefix call-with-output-files
          take-up-to flip-lists list/true find-duplicates all-partitions
-         argmins argmaxs index-of set-disjoint? comparator sample-double sample-single
+         argmins argmaxs index-of set-disjoint? comparator
          parse-flag get-seed set-seed!
          quasisyntax syntax-e* dict sym-append
          format-time format-bits in-sorted-dict web-resource
@@ -228,12 +228,6 @@
 (define ((comparator test) . args)
   (for/and ([left args] [right (cdr args)])
     (test left right)))
-
-(define (sample-double)
-  (floating-point-bytes->real (integer->integer-bytes (random-bits 64) 8 #f)))
-
-(define (sample-single)
-  (floating-point-bytes->real (integer->integer-bytes (random-bits 32) 4 #f)))
 
 (define (syntax-e* stx)
   (match (syntax-e stx)

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -5,7 +5,7 @@
 (module+ test (require rackunit))
 
 (provide reap define-table table-ref table-set! table-remove!
-         for/append string-prefix call-with-output-files
+         string-prefix call-with-output-files
          take-up-to flip-lists list/true find-duplicates all-partitions
          argmins argmaxs index-of set-disjoint? comparator sample-double sample-single
          parse-flag get-seed set-seed!
@@ -43,18 +43,6 @@
 
 (define (table-remove! tbl key)
   (hash-remove! (cdr tbl) key))
-
-;; More various helpful values
-
-(define-syntax-rule (for/append (defs ...)
-                                bodies ...)
-  (apply append
-         (for/list (defs ...)
-           bodies ...)))
-
-(module+ test
-  (check-equal? (for/append ([v (in-range 5)]) (list v v v))
-                '(0 0 0 1 1 1 2 2 2 3 3 3 4 4 4)))
 
 ;; Utility list functions
 

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -11,17 +11,28 @@
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
 
 (define default-flags
-  #hash([precision . (double fallback)]
+  #hash([precision . (fallback)]
         [setup . (simplify search)]
         [generate . (rr taylor simplify)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
         [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic special bools branches)]))
 
+(define (check-flag-deprecated! category flag)
+  (match* (category flag)
+    [('precision 'double)
+     (eprintf "The precision:double option has been removed.\n")
+     (eprintf "  Please use :precision binary32 and :precision binary64 instead.\n")
+     (eprintf "See <https://herbie.uwplse.org/doc/~a/input.html> for more.\n" *herbie-version*)]
+    [_
+     (void)]))
+
 (define (enable-flag! category flag)
+  (check-flag-deprecated! category flag)
   (define (update cat-flags) (set-add cat-flags flag))
   (*flags* (dict-update (*flags*) category update)))
 
 (define (disable-flag! category flag)
+  (check-flag-deprecated! category flag)
   (define (update cat-flags) (set-remove cat-flags flag))
   (*flags* (dict-update (*flags*) category update)))
 

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -23,7 +23,7 @@
      (eprintf "The precision:double option has been removed.\n")
      (eprintf "  Please use :precision binary32 and :precision binary64 instead.\n")
      (eprintf "See <https://herbie.uwplse.org/doc/~a/input.html> for more.\n" *herbie-version*)]
-    [_
+    [(_ _)
      (void)]))
 
 (define (enable-flag! category flag)

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -2,7 +2,7 @@
 
 (require "../common.rkt" "../programs.rkt" "matcher.rkt" "../interface.rkt"
          "../function-definitions.rkt" "../syntax/rules.rkt" "../syntax/syntax.rkt"
-         "../syntax/sugar.rkt")
+         "../syntax/sugar.rkt" "../syntax/types.rkt")
 
 (provide simplify)
 
@@ -278,7 +278,7 @@
     [`(1/2 . ,x) `(sqrt ,x)]
     [`(-1/2 . ,x) `(/ 1 (sqrt ,x))]
     [`(,power . ,x)
-     (match (type-of (desugar-program x (*output-repr*) (*var-reprs*) #:full #f)
-                     (*output-repr*) (*var-reprs*))
+     (define base* (desugar-program x (*output-repr*) (*var-reprs*) #:full #f))
+     (match (type-name (type-of base* (*output-repr*) (*var-reprs*)))
        ['real `(pow ,x ,power)]
        ['complex `(pow ,x (complex ,power 0))])]))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -1,7 +1,8 @@
 #lang racket
 
 (require "../common.rkt" "../programs.rkt" "matcher.rkt" "../interface.rkt"
-         "../function-definitions.rkt" "../syntax/rules.rkt" "../syntax/syntax.rkt")
+         "../function-definitions.rkt" "../syntax/rules.rkt" "../syntax/syntax.rkt"
+         "../syntax/sugar.rkt")
 
 (provide simplify)
 

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -62,7 +62,7 @@
   ;; We can only binary search if the branch expression is critical
   ;; for all of the alts and also for the start prgoram.
   (filter
-   (λ (e) (equal? (type-of e repr (*var-reprs*)) 'real))
+   (λ (e) (equal? (type-name (type-of e repr (*var-reprs*))) 'real))
    (set-intersect start-critexprs (apply set-union alt-critexprs))))
   
 ;; Requires that expr is not a λ expression

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -14,7 +14,7 @@
 (struct exn:fail:user:herbie:syntax exn:fail:user:herbie (locations)
   #:extra-constructor-name make-exn:fail:user:herbie:syntax)
 
-(struct exn:fail:user:herbie:sampling exn:fail:user (url)
+(struct exn:fail:user:herbie:sampling exn:fail:user:herbie ()
   #:extra-constructor-name make-exn:fail:user:herbie:sampling)
 
 (define (raise-herbie-error message #:url [url #f] . args)

--- a/src/function-definitions.rkt
+++ b/src/function-definitions.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "config.rkt" "syntax/rules.rkt" "core/matcher.rkt" "programs.rkt" "interface.rkt")
+(require "config.rkt" "syntax/rules.rkt" "core/matcher.rkt" "programs.rkt" "interface.rkt" "syntax/sugar.rkt")
 (provide get-expander get-evaluator)
 
 (define (evaluation-rule? rule)

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -119,7 +119,7 @@
    #:args files
    (match files
      ['()
-      (eprintf "Please specify a Herbie tool, such as `herbie shell`.\n")
+      (eprintf "Please specify a Herbie tool, such as `herbie web`.\n")
       (eprintf "See <https://herbie.uwplse.org/doc/~a/options.html> for more.\n" *herbie-version*)]
      [(cons tool _)
       (eprintf "Unknown Herbie tool `~a`. See a list of available tools with `herbie --help`.\n" tool)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -3,7 +3,8 @@
 (require "common.rkt" "programs.rkt" "points.rkt" "alternative.rkt" "errors.rkt"
          "timeline.rkt" "syntax/rules.rkt" "syntax/types.rkt" "conversions.rkt"
          "core/localize.rkt" "core/taylor.rkt" "core/alt-table.rkt" "sampling.rkt"
-         "core/simplify.rkt" "core/matcher.rkt" "core/regimes.rkt" "interface.rkt")
+         "core/simplify.rkt" "core/matcher.rkt" "core/regimes.rkt" "interface.rkt"
+         "syntax/sugar.rkt")
 
 (provide (all-defined-out))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -100,10 +100,6 @@
        (program-body (alt-program alt)))))
   (printf "Error: ~a bits\n" (errors-score (atab-min-errors (^table^)))))
 
-(define (add-conversion! prec1 prec2)
-  (define single-conv (list (list prec1 prec2)))
-  (generate-conversions single-conv))
-
 ;; Begin iteration
 (define (choose-alt! n)
   (unless (< n (length (atab-active-alts (^table^))))
@@ -244,10 +240,6 @@
   (^children^ (append (^children^) rewritten))
   (^gened-rewrites^ #t)
   (void))
-
-(define (num-nodes expr)
-  (if (not (list? expr)) 1
-      (add1 (apply + (map num-nodes (cdr expr))))))
 
 (define (simplify!)
   (unless (^children^)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -15,7 +15,6 @@
          location-do location-get location-repr
          batch-eval-progs eval-prog eval-application
          free-variables replace-expression
-         desugar-program resugar-program
          apply-repr-change)
 
 (define expr? (or/c list? symbol? value? real?))
@@ -68,6 +67,14 @@
    [(? variable?) (representation-name (dict-ref env expr))]
    [(list 'if cond ift iff) (repr-of ift repr env)]
    [(list op args ...) (operator-info op 'otype)]))
+
+(define (expr-supports? expr field)
+  (let loop ([expr expr])
+    (match expr
+      [(list op args ...)
+       (and (operator-info op field) (andmap loop args))]
+      [(? variable?) true]
+      [(? constant?) (or (not (symbol? expr)) (constant-info expr field))])))
 
 ;; Converting constants
 
@@ -285,167 +292,6 @@
     '(/ 1 cos))
    '(/ (cos (* 2 x)) (* (pow (/ 1 cos) 2) (* (fabs (* sin x)) (fabs (* sin x)))))))
 
-
-(define (unfold-let expr)
-  (match expr
-    [`(let ([,vars ,vals] ...) ,body)
-     (define bindings (map cons vars (map unfold-let vals)))
-     (replace-vars bindings (unfold-let body))]
-    [`(let* () ,body)
-     (unfold-let body)]
-    [`(let* ([,var ,val] ,rest ...) ,body)
-     (replace-vars (list (cons var (unfold-let val))) (unfold-let `(let* ,rest ,body)))]
-    [`(,head ,args ...)
-     (cons head (map unfold-let args))]
-    [x x]))
-
-(define (expand-associativity expr)
-  (match expr
-    [(list (and (or '+ '- '* '/) op) a ..2 b)
-     (list op
-           (expand-associativity (cons op a))
-           (expand-associativity b))]
-    [(list (or '+ '*) a) (expand-associativity a)]
-    [(list '- a) (list '- (expand-associativity a))]
-    [(list '/ a) (list '/ 1 (expand-associativity a))]
-    [(list (or '+ '-)) 0]
-    [(list (or '* '/)) 1]
-    [(list op a ...)
-     (cons op (map expand-associativity a))]
-    [_
-     expr]))
-
-;; TODO(interface): This needs to be changed once the syntax checker is updated
-;; and supports multiple precisions
-(define (expand-parametric expr repr var-reprs full?)
-  (define-values (expr* prec)
-    (let loop ([expr expr] [prec (representation-name repr)]) ; easier to work with repr names
-      ;; Run after unfold-let, so no need to track lets
-      (match expr
-        [(list 'if cond ift iff)
-         (define-values (cond* _a) (loop cond prec))
-         (define-values (ift* rtype) (loop ift prec))
-         (define-values (iff* _b) (loop iff prec))
-         (values (list 'if cond* ift* iff*) rtype)]
-        [(list '! props ... body)
-         (define props* (apply hash-set* (hash) props))
-         (cond
-           [(hash-has-key? props* ':precision)
-            (define-values (body* _) (loop body (hash-ref props* ':precision)))
-            (values body* prec)]
-           [else (loop body prec)])]
-        [(list (or 'neg '-) arg) ; unary minus
-         (define-values (arg* atype) (loop arg prec))
-         (define op* (get-parametric-operator '- atype))
-         (values (list op* arg*) (operator-info op* 'otype))]
-        [(list (? repr-conv? op) body) ; conversion (e.g. posit16->f64)
-         (define iprec (first (operator-info op 'itype)))
-         (define oprec (operator-info op 'otype))
-         (define-values (body* rtype) (loop body iprec))
-         (values (list op body*) oprec)]
-        [(list (and (or 're 'im) op) arg)
-         ; TODO: this special case can be removed when complex-herbie is moved to a composite type
-         (define-values (arg* atype) (loop arg 'complex))
-         (values (list op arg*) 'binary64)]
-        [(list 'complex re im)
-         ; TODO: this special case can be removed when complex-herbie is moved to a composite type
-         (define-values (re* re-type) (loop re 'binary64))
-         (define-values (im* im-type) (loop im 'binary64))
-         (values (list 'complex re* im*) 'complex)]
-        [(list op args ...)
-         (define-values (args* atypes)
-           (for/lists (args* atypes) ([arg args])
-             (loop arg prec)))
-         ;; Match guaranteed to succeed because we ran type-check first
-         (define op* (apply get-parametric-operator op atypes))
-         (values (cons op* args*) (operator-info op* 'otype))]
-        [(? real?) 
-         (values
-           (match expr
-             [(or +inf.0 -inf.0 +nan.0) expr]
-             [(? exact?) expr]
-             [_ (inexact->exact expr)])
-           prec)]
-        [(? boolean?) (values expr 'bool)]
-        [(? constant?) 
-         (define prec* (if (set-member? '(TRUE FALSE) expr) 'bool prec))
-         (define constant* (get-parametric-constant expr prec*))
-         (values constant* (constant-info constant* 'type))]
-        [(? variable?)
-         (values expr (representation-name (dict-ref var-reprs expr)))])))
-  expr*)
-
-;; TODO(interface): This needs to be changed once the syntax checker is updated
-;; and supports multiple precisions
-(define (expand-parametric-reverse expr repr full?)
-  (match expr
-    [(list 'if cond ift iff)
-     (define cond* (expand-parametric-reverse cond repr full?))
-     (define ift* (expand-parametric-reverse ift repr full?))
-     (define iff* (expand-parametric-reverse iff repr full?))
-     (list 'if cond* ift* iff*)]
-    [(list (? repr-conv? op) body) ; conversion (e.g. posit16->f64)
-     (define iprec (first (operator-info op 'itype)))
-     (define oprec (operator-info op 'otype))
-     (define repr* (get-representation iprec))
-     (define body* (expand-parametric-reverse body repr* full?))
-     (cond
-      [(not full?) `(,op ,body*)]
-      [(list? body*) `(cast (! :precision ,iprec ,body*))]
-      [else body*])] ; constants and variables should not have casts and precision changes
-    [(list op args ...)
-     (define op* (hash-ref parametric-operators-reverse op op))
-     (define atypes
-       (match (operator-info op 'itype)
-         [(? representation-name? a) (map (const a) args)] ; some repr names are lists
-         [(? list? as) as]))   
-     (define args*
-       (for/list ([arg args] [type atypes])
-         (expand-parametric-reverse arg (get-representation type) full?)))
-     (if (and (not full?) (equal? op* '-) (= (length args) 1))
-         (cons 'neg args*) ; if only unparameterizing, leave 'neg' alone
-         (cons op* args*))]
-    [(? (conjoin complex? (negate real?)))
-     `(complex ,(real-part expr) ,(imag-part expr))]
-    [(? real?)
-     (if full?
-         (match expr
-           [-inf.0 '(- INFINITY)] ; not '(neg INFINITY) because this is post-resugaring
-           [+inf.0 'INFINITY]
-           [+nan.0 'NAN]
-           [x
-            (if (set-member? '(binary64 binary32) (representation-name repr))
-                 (exact->inexact x) ; convert to flonum if binary64 or binary32
-                 x)])
-         expr)]
-    [(? constant?) (hash-ref parametric-constants-reverse expr expr)]
-    [(? variable?) expr]))
-
-(define (desugar-program prog repr var-reprs #:full [full? #t])
-  (if full?
-      (expand-parametric (expand-associativity (unfold-let prog)) repr var-reprs full?)
-      (expand-parametric prog repr var-reprs full?)))
-
-(define (resugar-program prog repr #:full [full? #t])
-  (match prog
-    [(list 'FPCore (list vars ...) body) `(FPCore ,vars ,(expand-parametric-reverse body repr full?))]
-    [(list (or 'λ 'lambda) (list vars ...) body) `(λ ,vars ,(expand-parametric-reverse body repr full?))]
-    [(? expr?) (expand-parametric-reverse prog repr full?)]))
-
-(define (replace-vars dict expr)
-  (cond
-    [(dict-has-key? dict expr) (dict-ref dict expr)]
-    [(list? expr)
-     (cons (replace-vars dict (car expr)) (map (curry replace-vars dict) (cdr expr)))]
-    [#t expr]))
-
-(define (expr-supports? expr field)
-  (let loop ([expr expr])
-    (match expr
-      [(list op args ...)
-       (and (operator-info op field) (andmap loop args))]
-      [(? variable?) true]
-      [(? constant?) (or (not (symbol? expr)) (constant-info expr field))])))
 
 ; Updates the repr of an expression if needed
 (define (apply-repr-change-expr expr)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -48,14 +48,14 @@
 ;; standards, this will have to have more information passed in
 (define (type-of expr repr env)
   (match expr
-   [(? real?) 'real]
-   [(? value?) (type-name (representation-type repr))]
+   [(? real?) (get-type 'real)]
+   [(? value?) (representation-type repr)]
    [(? constant?) 
-    (type-name (representation-type (get-representation (constant-info expr 'type))))]
-   [(? variable?) (type-name (representation-type (dict-ref env expr)))]
+    (representation-type (get-representation (constant-info expr 'type)))]
+   [(? variable?) (representation-type (dict-ref env expr))]
    [(list 'if cond ift iff) (type-of ift repr env)]
    [(list op args ...) ; repr-name -> repr -> type
-    (type-name (representation-type (get-representation (operator-info op 'otype))))]))
+    (representation-type (get-representation (operator-info op 'otype)))]))
 
 ;; Returns repr name
 ;; Fast version does not recurse into functions applications

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -128,7 +128,7 @@
          (not (empty? reprs)))
     (timeline-push! 'method "search")
     (define hyperrects (list->vector (get-hyperrects precondition programs reprs repr)))
-    (when (empty? hyperrects)
+    (when (vector-empty? hyperrects)
       (raise-herbie-sampling-error "No valid values." #:url "faq.html#no-valid-values"))
     (define weights (partial-sums (vector-map (curryr hyperrect-weight reprs) hyperrects)))
     (λ () (sample-multi-bounded hyperrects weights reprs))]

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -2,7 +2,7 @@
 (require math/bigfloat rival math/base
          (only-in fpbench interval range-table-ref condition->range-table [expr? fpcore-expr?]))
 (require "searchreals.rkt" "programs.rkt" "config.rkt" "errors.rkt" "float.rkt"
-         "interface.rkt" "timeline.rkt" "syntax/types.rkt")
+         "interface.rkt" "timeline.rkt" "syntax/types.rkt" "syntax/sugar.rkt")
 (module+ test (require rackunit))
 (provide make-sampler)
 

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -3,7 +3,8 @@
 (require "common.rkt" "errors.rkt" "debug.rkt" "points.rkt" "programs.rkt"
          "mainloop.rkt" "alternative.rkt" "timeline.rkt" (submod "timeline.rkt" debug)
          "interface.rkt" "datafile.rkt" "syntax/read.rkt" "syntax/rules.rkt" "profile.rkt"
-         (submod "syntax/rules.rkt" internals) "syntax/syntax.rkt" "conversions.rkt")
+         (submod "syntax/rules.rkt" internals) "syntax/syntax.rkt" "conversions.rkt"
+         "syntax/sugar.rkt")
 
 (provide get-test-result *reeval-pts* *timeout*
          (struct-out test-result) (struct-out test-success)

--- a/src/searchreals.rkt
+++ b/src/searchreals.rkt
@@ -60,8 +60,7 @@
   (search-space true* false* other*))
 
 (define (find-intervals ival-fn rects #:reprs reprs #:fuel [depth 128])
-  (define num-vars (length (first rects)))
-  (if (= num-vars 0)
+  (if (or (null? rects) (null? (first rects)))
       (map (curryr cons 'other) rects)
       (let loop ([space (apply make-search-space rects)] [n 0])
         (match-define (search-space true false other) space)
@@ -74,7 +73,7 @@
         (define wf (- 1 wt wo))
         (timeline-push! 'sampling n wt wo wf)
 
-        (define n* (remainder n num-vars))
+        (define n* (remainder n (length (first rects))))
         (if (or (>= n depth) (empty? (search-space-other space)))
             (append (search-space-true space) (search-space-other space))
             (loop (search-step ival-fn space reprs n*) (+ n 1))))))

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "../common.rkt" "../errors.rkt" "../programs.rkt" "../interface.rkt"
-         "syntax-check.rkt" "type-check.rkt")
+         "syntax-check.rkt" "type-check.rkt" "sugar.rkt")
 
 (provide (struct-out test)
          test-program test-target test-specification load-tests parse-test

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -83,10 +83,11 @@
         (parse-test test override-ctx)))))
 
 (define (load-directory dir override-ctx)
-  (for/append ([fname (in-directory dir)]
-               #:when (file-exists? fname)
-               #:when (equal? (filename-extension fname) #"fpcore"))
-    (load-file fname override-ctx)))
+  (apply append
+         (for/list ([fname (in-directory dir)]
+                    #:when (file-exists? fname)
+                    #:when (equal? (filename-extension fname) #"fpcore"))
+           (load-file fname override-ctx))))
 
 (define (load-tests path [override-ctx '()])
   (define path* (if (string? path) (string->path path) path))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -2,7 +2,7 @@
 
 ;; Arithmetic identities for rewriting programs.
 
-(require "../common.rkt" "../programs.rkt" "../interface.rkt" "syntax.rkt" "types.rkt")
+(require "../common.rkt" "../programs.rkt" "../interface.rkt" "syntax.rkt" "types.rkt" "sugar.rkt")
 
 (provide (struct-out rule) *rules* *simplify-rules* *fp-safe-simplify-rules*)
 (module+ internals (provide define-ruleset define-ruleset* register-ruleset!

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -1,0 +1,158 @@
+#lang racket
+
+(require "types.rkt" "syntax.rkt" "../interface.rkt")
+(provide desugar-program resugar-program)
+
+(define (unfold-let expr)
+  (match expr
+    [`(let ([,vars ,vals] ...) ,body)
+     (define bindings (map cons vars (map unfold-let vals)))
+     (replace-vars bindings (unfold-let body))]
+    [`(let* () ,body)
+     (unfold-let body)]
+    [`(let* ([,var ,val] ,rest ...) ,body)
+     (replace-vars (list (cons var (unfold-let val))) (unfold-let `(let* ,rest ,body)))]
+    [`(,head ,args ...)
+     (cons head (map unfold-let args))]
+    [x x]))
+
+(define (expand-associativity expr)
+  (match expr
+    [(list (and (or '+ '- '* '/) op) a ..2 b)
+     (list op
+           (expand-associativity (cons op a))
+           (expand-associativity b))]
+    [(list (or '+ '*) a) (expand-associativity a)]
+    [(list '- a) (list '- (expand-associativity a))]
+    [(list '/ a) (list '/ 1 (expand-associativity a))]
+    [(list (or '+ '-)) 0]
+    [(list (or '* '/)) 1]
+    [(list op a ...)
+     (cons op (map expand-associativity a))]
+    [_
+     expr]))
+
+;; TODO(interface): This needs to be changed once the syntax checker is updated
+;; and supports multiple precisions
+(define (expand-parametric expr repr var-reprs full?)
+  (define-values (expr* prec)
+    (let loop ([expr expr] [prec (representation-name repr)]) ; easier to work with repr names
+      ;; Run after unfold-let, so no need to track lets
+      (match expr
+        [(list 'if cond ift iff)
+         (define-values (cond* _a) (loop cond prec))
+         (define-values (ift* rtype) (loop ift prec))
+         (define-values (iff* _b) (loop iff prec))
+         (values (list 'if cond* ift* iff*) rtype)]
+        [(list '! props ... body)
+         (define props* (apply hash-set* (hash) props))
+         (cond
+           [(hash-has-key? props* ':precision)
+            (define-values (body* _) (loop body (hash-ref props* ':precision)))
+            (values body* prec)]
+           [else (loop body prec)])]
+        [(list (or 'neg '-) arg) ; unary minus
+         (define-values (arg* atype) (loop arg prec))
+         (define op* (get-parametric-operator '- atype))
+         (values (list op* arg*) (operator-info op* 'otype))]
+        [(list (? repr-conv? op) body) ; conversion (e.g. posit16->f64)
+         (define iprec (first (operator-info op 'itype)))
+         (define oprec (operator-info op 'otype))
+         (define-values (body* rtype) (loop body iprec))
+         (values (list op body*) oprec)]
+        [(list (and (or 're 'im) op) arg)
+         ; TODO: this special case can be removed when complex-herbie is moved to a composite type
+         (define-values (arg* atype) (loop arg 'complex))
+         (values (list op arg*) 'binary64)]
+        [(list 'complex re im)
+         ; TODO: this special case can be removed when complex-herbie is moved to a composite type
+         (define-values (re* re-type) (loop re 'binary64))
+         (define-values (im* im-type) (loop im 'binary64))
+         (values (list 'complex re* im*) 'complex)]
+        [(list op args ...)
+         (define-values (args* atypes)
+           (for/lists (args* atypes) ([arg args])
+             (loop arg prec)))
+         ;; Match guaranteed to succeed because we ran type-check first
+         (define op* (apply get-parametric-operator op atypes))
+         (values (cons op* args*) (operator-info op* 'otype))]
+        [(? real?) 
+         (values
+           (match expr
+             [(or +inf.0 -inf.0 +nan.0) expr]
+             [(? exact?) expr]
+             [_ (inexact->exact expr)])
+           prec)]
+        [(? boolean?) (values expr 'bool)]
+        [(? constant?) 
+         (define prec* (if (set-member? '(TRUE FALSE) expr) 'bool prec))
+         (define constant* (get-parametric-constant expr prec*))
+         (values constant* (constant-info constant* 'type))]
+        [(? variable?)
+         (values expr (representation-name (dict-ref var-reprs expr)))])))
+  expr*)
+
+;; TODO(interface): This needs to be changed once the syntax checker is updated
+;; and supports multiple precisions
+(define (expand-parametric-reverse expr repr full?)
+  (match expr
+    [(list 'if cond ift iff)
+     (define cond* (expand-parametric-reverse cond repr full?))
+     (define ift* (expand-parametric-reverse ift repr full?))
+     (define iff* (expand-parametric-reverse iff repr full?))
+     (list 'if cond* ift* iff*)]
+    [(list (? repr-conv? op) body) ; conversion (e.g. posit16->f64)
+     (define iprec (first (operator-info op 'itype)))
+     (define oprec (operator-info op 'otype))
+     (define repr* (get-representation iprec))
+     (define body* (expand-parametric-reverse body repr* full?))
+     (cond
+      [(not full?) `(,op ,body*)]
+      [(list? body*) `(cast (! :precision ,iprec ,body*))]
+      [else body*])] ; constants and variables should not have casts and precision changes
+    [(list op args ...)
+     (define op* (hash-ref parametric-operators-reverse op op))
+     (define atypes
+       (match (operator-info op 'itype)
+         [(? representation-name? a) (map (const a) args)] ; some repr names are lists
+         [(? list? as) as]))   
+     (define args*
+       (for/list ([arg args] [type atypes])
+         (expand-parametric-reverse arg (get-representation type) full?)))
+     (if (and (not full?) (equal? op* '-) (= (length args) 1))
+         (cons 'neg args*) ; if only unparameterizing, leave 'neg' alone
+         (cons op* args*))]
+    [(? (conjoin complex? (negate real?)))
+     `(complex ,(real-part expr) ,(imag-part expr))]
+    [(? real?)
+     (if full?
+         (match expr
+           [-inf.0 '(- INFINITY)] ; not '(neg INFINITY) because this is post-resugaring
+           [+inf.0 'INFINITY]
+           [+nan.0 'NAN]
+           [x
+            (if (set-member? '(binary64 binary32) (representation-name repr))
+                 (exact->inexact x) ; convert to flonum if binary64 or binary32
+                 x)])
+         expr)]
+    [(? constant?) (hash-ref parametric-constants-reverse expr expr)]
+    [(? variable?) expr]))
+
+(define (desugar-program prog repr var-reprs #:full [full? #t])
+  (if full?
+      (expand-parametric (expand-associativity (unfold-let prog)) repr var-reprs full?)
+      (expand-parametric prog repr var-reprs full?)))
+
+(define (resugar-program prog repr #:full [full? #t])
+  (match prog
+    [(list 'FPCore (list vars ...) body) `(FPCore ,vars ,(expand-parametric-reverse body repr full?))]
+    [(list (or 'λ 'lambda) (list vars ...) body) `(λ ,vars ,(expand-parametric-reverse body repr full?))]
+    [_ (expand-parametric-reverse prog repr full?)]))
+
+(define (replace-vars dict expr)
+  (cond
+    [(dict-has-key? dict expr) (dict-ref dict expr)]
+    [(list? expr)
+     (cons (replace-vars dict (car expr)) (map (curry replace-vars dict) (cdr expr)))]
+    [#t expr]))
+

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -149,10 +149,12 @@
        (operator-remove! op)))))
 
 (define (register-operator! operator name atypes rtype attrib-dict)
+  (define itypes (dict-ref attrib-dict 'itype atypes))
+  (define otype (dict-ref attrib-dict 'otype rtype))
   (table-set! operators name
-              (make-hash (append (list (cons 'itype atypes) (cons 'otype rtype)) attrib-dict)))
+              (make-hash (append (list (cons 'itype itypes) (cons 'otype otype)) attrib-dict)))
   (hash-update! parametric-operators operator 
-                (curry cons (list* name rtype (operator-info name 'itype))) '())
+                (curry cons (list* name otype (operator-info name 'itype))) '())
   (hash-set! parametric-operators-reverse name operator))
 
 (define-syntax-rule (define-operator (operator name atypes ...) rtype [key value] ...)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -21,8 +21,7 @@
   [type type-name?]
   [bf (->* () bigvalue?)]
   [fl (->* () value?)]
-  [ival (or/c (->* () ival?) #f)]
-  [nonffi (->* () value?)])
+  [ival (or/c (->* () ival?) #f)])
 
 (define parametric-constants (make-hash))
 (define parametric-constants-reverse (make-hash))
@@ -51,63 +50,53 @@
 (define-constant (PI PI.f64) binary64
   [bf (λ () pi.bf)]
   [fl (λ () pi)]
-  [ival ival-pi]
-  [nonffi (λ () pi)])
+  [ival ival-pi])
 
 (define-constant (E E.f64) binary64
   [bf (λ () (bfexp 1.bf))]
   [fl (λ () (exp 1.0))]
-  [ival ival-e]
-  [nonffi (λ () (exp 1.0))])
+  [ival ival-e])
 
 (define-constant (INFINITY INFINITY.f64) binary64
   [bf (λ () +inf.bf)]
   [fl (λ () +inf.0)]
-  [ival (λ () (mk-ival +inf.bf))]
-  [nonffi (λ () +inf.0)])
+  [ival (λ () (mk-ival +inf.bf))])
 
 (define-constant (NAN NAN.f64) binary64
   [bf (λ () +nan.bf)]
   [fl (λ () +nan.0)]
-  [ival (λ () (mk-ival +nan.bf))]
-  [nonffi (λ () +nan.0)]) 
+  [ival (λ () (mk-ival +nan.bf))]) 
 
 ;; binary32 ;;
 (define-constant (PI PI.f32) binary32
   [bf (λ () pi.bf)]
   [fl (λ () pi.f)]
-  [ival ival-pi]
-  [nonffi (λ () pi.f)])
+  [ival ival-pi])
 
 (define-constant (E E.f32) binary32
   [bf (λ () (bfexp 1.bf))]
   [fl (λ () (exp 1.0))]
-  [ival ival-e]
-  [nonffi (λ () (exp 1.0))])
+  [ival ival-e])
 
 (define-constant (INFINITY INFINITY.f32) binary32
   [bf (λ () +inf.bf)]
   [fl (λ () +inf.0)]
-  [ival (λ () (mk-ival +inf.bf))]
-  [nonffi (λ () +inf.0)])
+  [ival (λ () (mk-ival +inf.bf))])
 
 (define-constant (NAN NAN.f32) binary32
   [bf (λ () +nan.bf)]
   [fl (λ () +nan.0)]
-  [ival (λ () (mk-ival +nan.bf))]
-  [nonffi (λ () +nan.0)]) 
+  [ival (λ () (mk-ival +nan.bf))]) 
 
 ;; bool ;;
 (define-constant (TRUE TRUE) bool
   [bf (const true)]
   [fl (const true)]
-  [nonffi (const true)]
   [ival (λ () (ival-bool true))])
 
 (define-constant (FALSE FALSE) bool
   [bf (const false)]
   [fl (const false)]
-  [nonffi (const false)]
   [ival (λ () (ival-bool false))])
 
 ;; TODO: The contracts for operators are tricky because the number of arguments is unknown

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -4,7 +4,7 @@
 (require "../common.rkt" "../programs.rkt" "../sampling.rkt"
          (submod "../points.rkt" internals))
 (require "rules.rkt" (submod "rules.rkt" internals) "../interface.rkt")
-(require "../programs.rkt" "../float.rkt")
+(require "../programs.rkt" "../float.rkt" "sugar.rkt")
 
 (define num-test-points 1000)
 

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -74,10 +74,8 @@
   (define repr (get-representation otype))
   (define (make-point)
     (for/list ([v fv])
-      (match (dict-ref (rule-itypes test-rule) v)
-        [(or 'binary64 'binary32) (random-generate repr)]
-        ['bool (if (< (random) .5) false true)]
-        ['complex (make-rectangular (sample-double) (sample-double))])))
+      (define repr (get-representation (dict-ref (rule-itypes test-rule) v)))
+      (random-generate repr)))
   (define point-sequence (in-producer make-point))
   (define points (for/list ([n (in-range num-test-points)] [pt point-sequence]) pt))
   (define prog1 (eval-prog `(λ ,fv ,p1) 'fl repr))

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -41,7 +41,7 @@
 (define (timeline-adjust! type key . values)
   (-> symbol? symbol? jsexpr? ... void?)
   (unless (*timeline-disabled*)
-    (for/first ([cell (unbox *timeline*)] #:when (equal? (hash-ref cell 'type) type))
+    (for/first ([cell (unbox *timeline*)] #:when (equal? (hash-ref cell 'type) (~a type)))
       (hash-set! cell key values)
       true)
     (void)))

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -7,6 +7,7 @@
 
 ;; This is a box so we can get a reference outside the engine, and so
 ;; access its value even in a timeout.
+;; Important: Use 'eq?' based hash tables, process may freeze otherwise
 (define *timeline* (box '()))
 (define *timeline-disabled* (make-parameter true))
 
@@ -14,8 +15,8 @@
 
 (define (timeline-event! type)
   (unless (*timeline-disabled*)
-    (define initial (hash 'type (~a type) 'time (current-inexact-milliseconds)))
-    (define b (make-hash (hash->list initial))) ; convert to mutable hash
+    (define initial (hasheq 'type (~a type) 'time (current-inexact-milliseconds)))
+    (define b (make-hasheq (hash->list initial))) ; convert to mutable hash
     (set-box! *timeline* (cons b (unbox *timeline*)))))
 
 (define/contract (timeline-log! key value)
@@ -29,7 +30,6 @@
 
 (define/contract (timeline-push! key . values)
   (-> symbol? jsexpr? ... void?)
-
   (unless (*timeline-disabled*)
     (define val (if (= (length values) 1) (car values) values))
     (define (try-cons x)
@@ -40,7 +40,6 @@
 
 (define (timeline-adjust! type key . values)
   (-> symbol? symbol? jsexpr? ... void?)
-
   (unless (*timeline-disabled*)
     (for/first ([cell (unbox *timeline*)] #:when (equal? (hash-ref cell 'type) type))
       (hash-set! cell key values)
@@ -51,7 +50,7 @@
   (set! *timeline* value))
 
 (define (timeline-extract repr)
-  (define end (hash 'time (current-inexact-milliseconds)))
+  (define end (hasheq 'time (current-inexact-milliseconds)))
   (reverse
    (for/list ([evt (unbox *timeline*)] [next (cons end (unbox *timeline*))])
      (define evt* (hash-copy evt))
@@ -60,7 +59,7 @@
 
 (define (timeline-relink link timeline)
   (for/list ([event (in-list timeline)])
-    (for/hash ([(k v) (in-hash event)])
+    (for/hasheq ([(k v) (in-hash event)])
       (if (equal? k 'link)
           (values k (map (λ (p) (path->string (build-path link p))) v))
           (values k v)))))

--- a/src/web/common.rkt
+++ b/src/web/common.rkt
@@ -1,7 +1,7 @@
 #lang racket
 (require (only-in xml write-xexpr xexpr?) 
          (only-in fpbench fpcore? supported-by-lang? core->c core->tex expr->tex))
-(require "../common.rkt" "../syntax/read.rkt" "../programs.rkt" "../interface.rkt")
+(require "../common.rkt" "../syntax/read.rkt" "../programs.rkt" "../interface.rkt" "../syntax/sugar.rkt")
 (provide render-menu render-warnings render-large render-program program->fpcore render-reproduction js-tex-include)
 
 (define (program->fpcore prog)

--- a/src/web/history.rkt
+++ b/src/web/history.rkt
@@ -4,7 +4,7 @@
          (only-in fpbench core->tex supported-by-lang?))
 (require "../points.rkt" "../float.rkt" "../alternative.rkt" "../interface.rkt"
          "../syntax/rules.rkt" "../core/regimes.rkt" "../common.rkt"
-        "common.rkt" "../programs.rkt")
+        "common.rkt" "../programs.rkt" "../syntax/sugar.rkt")
 (provide render-history)
 
 (define (split-pcontext pcontext splitpoints alts repr)

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -5,7 +5,7 @@
 (require "../common.rkt" "../points.rkt" "../float.rkt" "../programs.rkt"
          "../alternative.rkt" "../interface.rkt"
          "../syntax/read.rkt" "../core/regimes.rkt" "../sandbox.rkt"
-         "common.rkt" "history.rkt")
+         "common.rkt" "history.rkt" "../syntax/sugar.rkt")
 (provide make-graph)
 
 (define/contract (regime-info altn)

--- a/src/web/pages.rkt
+++ b/src/web/pages.rkt
@@ -2,7 +2,8 @@
 
 (require (only-in fpbench fpcore? supported-by-lang? core->js js-header) json)
 (require "../alternative.rkt" "../syntax/read.rkt" "../sandbox.rkt" "../interface.rkt")
-(require "common.rkt" "timeline.rkt" "plot.rkt" "make-graph.rkt" "traceback.rkt" "../programs.rkt")
+(require "common.rkt" "timeline.rkt" "plot.rkt" "make-graph.rkt" "traceback.rkt" "../programs.rkt"
+         "../syntax/sugar.rkt")
 (provide all-pages make-page page-error-handler)
 
 (define (unique-values pts idx)

--- a/src/web/thread-pool.rkt
+++ b/src/web/thread-pool.rkt
@@ -45,7 +45,9 @@
            (place/context name (parameterize ([params fresh] ...) body ...))))]))
 
 (define (make-worker seed profile? debug? dir)
-  (place/context* ch #:parameters (*flags* *num-iterations* *num-points* *timeout* *reeval-pts*)
+  (place/context* ch
+    #:parameters (*flags* *num-iterations* *num-points* *timeout* *reeval-pts* *node-limit*
+                  *max-find-range-depth*)
     (parameterize ([current-error-port (open-output-nowhere)]) ; hide output
       (load-herbie-plugins))
     (for ([_ (in-naturals)])

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -60,7 +60,8 @@
          ,@(dict-call curr render-phase-algorithm 'method)
          ,@(dict-call curr render-phase-locations 'locations)
          ,@(dict-call curr render-phase-accuracy 'accuracy 'oracle 'baseline 'name 'link)
-         ,@(dict-call curr render-phase-pruning 'kept 'min-error)
+         ,@(dict-call curr render-phase-pruning 'kept)
+         ,@(dict-call curr render-phase-error 'min-error)
          ,@(dict-call curr render-phase-rules 'rules)
          ,@(dict-call curr render-phase-counts 'inputs 'outputs)
          ,@(dict-call curr render-phase-times #:extra n 'times)
@@ -168,8 +169,8 @@
                            (td ,(format-percent (* fraction 100)))
                            (td (a ([href ,(format "~a/graph.html" link)]) ,(or name "")))))))
               '())))))
-  
-(define (render-phase-pruning kept min-error)
+
+(define (render-phase-pruning kept)
   (define (altnum kind [col #f])
     (define rec (hash-ref kept kind))
     (match col [#f (first rec)] [0 (- (first rec) (second rec))] [1 (second rec)]))
@@ -190,8 +191,11 @@
           (tr (th "Total")
               (td ,(~a (apply + (map (curryr altnum 0) '(new fresh picked done)))))
               (td ,(~a (apply + (map (curryr altnum 1) '(new fresh picked done)))))
-              (td ,(~a (apply + (map altnum '(new fresh picked done))))))))
-        (p "Merged error: " ,(format-bits min-error) "b"))))
+              (td ,(~a (apply + (map altnum '(new fresh picked done)))))))))))
+
+(define (render-phase-error min-error)
+  `((dt "Error")
+    (dd ,(format-bits min-error) "b")))
 
 (define (render-phase-rules rules)
   (define by-count (make-hash))

--- a/src/web/timeline.rkt
+++ b/src/web/timeline.rkt
@@ -55,7 +55,7 @@
   `(div ([class ,(format "timeline-block timeline-~a" type)] [id ,(format "timeline~a" n)])
         (h3 ,(~a type)
             (span ([class "time"])
-                  ,(format-time time) " (" ,(format-percent (/ time total-time)) ")"))
+                  ,(format-time time) " (" ,(format-percent time total-time) ")"))
         (dl
          ,@(dict-call curr render-phase-algorithm 'method)
          ,@(dict-call curr render-phase-locations 'locations)
@@ -119,11 +119,11 @@
               `(tr (td ,(~a iter)) (td ,(~a nodes)) (td ,(~a cost))))))))
 
 
-(define (format-percent num)
+(define (format-percent num den)
   (string-append
-   (if (infinite? num)
-       (if (> num 0) "+∞" "-∞")
-       (~r (* num 100) #:precision 1))
+   (if (zero? den)
+       (cond [(positive? num) "+∞"] [(zero? num) "0"] [(zero? num) "-∞"])
+       (~r (* (/ num den) 100) #:precision 1))
    "%"))
 
 (define (average . values)
@@ -136,9 +136,9 @@
          (tr (th "True") (th "Other") (th "False") (th "Iter"))
          ,@(for/list ([rec (in-list (sort sampling < #:key first))])
              (match-define (list n wt wo wf) rec)
-             `(tr (td ,(format-percent (/ wt total)))
-                  (td ,(format-percent (/ wo total)))
-                  (td ,(format-percent (/ wf total)))
+             `(tr (td ,(format-percent wt total))
+                  (td ,(format-percent wo total))
+                  (td ,(format-percent wf total))
                   (td ,(~a n))))))))
 
 (define (render-phase-accuracy accuracy oracle baseline name link)
@@ -146,9 +146,7 @@
     (sort
      (for/list ([acc accuracy] [ora oracle] [bas baseline] [name name] [link link])
        (list (- acc ora)
-             (if (= bas ora)
-                 (if (= bas acc) 1 -inf.0)
-                 (/ (- bas acc) (- bas ora)))
+             (- bas acc)
              link
              name))
      > #:key first))
@@ -158,15 +156,15 @@
 
   `((dt "Accuracy")
     (dd (p "Total " ,(format-bits (apply + bits)) "b" " remaining"
-            " (" ,(format-percent (/ (apply + bits) total-remaining)) ")"
+            " (" ,(format-percent (apply + bits) total-remaining) ")"
         (p "Threshold costs " ,(format-bits (apply + (filter (curry > 1) bits))) "b"
-           " (" ,(format-percent (/ (apply + (filter (curry > 1) bits)) total-remaining)) ")")
+           " (" ,(format-percent (apply + (filter (curry > 1) bits)) total-remaining) ")")
         ,@(if (> (length rows) 1)
               `((table ([class "times"])
                   ,@(for/list ([row (in-list rows)] [_ (in-range 5)])
-                      (match-define (list left fraction link name) row)
+                      (match-define (list left gained link name) row)
                       `(tr (td ,(format-bits left) "b")
-                           (td ,(format-percent (* fraction 100)))
+                           (td ,(format-percent gained (+ left gained)))
                            (td (a ([href ,(format "~a/graph.html" link)]) ,(or name "")))))))
               '())))))
 
@@ -225,10 +223,9 @@
   (match-define (list (list sizes compileds) ...) compiler)
   (define size (apply + sizes))
   (define compiled (apply + compileds))
-  (define ratio (if (zero? size) 0 (- 1 (/ compiled size))))  ; 0/0 means 0% improvement
   `((dt "Compiler")
     (dd (p "Compiled " ,(~a size) " to " ,(~a compiled) " computations "
-           "(" ,(format-percent ratio) " saved)"))))
+           "(" ,(format-percent (- size compiled) size) " saved)"))))
 
 (define (render-phase-outcomes outcomes)
   `((dt "Results")


### PR DESCRIPTION
This PR of tiny fixes:

- Fix infinite-value handling in fixpoint representations
- Possibly fix some race conditions
- Fix crashes when there are no valid inputs
- Remove `precision:double`
- Remove a bunch of unused or dead code
- GZip JSON files so they take up less space
- Fix the `--num-enodes` and `--num-analysis` flags
- Reorganize some code