### PR TITLE
Merge egg herbie into herbie repository

### DIFF
--- a/.github/workflows/egg-herbie.yml
+++ b/.github/workflows/egg-herbie.yml
@@ -1,0 +1,29 @@
+name: Build egg-herbie on all three OSes
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@master
+      - name: "Install Racket"
+        uses: Bogdanp/setup-racket@v0.5
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
+      - run: cd egg-herbie && cargo clippy --tests
+        continue-on-error: true
+      - run: cd egg-herbie && cargo test
+      - run: cd egg-herbie && cargo fmt -- --check
+      - run: cd egg-herbie && cargo build --release
+      - run: cd egg-herbie && raco test ./

--- a/.github/workflows/egg-herbie.yml
+++ b/.github/workflows/egg-herbie.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v0.5
+        uses: Bogdanp/setup-racket@v0.12
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ papers
 plugins
 rival
 regraph
-egg-herbie
 
 # Racket
 *.zo

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ help:
 install:
 	cargo build --release --manifest-path=egg-herbie/Cargo.toml
 	-raco pkg remove --auto herbie && echo "Warning: uninstalling herbie and reinstalling local version"
+	-raco pkg remove --auto egg-herbie && echo "Warning: uninstalling egg-herbie and reinstalling local version"
+	-raco pkg remove --auto egg-herbie-linux && echo "Warning: uninstalling egg-herbie and reinstalling local version"
+	-raco pkg remove --auto egg-herbie-windows && echo "Warning: uninstalling egg-herbie and reinstalling local version"
+	-raco pkg remove --auto egg-herbie-osx && echo "Warning: uninstalling egg-herbie and reinstalling local version"
 	raco pkg install ./egg-herbie
 	raco pkg install --skip-installed --name herbie src/
 	raco pkg update --name herbie src/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ help:
 
 install:
 	cargo build --release --manifest-path=egg-herbie/Cargo.toml
-	raco pkg install --skip-installed ./egg-herbie
+	-raco pkg remove --auto egg-herbie && echo "Warning: uninstalling egg-herbie and reinstalling local version"
+	-raco pkg remove --auto egg-herbie-linux && echo "Warning: uninstalling egg-herbie and reinstalling local version"
+	-raco pkg remove --auto egg-herbie-windows && echo "Warning: uninstalling egg-herbie and reinstalling local version"
+	-raco pkg remove --auto egg-herbie-osx && echo "Warning: uninstalling egg-herbie and reinstalling local version"
+	raco pkg install ./egg-herbie
 	raco pkg install --skip-installed --name herbie src/
 	raco pkg update --name herbie src/
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ help:
 
 install:
 	cargo build --release --manifest-path=egg-herbie/Cargo.toml
-	-raco pkg remove --auto egg-herbie && echo "Warning: uninstalling egg-herbie and reinstalling local version"
-	-raco pkg remove --auto egg-herbie-linux && echo "Warning: uninstalling egg-herbie and reinstalling local version"
-	-raco pkg remove --auto egg-herbie-windows && echo "Warning: uninstalling egg-herbie and reinstalling local version"
-	-raco pkg remove --auto egg-herbie-osx && echo "Warning: uninstalling egg-herbie and reinstalling local version"
+	-raco pkg remove --auto herbie && echo "Warning: uninstalling herbie and reinstalling local version"
 	raco pkg install ./egg-herbie
 	raco pkg install --skip-installed --name herbie src/
 	raco pkg update --name herbie src/

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ help:
 
 install:
 	cargo build --release --manifest-path=egg-herbie/Cargo.toml
-	-raco pkg remove egg-herbie
-	raco pkg install ./egg-herbie
+	raco pkg install --skip-installed ./egg-herbie
 	raco pkg install --skip-installed --name herbie src/
 	raco pkg update --name herbie src/
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ help:
 	@echo "Then type 'racket src/herbie.rkt web' to run it."
 
 install:
+	cargo build --release --manifest-path=egg-herbie/Cargo.toml
+	-raco pkg remove egg-herbie
+	raco pkg install ./egg-herbie
 	raco pkg install --skip-installed --name herbie src/
 	raco pkg update --name herbie src/
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Linux. Install it with:
 This will install a `herbie` binary to somewhere under `~/.racket`.
 You can also download the source and run `src/herbie.rkt` directly.
 
+Alternatively, Herbie and Herbie's Rust components can be built from source and installed
+  using `make install` in the herbie directory.
+
 Running Herbie
 --------------
 

--- a/egg-herbie/.gitignore
+++ b/egg-herbie/.gitignore
@@ -1,0 +1,14 @@
+target
+**/*.rs.bk
+Cargo.lock
+
+dots/
+egg/data/
+
+# nix stuff
+.envrc
+default.nix
+
+# Racket
+*.zo
+*.dep

--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "egg-herbie"
+version = "0.2.0"
+authors = [ "Oliver Flatt <oflatt@gmail.com>", "Max Willsey <me@mwillsey.com>" ]
+edition = "2018"
+
+
+[dependencies]
+egg = "0.6"
+
+log = "0.4"
+indexmap = "1"
+libc = "0.2.71"
+smallvec = "1.4.0"
+
+num-rational = "0.3.0"
+num-bigint = "0.3.0"
+num-traits = "0.2.12"
+env_logger = { version = "0.7", default-features = false }
+
+[features]
+upward-merging = ["egg/upward-merging"]
+
+[lib]
+name = "egg_math"
+crate-type = ["rlib", "cdylib"]
+
+[profile.test]
+debug = true
+opt-level = 1
+
+[profile.release]
+debug = true
+lto = "fat"
+codegen-units = 1

--- a/egg-herbie/LICENSE
+++ b/egg-herbie/LICENSE
@@ -1,0 +1,20 @@
+Copyright 2019 Max Willsey
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/egg-herbie/Makefile
+++ b/egg-herbie/Makefile
@@ -1,0 +1,9 @@
+.PHONY:
+test: test-math
+	cargo fmt -- --check
+
+
+.PHONY: test-math
+test-math:
+	cargo clippy --tests
+	cargo test

--- a/egg-herbie/README.md
+++ b/egg-herbie/README.md
@@ -1,0 +1,16 @@
+# An ffi interface to mwillsey/egg for use in herbie
+
+[![Build Status](https://travis-ci.org/oflatt/egg-herbie.svg?branch=master)](https://travis-ci.org/oflatt/egg-herbie)
+
+
+## Developing
+
+It's written in [Rust](https://www.rust-lang.org/).
+Typically, you install Rust using [`rustup`](https://www.rust-lang.org/tools/install).
+
+Before committing/pushing, run `make` to check tests and formatting.
+
+
+To use as a racket package, run `raco pkg install` on the egg-herbie folder.
+
+We use github actions to build racket packages. When the build succeeds, it automatically deploys the build binary.

--- a/egg-herbie/deploy.sh
+++ b/egg-herbie/deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -ex
+
+TAG=generic
+if [ "_$1" = "_ubuntu-latest" ]; then
+    TAG=linux
+elif [ "_$1" = "_windows-latest" ]; then
+    TAG=windows
+elif [ "_$1" = "_macos-latest" ]; then
+    TAG=osx
+else
+    echo "Invalid OS tag! Cannot deploy!"
+    exit 4
+fi
+
+setup_git() {
+    git config --global user.email "travis@travis-ci.org"
+    git config --global user.name "Travis CI"
+}
+
+commit_website_files() {
+    git checkout -b egg-herbie-deploy-$TAG
+    git add -u
+    git add target/release/* -f
+    git add .travis.yml
+    git commit --message "Travis build: $(git rev-parse HEAD)"
+}
+
+upload_files() {
+    git remote add origin-pages https://${GITHUB_TOKEN}@github.com/oflatt/egg-herbie > /dev/null 2>&1
+    git push -f --set-upstream origin-pages egg-herbie-deploy-$TAG
+}
+
+setup_git
+commit_website_files
+upload_files

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -1,0 +1,58 @@
+#lang racket
+
+(require ffi/unsafe
+         ffi/unsafe/define)
+(require racket/runtime-path)
+
+(provide egraph_create egraph_destroy egraph_add_expr
+         egraph_addresult_destroy egraph_run_iter egraph_get_simplest
+         egraph_get_cost egraph_get_size (struct-out EGraphAddResult)
+         (struct-out FFIRule))
+
+
+(define-runtime-path libeggmath-path
+  (build-path "target" "release"
+              (case (system-type)
+                [(windows) "egg_math"]
+                [else "libegg_math"])))
+
+
+(define-ffi-definer define-eggmath (ffi-lib libeggmath-path))
+
+(define _egraph-pointer (_cpointer 'egraph))
+
+(define-cstruct _EGraphAddResult
+  ([id _uint]
+   [successp _bool]))
+
+(define-cstruct _FFIRule ; The pointers are pointers to strings, but types hidden for allocation
+  ([name _pointer]
+   [left _pointer]
+   [right _pointer])
+  #:malloc-mode 'raw)
+
+
+;;  -> a pointer to an egraph
+(define-eggmath egraph_create (_fun -> _egraph-pointer))
+
+(define-eggmath egraph_destroy (_fun _egraph-pointer -> _void))
+
+;; egraph pointer, s-expr string -> node number
+(define-eggmath egraph_add_expr (_fun _egraph-pointer _string/utf-8 -> _EGraphAddResult-pointer))
+
+(define-eggmath egraph_addresult_destroy (_fun _EGraphAddResult-pointer -> _void))
+
+
+;; egraph pointer, a node limit, a pointer to an array of ffirule, a bool for constant folding, and the size of the ffirule array
+(define-eggmath egraph_run_iter (_fun _egraph-pointer
+                                      _uint
+                                      (ffi-rules : (_list i _FFIRule-pointer))
+                                      _bool
+                                      (_uint = (length ffi-rules))
+                                      -> _void))
+
+;; node number -> s-expr string
+(define-eggmath egraph_get_simplest (_fun _egraph-pointer _uint -> _string/utf-8))
+
+(define-eggmath egraph_get_cost (_fun _egraph-pointer _uint -> _uint))
+(define-eggmath egraph_get_size (_fun _egraph-pointer -> _uint))

--- a/egg-herbie/info.rkt
+++ b/egg-herbie/info.rkt
@@ -1,0 +1,9 @@
+#lang info
+
+(define collection "egg-herbie")
+(define version "1.4")
+
+(define pkg-desc "Racket bindings for simplifying math expressions using egg")
+
+(define pkg-authors
+  `("Oliver Flatt"))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -1,0 +1,210 @@
+#lang racket
+
+(require ffi/unsafe ffi/unsafe/define racket/runtime-path)
+
+(require "./to-egg-pattern.rkt" "./egg-interface.rkt")
+
+(module+ test (require rackunit))
+
+(provide egraph-run egraph-add-exprs egraph-run-iter
+         egraph-get-simplest egg-expr->expr egg-add-exn?
+         make-ffi-rules free-ffi-rules egraph-get-cost egraph-get-size)
+
+;; the first hash table maps all symbols and non-integer values to new names for egg
+;; the second hash is the reverse of the first
+(struct egraph-data (egraph-pointer egg->herbie-dict herbie->egg-dict))
+;; interface struct for accepting rules
+(struct irule (name input output) #:prefab)
+
+(define (egraph-get-size egraph-data)
+  (egraph_get_size (egraph-data-egraph-pointer egraph-data)))
+
+(define (egraph-get-cost egraph-data node-id)
+  (egraph_get_cost (egraph-data-egraph-pointer egraph-data) node-id))
+
+(define (egraph-get-simplest egraph-data node-id)
+  (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id))
+
+(define (make-raw-string s)
+  (define b (string->bytes/utf-8 s))
+  (define n (bytes-length b))
+  (define ptr (malloc 'raw (+ n 1)))
+  (memcpy ptr b n)
+  (ptr-set! ptr _byte n 0)
+  ptr)
+
+(define (make-ffi-rules rules)
+  (for/list [(rule rules)]
+    (define name (make-raw-string (symbol->string (irule-name rule))))
+    (define left (make-raw-string (to-egg-pattern (irule-input rule))))
+    (define right (make-raw-string (to-egg-pattern (irule-output rule))))
+    (make-FFIRule name left right)))
+
+(define (free-ffi-rules rules)
+  (for [(rule rules)]
+    (free (FFIRule-name rule))
+    (free (FFIRule-left rule))
+    (free (FFIRule-right rule))
+    (free rule)))
+
+(define (egraph-run-iter egraph-data node-limit ffi-rules precompute?)
+  (egraph_run_iter (egraph-data-egraph-pointer egraph-data) node-limit ffi-rules precompute?))
+
+(define (run-rules-recursive egraph-data node-limit ffi-rules precompute? last-count)
+  (egraph_run_iter (egraph-data-egraph-pointer egraph-data) node-limit ffi-rules precompute?)
+  (define cnt (egraph_get_size (egraph-data-egraph-pointer egraph-data)))
+  (if (and (< cnt node-limit) (> cnt last-count))
+      (run-rules-recursive egraph-data node-limit ffi-rules precompute? cnt)
+      (void)))
+
+(define (egraph-run-rules egraph-data node-limit rules precompute?)
+  (run-rules-recursive egraph-data node-limit (make-ffi-rules rules) precompute? 0))
+
+
+;; calls the function on a new egraph, and cleans up
+(define (egraph-run egraph-function)
+  (define egraph (egraph-data (egraph_create) (make-hash) (make-hash)))
+  (define res (egraph-function egraph))
+  (egraph_destroy (egraph-data-egraph-pointer egraph))
+  res)
+
+(define (egg-expr->expr expr eg-data)
+  (define parsed (read (open-input-string expr)))
+  (egg-parsed->expr parsed (egraph-data-egg->herbie-dict eg-data)))
+
+(define (egg-parsed->expr parsed rename-dict)
+  (match parsed
+    [(list first-parsed second-parsed rest-parsed ...)
+     (if (empty? rest-parsed) ; Assuming no nullary functions
+         (if (equal? second-parsed 'real)  ; parameterized constants: (name type) => name.type
+               first-parsed
+               (string->symbol (string-append (~s first-parsed) "." (~s second-parsed))))
+         (cons       ; parameterized operators: (name type args ...) => (name.type args ...)
+           (if (equal? second-parsed 'real)
+               first-parsed
+               (string->symbol (string-append (~s first-parsed) "." (~s second-parsed))))
+           (map (curryr egg-parsed->expr rename-dict) rest-parsed)))]
+    [(or (? number?) (? constant?))
+     parsed]
+    [else
+     (hash-ref rename-dict parsed)]))
+
+(define (parameterized-constant? sym)
+  (if (symbol? sym)
+      (match (regexp-match #px"([^\\s^\\.]+)\\.([^\\s]+)" (~s sym))
+        [(list _ constant prec) #t]
+        [_ #f])
+      #f))
+
+;; returns a pair of the string representing an egg expr, and updates the hash tables in the egraph
+(define (expr->egg-expr expr egg-data)
+  (define egg->herbie-dict (egraph-data-egg->herbie-dict egg-data))
+  (define herbie->egg-dict (egraph-data-herbie->egg-dict egg-data))
+  (expr->egg-expr-helper expr egg->herbie-dict herbie->egg-dict))
+
+(define (expr->egg-expr-helper expr egg->herbie-dict herbie->egg-dict)
+  (cond
+    [(list? expr)
+     (string-join
+      (append
+       (extract-operator (first expr))
+       (map (lambda (e) (expr->egg-expr-helper e egg->herbie-dict herbie->egg-dict))
+            (rest expr)))
+      " "
+      #:before-first "("
+      #:after-last ")")]
+    [(and (number? expr) (exact? expr) (real? expr))
+     (number->string expr)]
+    [(constant? expr)
+     (extract-symbol expr)]
+    [(parameterized-constant? expr)
+     (extract-symbol expr)]
+    [(hash-has-key? herbie->egg-dict expr)
+     (symbol->string (hash-ref herbie->egg-dict expr))]
+    [else
+     (define new-key (format "h~a" (number->string (hash-count herbie->egg-dict))))
+     (define new-key-symbol (string->symbol new-key))
+         
+     (hash-set! herbie->egg-dict
+                expr
+                new-key-symbol)
+     (hash-set! egg->herbie-dict
+                new-key-symbol
+                expr)
+      new-key]))
+
+(struct egg-add-exn exn:fail ())
+
+;; result function is a function that takes the ids of the nodes
+;; egraph-add-exprs returns the result of result-function
+(define (egraph-add-exprs eg-data exprs result-function)
+  (define egg-exprs
+    (map
+     (lambda (expr) (expr->egg-expr expr eg-data))
+     exprs))
+    
+  #;
+  (debug #:from 'simplify (format "Sending expressions to egg_math:\n ~a"
+                                  (string-join egg-exprs "\n ")))
+      
+  (define expr-results
+    (map
+     (lambda (expr)
+       (egraph_add_expr (egraph-data-egraph-pointer eg-data) expr))
+     egg-exprs))
+  
+  (define node-ids
+    (for/list ([result expr-results])
+      (if (EGraphAddResult-successp result)
+          (EGraphAddResult-id result)
+          (raise (egg-add-exn
+               (string-append "Failed to add expr to egraph")
+               (current-continuation-marks))))))
+
+  (define res (result-function node-ids))
+
+  (for/list ([result expr-results])
+    (egraph_addresult_destroy result))
+
+  res)
+
+
+(module+ test
+
+  (define test-exprs
+    (list (cons '(+ y x) "(+ real h0 h1)")
+          (cons '(+ x y) "(+ real h1 h0)")
+          (cons '(- 2 (+ x y)) "(- real 2 (+ real h1 h0))")
+          (cons '(- z (+ (+ y 2) x)) "(- real h2 (+ real (+ real h0 2) h1))")
+          (cons '(*.f64 x y) "(* f64 h1 h0)")
+          (cons '(+.f32 (*.f32 x y) 2) "(+ f32 (* f32 h1 h0) 2)")
+          (cons '(cos.f64 PI.f64) "(cos f64 (PI f64))")
+          (cons '(if TRUE x y) "(if real (TRUE real) h1 h0)")))
+
+  (define nil
+    (egraph-run
+     (lambda (egg-graph)
+      (for/list ([expr-pair test-exprs])
+        (let* ([out (expr->egg-expr (car expr-pair) egg-graph)]
+               [inv (egg-expr->expr out egg-graph)])
+          (check-equal? out (cdr expr-pair))      ; check output against expected
+          (check-equal? inv (car expr-pair))))))) ; check if procedures are truly inverses
+
+  (define extended-expr-list
+    (list
+     '(/ (- (exp x) (exp (- x))) 2)
+     '(/ (+ (- b) (sqrt (- (* b b) (* (* 3 a) c)))) (* 3 a))
+     '(/ (+ (- b) (sqrt (- (* b b) (* (* 3 a) c)))) (* 3 a)) ;; duplicated to make sure it would still work
+     '(* r 30)
+     '(* 23/54 r)
+     '(+ 3/2 1.4)))
+
+  (define extended-results
+   (egraph-run
+    (lambda (egg-graph)
+      (for/list ([expr
+                  extended-expr-list])
+        (egg-expr->expr (expr->egg-expr expr egg-graph) egg-graph)))))
+  (for ([res extended-results] [expected extended-expr-list])
+    (check-equal? res expected))
+  )

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -1,0 +1,235 @@
+pub mod math;
+pub mod rules;
+
+use egg::Id;
+use math::*;
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::{slice, sync::atomic::Ordering};
+
+unsafe fn cstring_to_recexpr(c_string: *const c_char) -> Option<RecExpr> {
+    match CStr::from_ptr(c_string).to_str() {
+        Ok(expr_string) => match expr_string.parse() {
+            Ok(expr) => Some(expr),
+            Err(err) => {
+                eprintln!("{}", err);
+                None
+            }
+        },
+        Err(_error) => None,
+    }
+}
+
+pub struct Context {
+    iteration: usize,
+    runner: Option<Runner>,
+}
+
+// I had to add $(rustc --print sysroot)/lib to LD_LIBRARY_PATH to get linking to work after installing rust with rustup
+#[no_mangle]
+pub unsafe extern "C" fn egraph_create() -> *mut Context {
+    Box::into_raw(Box::new(Context {
+        iteration: 0,
+        runner: Some(Runner::new(Default::default())),
+    }))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn egraph_destroy(ptr: *mut Context) {
+    std::mem::drop(Box::from_raw(ptr))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn egraph_addresult_destroy(ptr: *mut EGraphAddResult) {
+    std::mem::drop(Box::from_raw(ptr))
+}
+
+// a struct to report failure if the add fails
+#[repr(C)]
+pub struct EGraphAddResult {
+    id: u32,
+    successp: bool,
+}
+
+// a struct for loading rules from external source
+#[repr(C)]
+pub struct FFIRule {
+    name: *const c_char,
+    left: *const c_char,
+    right: *const c_char,
+}
+
+fn ffirun<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let f = std::panic::AssertUnwindSafe(f);
+    match std::panic::catch_unwind(f) {
+        Ok(t) => t,
+        Err(_) => {
+            eprintln!("Caught a panic, aborting!");
+            std::process::abort()
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn egraph_add_expr(
+    ptr: *mut Context,
+    expr: *const c_char,
+) -> *mut EGraphAddResult {
+    ffirun(|| {
+        let _ = env_logger::try_init();
+        let ctx = &mut *ptr;
+        let mut runner = ctx
+            .runner
+            .take()
+            .unwrap_or_else(|| panic!("Runner has been invalidated"));
+
+        assert_eq!(ctx.iteration, 0);
+
+        let result = match cstring_to_recexpr(expr) {
+            None => EGraphAddResult {
+                id: 0,
+                successp: false,
+            },
+            Some(rec_expr) => {
+                runner = runner.with_expr(&rec_expr);
+                let id = *runner.roots.last().unwrap();
+                let id = usize::from(id) as u32;
+                EGraphAddResult { id, successp: true }
+            }
+        };
+
+        ctx.runner = Some(runner);
+        Box::into_raw(Box::new(result))
+    })
+}
+
+// todo don't just unwrap, also make sure the rules are validly parsed
+unsafe fn ffirule_to_tuple(rule_ptr: *mut FFIRule) -> (String, String, String) {
+    let rule = &mut *rule_ptr;
+    let bytes1 = CStr::from_ptr(rule.name).to_bytes();
+    let string_result1 = String::from_utf8(bytes1.to_vec()).unwrap();
+    let bytes2 = CStr::from_ptr(rule.left).to_bytes();
+    let string_result2 = String::from_utf8(bytes2.to_vec()).unwrap();
+    let bytes3 = CStr::from_ptr(rule.right).to_bytes();
+    let string_result3 = String::from_utf8(bytes3.to_vec()).unwrap();
+    (string_result1, string_result2, string_result3)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn egraph_run_iter(
+    ptr: *mut Context,
+    limit: u32,
+    rules_array_ptr: *const *mut FFIRule,
+    is_constant_folding_enabled: bool,
+    rules_array_length: u32,
+) {
+    ffirun(|| {
+        let ctx = &mut *ptr;
+        let mut runner = ctx
+            .runner
+            .take()
+            .unwrap_or_else(|| panic!("Runner has been invalidated"));
+
+        if runner.stop_reason.is_some() {
+            // we've already run, just fake an iteration
+            ctx.iteration += 1;
+        } else {
+            let length: usize = rules_array_length as usize;
+            let ffi_rules: &[*mut FFIRule] = slice::from_raw_parts(rules_array_ptr, length);
+            let mut ffi_tuples: Vec<(&str, &str, &str)> = vec![];
+            let mut ffi_strings: Vec<(String, String, String)> = vec![];
+            for ffi_rule in ffi_rules.iter() {
+                let str_tuple = ffirule_to_tuple(*ffi_rule);
+                ffi_strings.push(str_tuple);
+            }
+
+            for ffi_string in ffi_strings.iter() {
+                ffi_tuples.push((&ffi_string.0, &ffi_string.1, &ffi_string.2));
+            }
+
+            let rules: Vec<Rewrite> = rules::mk_rules(&ffi_tuples);
+
+            runner.egraph.analysis.constant_fold = is_constant_folding_enabled;
+            runner = runner
+                .with_node_limit(limit as usize)
+                .with_hook(|r| {
+                    if r.egraph.analysis.unsound.load(Ordering::SeqCst) {
+                        Err("Unsoundness detected".into())
+                    } else {
+                        Ok(())
+                    }
+                })
+                .run(&rules);
+        }
+        ctx.runner = Some(runner);
+    })
+}
+
+fn find_extracted(runner: &Runner, id: u32) -> &Extracted {
+    let id = runner.egraph.find(Id::from(id as usize));
+    let desired_iter = if runner.egraph.analysis.unsound.load(Ordering::SeqCst) {
+        // go back one more iter, add egg can duplicate the final iter in the case of an error
+        runner.iterations.len().saturating_sub(3)
+    } else {
+        runner.iterations.len().saturating_sub(1)
+    };
+
+    runner.iterations[desired_iter]
+        .data
+        .extracted
+        .iter()
+        .find(|(i, _)| runner.egraph.find(*i) == id)
+        .map(|(_, ext)| ext)
+        .expect("Couldn't find matching extraction!")
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn egraph_get_simplest(ptr: *mut Context, node_id: u32) -> *const c_char {
+    ffirun(|| {
+        let ctx = &*ptr;
+        let runner = ctx
+            .runner
+            .as_ref()
+            .unwrap_or_else(|| panic!("Runner has been invalidated"));
+
+        let ext = find_extracted(runner, node_id);
+
+        let best_str = CString::new(ext.best.to_string()).unwrap();
+        let best_str_pointer = best_str.as_ptr();
+        std::mem::forget(best_str);
+        best_str_pointer
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn egraph_get_cost(ptr: *mut Context, node_id: u32) -> u32 {
+    ffirun(|| {
+        let ctx = &*ptr;
+        let runner = ctx
+            .runner
+            .as_ref()
+            .unwrap_or_else(|| panic!("Runner has been invalidated"));
+
+        let ext = find_extracted(runner, node_id);
+        ext.cost as u32
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn egraph_get_size(ptr: *mut Context) -> u32 {
+    ffirun(|| {
+        let ctx = &*ptr;
+        let runner = ctx
+            .runner
+            .as_ref()
+            .unwrap_or_else(|| panic!("Runner has been invalidated"));
+        match runner.iterations.last() {
+            None => 0,
+            Some(iter) => iter.egraph_nodes as u32,
+        }
+    })
+}

--- a/egg-herbie/src/math.rs
+++ b/egg-herbie/src/math.rs
@@ -1,0 +1,178 @@
+use egg::*;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use num_bigint::BigInt;
+use num_rational::Ratio;
+use num_traits::{Pow, Signed, Zero};
+
+pub type Constant = num_rational::BigRational;
+pub type RecExpr = egg::RecExpr<Math>;
+pub type Pattern = egg::Pattern<Math>;
+pub type EGraph = egg::EGraph<Math, ConstantFold>;
+pub type Rewrite = egg::Rewrite<Math, ConstantFold>;
+pub type Runner = egg::Runner<Math, ConstantFold, IterData>;
+pub type Iteration = egg::Iteration<IterData>;
+
+pub struct IterData {
+    pub extracted: Vec<(Id, Extracted)>,
+}
+
+pub struct Extracted {
+    pub best: RecExpr,
+    pub cost: usize,
+}
+
+impl IterationData<Math, ConstantFold> for IterData {
+    fn make(runner: &Runner) -> Self {
+        let mut extractor = Extractor::new(&runner.egraph, AstSize);
+        let extracted = runner
+            .roots
+            .iter()
+            .map(|&root| {
+                let (cost, best) = extractor.find_best(root);
+                let ext = Extracted { cost, best };
+                (root, ext)
+            })
+            .collect();
+        Self { extracted }
+    }
+}
+
+// operators from FPCore
+define_language! {
+    pub enum Math {
+
+        // constant-folding operators
+
+        "+" = Add([Id; 3]),
+        "-" = Sub([Id; 3]),
+        "*" = Mul([Id; 3]),
+        "/" = Div([Id; 3]),
+        "pow" = Pow([Id; 3]),
+        "neg" = Neg([Id; 2]),
+        "sqrt" = Sqrt([Id; 2]),
+        "fabs" = Fabs([Id; 2]),
+        "ceil" = Ceil([Id; 2]),
+        "floor" = Floor([Id; 2]),
+        "round" = Round([Id; 2]),
+
+        Constant(Constant),
+        Symbol(egg::Symbol),
+        Other(egg::Symbol, Vec<Id>),
+    }
+}
+
+pub struct ConstantFold {
+    pub unsound: AtomicBool,
+    pub constant_fold: bool,
+    pub prune: bool,
+}
+
+impl Default for ConstantFold {
+    fn default() -> Self {
+        Self {
+            constant_fold: true,
+            prune: true,
+            unsound: AtomicBool::from(false),
+        }
+    }
+}
+
+impl Analysis<Math> for ConstantFold {
+    type Data = Option<Constant>;
+    fn make(egraph: &EGraph, enode: &Math) -> Self::Data {
+        if !egraph.analysis.constant_fold {
+            return None;
+        }
+
+        let x = |id: &Id| egraph[*id].data.as_ref();
+        let is_zero = |id: &Id| {
+            let data = egraph[*id].data.as_ref();
+            match data {
+                Some(data) => data.is_zero(),
+                None => false,
+            }
+        };
+
+        match enode {
+            Math::Constant(c) => Some(c.clone()),
+
+            // real
+            Math::Add([_p, a, b]) => Some(x(a)? + x(b)?),
+            Math::Sub([_p, a, b]) => Some(x(a)? - x(b)?),
+            Math::Mul([_p, a, b]) => Some(x(a)? * x(b)?),
+            Math::Div([_p, a, b]) => {
+                if x(b)?.is_zero() {
+                    None
+                } else {
+                    Some(x(a)? / x(b)?)
+                }
+            }
+            Math::Neg([_p, a]) => Some(-x(a)?.clone()),
+            Math::Pow([_p, a, b]) => {
+                if is_zero(b) && !is_zero(a) {
+                    Some(Ratio::new(BigInt::from(1), BigInt::from(1)))
+                } else if is_zero(a) && !is_zero(b) {
+                    Some(Ratio::new(BigInt::from(0), BigInt::from(1)))
+                } else if x(b)?.is_integer()
+                    && !(x(a)?.is_zero() && (x(b)?.is_zero() || x(b)?.is_negative()))
+                {
+                    Some(Pow::pow(x(a)?, x(b)?.to_integer()))
+                } else {
+                    None
+                }
+            }
+            Math::Sqrt([_p, a]) => {
+                let a = x(a)?;
+                if *a.numer() > BigInt::from(0) && *a.denom() > BigInt::from(0) {
+                    let s1 = a.numer().sqrt();
+                    let s2 = a.denom().sqrt();
+                    let is_perfect = &(&s1 * &s1) == a.numer() && &(&s2 * &s2) == a.denom();
+                    if is_perfect {
+                        Some(Ratio::new(s1, s2))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+            Math::Fabs([_p, a]) => Some(x(a)?.clone().abs()),
+            Math::Floor([_p, a]) => Some(x(a)?.floor()),
+            Math::Ceil([_p, a]) => Some(x(a)?.ceil()),
+            Math::Round([_p, a]) => Some(x(a)?.round()),
+
+            _ => None,
+        }
+    }
+
+    fn merge(&self, to: &mut Self::Data, from: Self::Data) -> bool {
+        match (&to, from) {
+            (None, None) => false,
+            (Some(_), None) => false, // no update needed
+            (None, Some(c)) => {
+                *to = Some(c);
+                true
+            }
+            (Some(a), Some(ref b)) => {
+                if a != b {
+                    if !self.unsound.swap(true, Ordering::SeqCst) {
+                        log::warn!("Bad merge detected: {} != {}", a, b);
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    fn modify(egraph: &mut EGraph, id: Id) {
+        if let Some(constant) = egraph[id].data.clone() {
+            let added = egraph.add(Math::Constant(constant));
+            let (id, _) = egraph.union(id, added);
+            if egraph.analysis.prune {
+                egraph[id].nodes.retain(|n| n.is_leaf())
+            }
+        }
+    }
+}

--- a/egg-herbie/src/rules.rs
+++ b/egg-herbie/src/rules.rs
@@ -1,0 +1,934 @@
+use crate::math::*;
+
+use indexmap::IndexMap;
+use std::str::FromStr;
+
+pub fn mk_rules(tuples: &[(&str, &str, &str)]) -> Vec<Rewrite> {
+    tuples
+        .iter()
+        .map(|(name, left, right)| {
+            let left = Pattern::from_str(left).unwrap();
+            let right = Pattern::from_str(right).unwrap();
+            Rewrite::new(*name, *name, left, right).unwrap()
+        })
+        .collect()
+}
+
+pub fn math_rules() -> IndexMap<&'static str, Vec<Rewrite>> {
+    let mut m = IndexMap::new();
+    let mut add = |name, rules| {
+        if m.contains_key(name) {
+            panic!("{} was already there", name);
+        }
+        m.insert(name, mk_rules(rules));
+    };
+
+    add(
+        "erf-rules",
+        &[
+            (
+                "erf-odd",
+                "(erf f64 (neg f64 ?x))",
+                "(neg f64 (erf f64 ?x))",
+            ),
+            ("erf-erfc", "(erfc f64 ?x)", "(- f64 1 (erf f64 ?x))"),
+            ("erfc-erf", "(erf f64 ?x)", "(- f64 1 (erfc f64 ?x))"),
+        ],
+    );
+    add("complex-number-basics",
+        &[
+            ("real-part","(re real (complex real ?x ?y))","?x"),
+            ("imag-part","(im real (complex real ?x ?y))","?y"),
+            ("complex-add-def","(+ c (complex real ?a ?b) (complex real ?c ?d))","(complex real (+ f64 ?a ?c) (+ f64 ?b ?d))"),
+            ("complex-def-add","(complex real (+ f64 ?a ?c) (+ f64 ?b ?d))","(+ c (complex real ?a ?b) (complex real ?c ?d))"),
+            ("complex-sub-def","(- c (complex real ?a ?b) (complex real ?c ?d))","(complex real (- f64 ?a ?c) (- f64 ?b ?d))"),
+            ("complex-def-sub","(complex real (- f64 ?a ?c) (- f64 ?b ?d))","(- c (complex real ?a ?b) (complex real ?c ?d))"),
+            ("complex-neg-def","(neg c (complex real ?a ?b))","(complex real (neg f64 ?a) (neg f64 ?b))"),
+            ("complex-def-neg","(complex real (neg f64 ?a) (neg f64 ?b))","(neg c (complex real ?a ?b))"),
+            ("complex-mul-def","(* c (complex real ?a ?b) (complex real ?c ?d))","(complex real (- f64 (* f64 ?a ?c) (* f64 ?b ?d)) (+ f64 (* f64 ?a ?d) (* f64 ?b ?c)))"),
+            ("complex-div-def","(/ c (complex real ?a ?b) (complex real ?c ?d))","(complex real (/ f64 (+ f64 (* f64 ?a ?c) (* f64 ?b ?d)) (+ f64 (* f64 ?c ?c) (* f64 ?d ?d))) (/ f64 (- f64 (* f64 ?b ?c) (* f64 ?a ?d)) (+ f64 (* f64 ?c ?c) (* f64 ?d ?d))))"),
+            ("complex-conj-def","(conj real (complex real ?a ?b))","(complex real ?a (neg f64 ?b))"),
+        ],
+    );
+    add(
+        "branch-reduce",
+        &[
+            ("if-true", "(if real (TRUE real) ?x ?y)", "?x"),
+            ("if-false", "(if real (FALSE real) ?x ?y)", "?y"),
+            ("if-same", "(if real ?a ?x ?x)", "?x"),
+            (
+                "if-not",
+                "(if real (not real ?a) ?x ?y)",
+                "(if real ?a ?y ?x)",
+            ),
+            (
+                "if-if-or",
+                "(if real ?a ?x (if real ?b ?x ?y))",
+                "(if real (or real ?a ?b) ?x ?y)",
+            ),
+            (
+                "if-if-or-not",
+                "(if real ?a ?x (if real ?b ?y ?x))",
+                "(if real (or real ?a (not real ?b)) ?x ?y)",
+            ),
+            (
+                "if-if-and",
+                "(if real ?a (if real ?b ?x ?y) ?y)",
+                "(if real (and real ?a ?b) ?x ?y)",
+            ),
+            (
+                "if-if-and-not",
+                "(if real ?a (if real ?b ?y ?x) ?y)",
+                "(if real (and real ?a (not real ?b)) ?x ?y)",
+            ),
+        ],
+    );
+    add(
+        "compare-reduce",
+        &[
+            ("lt-same", "(< f64 ?x ?x)", "(FALSE real)"),
+            ("gt-same", "(> f64 ?x ?x)", "(FALSE real)"),
+            ("lte-same", "(<= f64 ?x ?x)", "(TRUE real)"),
+            ("gte-same", "(>= f64 ?x ?x)", "(TRUE real)"),
+            ("not-lt", "(not real (< f64 ?x ?y))", "(>= f64 ?x ?y)"),
+            ("not-gt", "(not real (> f64 ?x ?y))", "(<= f64 ?x ?y)"),
+            ("not-lte", "(not real (<= f64 ?x ?y))", "(> f64 ?x ?y)"),
+            ("not-gte", "(not real (>= f64 ?x ?y))", "(< f64 ?x ?y)"),
+        ],
+    );
+    add(
+        "bool-reduce",
+        &[
+            ("not-true", "(not real (TRUE real))", "(FALSE real)"),
+            ("not-false", "(not real (FALSE real))", "(TRUE real)"),
+            ("not-not", "(not real (not real ?a))", "?a"),
+            (
+                "not-and",
+                "(not real (and real ?a ?b))",
+                "(or real (not real ?a) (not real ?b))",
+            ),
+            (
+                "not-or",
+                "(not real (or real ?a ?b))",
+                "(and real (not real ?a) (not real ?b))",
+            ),
+            ("and-true-l", "(and real (TRUE real) ?a)", "?a"),
+            ("and-true-r", "(and real ?a (TRUE real))", "?a"),
+            ("and-false-l", "(and real (FALSE real) ?a)", "(FALSE real)"),
+            ("and-false-r", "(and real ?a (FALSE real))", "(FALSE real)"),
+            ("and-same", "(and real ?a ?a)", "?a"),
+            ("or-true-l", "(or real (TRUE real) ?a)", "(TRUE real)"),
+            ("or-true-r", "(or real ?a (TRUE real))", "(TRUE real)"),
+            ("or-false-l", "(or real (FALSE real) ?a)", "?a"),
+            ("or-false-r", "(or real ?a (FALSE real))", "?a"),
+            ("or-same", "(or real ?a ?a)", "?a"),
+        ],
+    );
+    add(
+        "htrig-reduce",
+        &[
+            ("sinh-def", "(sinh f64 ?x)", "(/ f64 (- f64 (exp f64 ?x) (exp f64 (neg f64 ?x))) 2)"),
+            ("cosh-def", "(cosh f64 ?x)", "(/ f64 (+ f64 (exp f64 ?x) (exp f64 (neg f64 ?x))) 2)"),
+            (
+                "tanh-def1",
+                "(tanh f64 ?x)",
+                "(/ f64 (- f64 (exp f64 ?x) (exp f64 (neg f64 ?x))) (+ f64 (exp f64 ?x) (exp f64 (neg f64 ?x))))",
+            ),
+            (
+                "tanh-def2",
+                "(tanh f64 ?x)",
+                "(/ f64 (- f64 (exp f64 (* f64 2 ?x)) 1) (+ f64 (exp f64 (* f64 2 ?x)) 1))",
+            ),
+            (
+                "tanh-def3",
+                "(tanh f64 ?x)",
+                "(/ f64 (- f64 1 (exp f64 (* f64 -2 ?x))) (+ f64 1 (exp f64 (* f64 -2 ?x))))",
+            ),
+            (
+                "sinh-cosh",
+                "(- f64 (* f64 (cosh f64 ?x) (cosh f64 ?x)) (* f64 (sinh f64 ?x) (sinh f64 ?x)))",
+                "1",
+            ),
+            ("sinh-+-cosh", "(+ f64 (cosh f64 ?x) (sinh f64 ?x))", "(exp f64 ?x)"),
+            ("sinh---cosh", "(- f64 (cosh f64 ?x) (sinh f64 ?x))", "(exp f64 (neg f64 ?x))"),
+        ],
+    );
+    add(
+        "trig-reduce-fp-sound-nan",
+        &[
+            (
+                "sin-neg",
+                "(sin f64 (neg f64 ?x))",
+                "(neg f64 (sin f64 ?x))",
+            ),
+            ("cos-neg", "(cos f64 (neg f64 ?x))", "(cos f64 ?x)"),
+            (
+                "tan-neg",
+                "(tan f64 (neg f64 ?x))",
+                "(neg f64 (tan f64 ?x))",
+            ),
+        ],
+    );
+    add(
+        "trig-reduce-fp-sound",
+        &[
+            ("sin-0", "(sin f64 0)", "0"),
+            ("cos-0", "(cos f64 0)", "1"),
+            ("tan-0", "(tan f64 0)", "0"),
+        ],
+    );
+    add(
+        "trig-reduce",
+        &[
+            (
+                "cos-sin-sum",
+                "(+ f64 (* f64 (cos f64 ?a) (cos f64 ?a)) (* f64 (sin f64 ?a) (sin f64 ?a)))",
+                "1",
+            ),
+            (
+                "1-sub-cos",
+                "(- f64 1 (* f64 (cos f64 ?a) (cos f64 ?a)))",
+                "(* f64 (sin f64 ?a) (sin f64 ?a))",
+            ),
+            (
+                "1-sub-sin",
+                "(- f64 1 (* f64 (sin f64 ?a) (sin f64 ?a)))",
+                "(* f64 (cos f64 ?a) (cos f64 ?a))",
+            ),
+            (
+                "-1-add-cos",
+                "(+ f64 (* f64 (cos f64 ?a) (cos f64 ?a)) -1)",
+                "(neg f64 (* f64 (sin f64 ?a) (sin f64 ?a)))",
+            ),
+            (
+                "-1-add-sin",
+                "(+ f64 (* f64 (sin f64 ?a) (sin f64 ?a)) -1)",
+                "(neg f64 (* f64 (cos f64 ?a) (cos f64 ?a)))",
+            ),
+            (
+                "sub-1-cos",
+                "(- f64 (* f64 (cos f64 ?a) (cos f64 ?a)) 1)",
+                "(neg f64 (* f64 (sin f64 ?a) (sin f64 ?a)))",
+            ),
+            (
+                "sub-1-sin",
+                "(- f64 (* f64 (sin f64 ?a) (sin f64 ?a)) 1)",
+                "(neg f64 (* f64 (cos f64 ?a) (cos f64 ?a)))",
+            ),
+            ("sin-PI/6", "(sin f64 (/ f64 (PI f64) 6))", "1/2"),
+            (
+                "sin-PI/4",
+                "(sin f64 (/ f64 (PI f64) 4))",
+                "(/ f64 (sqrt f64 2) 2)",
+            ),
+            (
+                "sin-PI/3",
+                "(sin f64 (/ f64 (PI f64) 3))",
+                "(/ f64 (sqrt f64 3) 2)",
+            ),
+            ("sin-PI/2", "(sin f64 (/ f64 (PI f64) 2))", "1"),
+            ("sin-PI", "(sin f64 PI)", "0"),
+            (
+                "sin-+PI",
+                "(sin f64 (+ f64 ?x PI))",
+                "(neg f64 (sin f64 ?x))",
+            ),
+            (
+                "sin-+PI/2",
+                "(sin f64 (+ f64 ?x (/ f64 (PI f64) 2)))",
+                "(cos f64 ?x)",
+            ),
+            (
+                "cos-PI/6",
+                "(cos f64 (/ f64 (PI f64) 6))",
+                "(/ f64 (sqrt f64 3) 2)",
+            ),
+            (
+                "cos-PI/4",
+                "(cos f64 (/ f64 (PI f64) 4))",
+                "(/ f64 (sqrt f64 2) 2)",
+            ),
+            ("cos-PI/3", "(cos f64 (/ f64 (PI f64) 3))", "1/2"),
+            ("cos-PI/2", "(cos f64 (/ f64 (PI f64) 2))", "0"),
+            ("cos-PI", "(cos f64 PI)", "-1"),
+            (
+                "cos-+PI",
+                "(cos f64 (+ f64 ?x (PI f64)))",
+                "(neg f64 (cos f64 ?x))",
+            ),
+            (
+                "cos-+PI/2",
+                "(cos f64 (+ f64 ?x (/ f64 (PI f64) 2)))",
+                "(neg f64 (sin f64 ?x))",
+            ),
+            (
+                "tan-PI/6",
+                "(tan f64 (/ f64 (PI f64) 6))",
+                "(/ f64 1 (sqrt f64 3))",
+            ),
+            ("tan-PI/4", "(tan f64 (/ f64 (PI f64) 4))", "1"),
+            ("tan-PI/3", "(tan f64 (/ f64 (PI f64) 3))", "(sqrt f64 3)"),
+            ("tan-PI", "(tan f64 PI)", "0"),
+            ("tan-+PI", "(tan f64 (+ f64 ?x PI))", "(tan f64 ?x)"),
+            (
+                "tan-+PI/2",
+                "(tan f64 (+ f64 ?x (/ f64 (PI f64) 2)))",
+                "(neg f64 (/ f64 1 (tan f64 ?x)))",
+            ),
+            (
+                "hang-0p-tan",
+                "(/ f64 (sin f64 ?a) (+ f64 1 (cos f64 ?a)))",
+                "(tan f64 (/ f64 ?a 2))",
+            ),
+            (
+                "hang-0m-tan",
+                "(/ f64 (neg f64 (sin f64 ?a)) (+ f64 1 (cos f64 ?a)))",
+                "(tan f64 (/ f64 (neg f64 ?a) 2))",
+            ),
+            (
+                "hang-p0-tan",
+                "(/ f64 (- f64 1 (cos f64 ?a)) (sin f64 ?a))",
+                "(tan f64 (/ f64 ?a 2))",
+            ),
+            (
+                "hang-m0-tan",
+                "(/ f64 (- f64 1 (cos f64 ?a)) (neg f64 (sin f64 ?a)))",
+                "(tan f64 (/ f64 (neg f64 ?a) 2))",
+            ),
+            (
+                "hang-p-tan",
+                "(/ f64 (+ f64 (sin f64 ?a) (sin f64 ?b)) (+ f64 (cos f64 ?a) (cos f64 ?b)))",
+                "(tan f64 (/ f64 (+ f64 ?a ?b) 2))",
+            ),
+            (
+                "hang-m-tan",
+                "(/ f64 (- f64 (sin f64 ?a) (sin f64 ?b)) (+ f64 (cos f64 ?a) (cos f64 ?b)))",
+                "(tan f64 (/ f64 (- f64 ?a ?b) 2))",
+            ),
+        ],
+    );
+    add(
+        "log-distribute-fp-safe",
+        &[("log-E", "(log f64 (E f64))", "1")],
+    );
+    add(
+        "log-distribute",
+        &[
+            (
+                "log-prod",
+                "(log f64 (* f64 ?a ?b))",
+                "(+ f64 (log f64 ?a) (log f64 ?b))",
+            ),
+            (
+                "log-div",
+                "(log f64 (/ f64 ?a ?b))",
+                "(- f64 (log f64 ?a) (log f64 ?b))",
+            ),
+            (
+                "log-rec",
+                "(log f64 (/ f64 1 ?a))",
+                "(neg f64 (log f64 ?a))",
+            ),
+            (
+                "log-pow",
+                "(log f64 (pow f64 ?a ?b))",
+                "(* f64 ?b (log f64 ?a))",
+            ),
+        ],
+    );
+    add(
+        "pow-canonicalize",
+        &[
+            (
+                "exp-to-pow",
+                "(exp f64 (* f64 (log f64 ?a) ?b))",
+                "(pow f64 ?a ?b)",
+            ),
+            (
+                "pow-plus",
+                "(* f64 (pow f64 ?a ?b) ?a)",
+                "(pow f64 ?a (+ f64 ?b 1))",
+            ),
+            ("unpow1/2", "(pow f64 ?a 1/2)", "(sqrt f64 ?a)"),
+            ("unpow2", "(pow f64 ?a 2)", "(* f64 ?a ?a)"),
+            ("unpow3", "(pow f64 ?a 3)", "(* f64 (* f64 ?a ?a) ?a)"),
+            ("unpow1/3", "(pow f64 ?a 1/3)", "(cbrt f64 ?a)"),
+        ],
+    );
+    add(
+        "pow-reduce-fp-safe-nan",
+        &[
+            ("unpow0", "(pow f64 ?a 0)", "1"),
+            ("pow-base-1", "(pow f64 1 ?a)", "1"),
+        ],
+    );
+    add("pow-reduce-fp-safe", &[("unpow1", "(pow f64 ?a 1)", "?a")]);
+    add(
+        "pow-reduce",
+        &[("unpow-1", "(pow f64 ?a -1)", "(/ f64 1 ?a)")],
+    );
+    add(
+        "exp-factor",
+        &[
+            (
+                "prod-exp",
+                "(* f64 (exp f64 ?a) (exp f64 ?b))",
+                "(exp f64 (+ f64 ?a ?b))",
+            ),
+            (
+                "rec-exp",
+                "(/ f64 1 (exp f64 ?a))",
+                "(exp f64 (neg f64 ?a))",
+            ),
+            (
+                "div-exp",
+                "(/ f64 (exp f64 ?a) (exp f64 ?b))",
+                "(exp f64 (- f64 ?a ?b))",
+            ),
+            (
+                "exp-prod",
+                "(exp f64 (* f64 ?a ?b))",
+                "(pow f64 (exp f64 ?a) ?b)",
+            ),
+            (
+                "exp-sqrt",
+                "(exp f64 (/ f64 ?a 2))",
+                "(sqrt f64 (exp f64 ?a))",
+            ),
+            (
+                "exp-cbrt",
+                "(exp f64 (/ f64 ?a 3))",
+                "(cbrt f64 (exp f64 ?a))",
+            ),
+            (
+                "exp-lft-sqr",
+                "(exp f64 (* f64 ?a 2))",
+                "(* f64 (exp f64 ?a) (exp f64 ?a))",
+            ),
+            (
+                "exp-lft-cube",
+                "(exp f64 (* f64 ?a 3))",
+                "(pow f64 (exp f64 ?a) 3)",
+            ),
+        ],
+    );
+    add(
+        "exp-distribute",
+        &[
+            (
+                "exp-sum",
+                "(exp f64 (+ f64 ?a ?b))",
+                "(* f64 (exp f64 ?a) (exp f64 ?b))",
+            ),
+            (
+                "exp-neg",
+                "(exp f64 (neg f64 ?a))",
+                "(/ f64 1 (exp f64 ?a))",
+            ),
+            (
+                "exp-diff",
+                "(exp f64 (- f64 ?a ?b))",
+                "(/ f64 (exp f64 ?a) (exp f64 ?b))",
+            ),
+        ],
+    );
+    add(
+        "exp-constants",
+        &[
+            ("exp-0", "(exp f64 0)", "1"),
+            ("exp-1-e", "(exp f64 1)", "(E f64)"),
+            ("1-exp", "1", "(exp f64 0)"),
+            ("e-exp-1", "(E f64)", "(exp f64 1)"),
+        ],
+    );
+    add(
+        "exp-reduce",
+        &[
+            ("rem-exp-log", "(exp f64 (log f64 ?x))", "?x"),
+            ("rem-log-exp", "(log f64 (exp f64 ?x))", "?x"),
+        ],
+    );
+    add(
+        "cubes-canonicalize",
+        &[("cube-unmult", "(* f64 ?x (* f64 ?x ?x))", "(pow f64 ?x 3)")],
+    );
+    add(
+        "cubes-distribute",
+        &[
+            (
+                "cube-prod",
+                "(pow f64 (* f64 ?x ?y) 3)",
+                "(* f64 (pow f64 ?x 3) (pow f64 ?y 3))",
+            ),
+            (
+                "cube-div",
+                "(pow f64 (/ f64 ?x ?y) 3)",
+                "(/ f64 (pow f64 ?x 3) (pow f64 ?y 3))",
+            ),
+            ("cube-mult", "(pow f64 ?x 3)", "(* f64 ?x (* f64 ?x ?x))"),
+        ],
+    );
+    add(
+        "cubes-reduce",
+        &[
+            ("rem-cube-cbrt", "(pow f64 (cbrt f64 ?x) 3)", "?x"),
+            ("rem-cbrt-cube", "(cbrt f64 (pow f64 ?x 3))", "?x"),
+            (
+                "cube-neg",
+                "(pow f64 (neg f64 ?x) 3)",
+                "(neg f64 (pow f64 ?x 3))",
+            ),
+        ],
+    );
+    add(
+        "squares-reduce-fp-sound",
+        &[(
+            "sqr-neg",
+            "(* f64 (neg f64 ?x) (neg f64 ?x))",
+            "(* f64 ?x ?x)",
+        )],
+    );
+    add(
+        "squares-reduce",
+        &[
+            (
+                "rem-square-sqrt",
+                "(* f64 (sqrt f64 ?x) (sqrt f64 ?x))",
+                "?x",
+            ),
+            (
+                "rem-sqrt-square",
+                "(sqrt f64 (* f64 ?x ?x))",
+                "(fabs f64 ?x)",
+            ),
+        ],
+    );
+    add(
+        "fractions-distribute.c",
+        &[
+            (
+                "div-sub.c",
+                "(/ c (- c ?a ?b) ?c)",
+                "(- c (/ c ?a ?c) (/ c ?b ?c))",
+            ),
+            (
+                "times-frac.c",
+                "(/ c (* c ?a ?b) (* c ?c ?d))",
+                "(* c (/ c ?a ?c) (/ c ?b ?d))",
+            ),
+        ],
+    );
+    add(
+        "fractions-distribute",
+        &[
+            (
+                "div-sub",
+                "(/ f64 (- f64 ?a ?b) ?c)",
+                "(- f64 (/ f64 ?a ?c) (/ f64 ?b ?c))",
+            ),
+            (
+                "times-frac",
+                "(/ f64 (* f64 ?a ?b) (* f64 ?c ?d))",
+                "(* f64 (/ f64 ?a ?c) (/ f64 ?b ?d))",
+            ),
+        ],
+    );
+    add(
+        "id-reduce-fp-safe",
+        &[
+            ("+-lft-identity", "(+ f64 0 ?a)", "?a"),
+            ("+-rgt-identity", "(+ f64 ?a 0)", "?a"),
+            ("--rgt-identity", "(- f64 ?a 0)", "?a"),
+            ("sub0-neg", "(- f64 0 ?a)", "(neg f64 ?a)"),
+            ("remove-double-neg", "(neg f64 (neg f64 ?a))", "?a"),
+            ("*-lft-identity", "(* f64 1 ?a)", "?a"),
+            ("*-rgt-identity", "(* f64 ?a 1)", "?a"),
+            ("/-rgt-identity", "(/ f64 ?a 1)", "?a"),
+            ("mul-1-neg", "(* f64 -1 ?a)", "(neg f64 ?a)"),
+        ],
+    );
+    add(
+        "id-reduce-fp-safe-nan",
+        &[
+            ("+-inverses", "(- f64 ?a ?a)", "0"),
+            ("*-inverses", "(/ f64 ?a ?a)", "1"),
+            ("div0", "(/ f64 0 ?a)", "0"),
+            ("mul0l", "(* f64 0 ?a)", "0"),
+            ("mul0r", "(* f64 ?a 0)", "0"),
+        ],
+    );
+    add(
+        "id-reduce",
+        &[
+            ("remove-double-div", "(/ f64 1 (/ f64 1 ?a))", "?a"),
+            ("rgt-mult-inverse", "(* f64 ?a (/ f64 1 ?a))", "1"),
+            ("lft-mult-inverse", "(* f64 (/ f64 1 ?a) ?a)", "1"),
+        ],
+    );
+    add(
+        "difference-of-squares-canonicalize",
+        &[
+            (
+                "swap-sqr",
+                "(* f64 (* f64 ?a ?b) (* f64 ?a ?b))",
+                "(* f64 (* f64 ?a ?a) (* f64 ?b ?b))",
+            ),
+            (
+                "unswap-sqr",
+                "(* f64 (* f64 ?a ?a) (* f64 ?b ?b))",
+                "(* f64 (* f64 ?a ?b) (* f64 ?a ?b))",
+            ),
+            (
+                "difference-of-squares",
+                "(- f64 (* f64 ?a ?a) (* f64 ?b ?b))",
+                "(* f64 (+ f64 ?a ?b) (- f64 ?a ?b))",
+            ),
+            (
+                "difference-of-sqr-1",
+                "(- f64 (* f64 ?a ?a) 1)",
+                "(* f64 (+ f64 ?a 1) (- f64 ?a 1))",
+            ),
+            (
+                "difference-of-sqr--1",
+                "(+ f64 (* f64 ?a ?a) -1)",
+                "(* f64 (+ f64 ?a 1) (- f64 ?a 1))",
+            ),
+            (
+                "sqr-pow",
+                "(pow f64 ?a ?b)",
+                "(* f64 (pow f64 ?a (/ f64 ?b 2)) (pow f64 ?a (/ f64 ?b 2)))",
+            ),
+            (
+                "pow-sqr",
+                "(* f64 (pow f64 ?a ?b) (pow f64 ?a ?b))",
+                "(pow f64 ?a (* f64 2 ?b))",
+            ),
+        ],
+    );
+    add(
+        "distributivity-fp-safe",
+        &[
+            (
+                "distribute-lft-neg-in",
+                "(neg f64 (* f64 ?a ?b))",
+                "(* f64 (neg f64 ?a) ?b)",
+            ),
+            (
+                "distribute-rgt-neg-in",
+                "(neg f64 (* f64 ?a ?b))",
+                "(* f64 ?a (neg f64 ?b))",
+            ),
+            (
+                "distribute-lft-neg-out",
+                "(* f64 (neg f64 ?a) ?b)",
+                "(neg f64 (* f64 ?a ?b))",
+            ),
+            (
+                "distribute-rgt-neg-out",
+                "(* f64 ?a (neg f64 ?b))",
+                "(neg f64 (* f64 ?a ?b))",
+            ),
+            (
+                "distribute-neg-in",
+                "(neg f64 (+ f64 ?a ?b))",
+                "(+ f64 (neg f64 ?a) (neg f64 ?b))",
+            ),
+            (
+                "distribute-neg-out",
+                "(+ f64 (neg f64 ?a) (neg f64 ?b))",
+                "(neg f64 (+ f64 ?a ?b))",
+            ),
+            (
+                "distribute-frac-neg",
+                "(/ f64 (neg f64 ?a) ?b)",
+                "(neg f64 (/ f64 ?a ?b))",
+            ),
+            (
+                "distribute-neg-frac",
+                "(neg f64 (/ f64 ?a ?b))",
+                "(/ f64 (neg f64 ?a) ?b)",
+            ),
+        ],
+    );
+    add(
+        "distributivity.c",
+        &[
+            (
+                "distribute-lft-in.c",
+                "(* c ?a (+ c ?b ?c))",
+                "(+ c (* c ?a ?b) (* c ?a ?c))",
+            ),
+            (
+                "distribute-rgt-in.c",
+                "(* c ?a (+ c ?b ?c))",
+                "(+ c (* c ?b ?a) (* c ?c ?a))",
+            ),
+            (
+                "distribute-lft-out.c",
+                "(+ c (* c ?a ?b) (* c ?a ?c))",
+                "(* c ?a (+ c ?b ?c))",
+            ),
+            (
+                "distribute-lft-out--.c",
+                "(- c (* c ?a ?b) (* c ?a ?c))",
+                "(* c ?a (- c ?b ?c))",
+            ),
+            (
+                "distribute-rgt-out.c",
+                "(+ c (* c ?b ?a) (* c ?c ?a))",
+                "(* c ?a (+ c ?b ?c))",
+            ),
+            (
+                "distribute-rgt-out-- c",
+                "(- c (* c ?b ?a) (* c ?c ?a))",
+                "(* c ?a (- c ?b ?c))",
+            ),
+            (
+                "distribute-lft1-in.c",
+                "(+ c (* c ?b ?a) ?a)",
+                "(* c (+ c ?b (complex real 1 0)) ?a)",
+            ),
+            (
+                "distribute-rgt1-in.c",
+                "(+ c ?a (* c ?c ?a))",
+                "(* c (+ c ?c (complex real 1 0)) ?a)",
+            ),
+        ],
+    );
+    add(
+        "distributivity",
+        &[
+            (
+                "distribute-lft-in",
+                "(* f64 ?a (+ f64 ?b ?c))",
+                "(+ f64 (* f64 ?a ?b) (* f64 ?a ?c))",
+            ),
+            (
+                "distribute-rgt-in",
+                "(* f64 ?a (+ f64 ?b ?c))",
+                "(+ f64 (* f64 ?b ?a) (* f64 ?c ?a))",
+            ),
+            (
+                "distribute-lft-out",
+                "(+ f64 (* f64 ?a ?b) (* f64 ?a ?c))",
+                "(* f64 ?a (+ f64 ?b ?c))",
+            ),
+            (
+                "distribute-lft-out--",
+                "(- f64 (* f64 ?a ?b) (* f64 ?a ?c))",
+                "(* f64 ?a (- f64 ?b ?c))",
+            ),
+            (
+                "distribute-rgt-out",
+                "(+ f64 (* f64 ?b ?a) (* f64 ?c ?a))",
+                "(* f64 ?a (+ f64 ?b ?c))",
+            ),
+            (
+                "distribute-rgt-out--",
+                "(- f64 (* f64 ?b ?a) (* f64 ?c ?a))",
+                "(* f64 ?a (- f64 ?b ?c))",
+            ),
+            (
+                "distribute-lft1-in",
+                "(+ f64 (* f64 ?b ?a) ?a)",
+                "(* f64 (+ f64 ?b 1) ?a)",
+            ),
+            (
+                "distribute-rgt1-in",
+                "(+ f64 ?a (* f64 ?c ?a))",
+                "(* f64 (+ f64 ?c 1) ?a)",
+            ),
+        ],
+    );
+    add("counting", &[("count-2", "(+ f64 ?x ?x)", "(* f64 2 ?x)")]);
+    add(
+        "associativity.c",
+        &[
+            (
+                "associate-+r+.c",
+                "(+ c ?a (+ c ?b ?c))",
+                "(+ c (+ c ?a ?b) ?c)",
+            ),
+            (
+                "associate-+l+.c",
+                "(+ c (+ c ?a ?b) ?c)",
+                "(+ c ?a (+ c ?b ?c))",
+            ),
+            (
+                "associate-+r-.c",
+                "(+ c ?a (- c ?b ?c))",
+                "(- c (+ c ?a ?b) ?c)",
+            ),
+            (
+                "associate-+l-.c",
+                "(+ c (- c ?a ?b) ?c)",
+                "(- c ?a (- c ?b ?c))",
+            ),
+            (
+                "associate--r+.c",
+                "(- c ?a (+ c ?b ?c))",
+                "(- c (- c ?a ?b) ?c)",
+            ),
+            (
+                "associate--l+.c",
+                "(- c (+ c ?a ?b) ?c)",
+                "(+ c ?a (- c ?b ?c))",
+            ),
+            (
+                "associate--l-.c",
+                "(- c (- c ?a ?b) ?c)",
+                "(- c ?a (+ c ?b ?c))",
+            ),
+            (
+                "associate--r-.c",
+                "(- c ?a (- c ?b ?c))",
+                "(+ c (- c ?a ?b) ?c)",
+            ),
+            (
+                "associate-*r*.c",
+                "(* c ?a (* c ?b ?c))",
+                "(* c (* c ?a ?b) ?c)",
+            ),
+            (
+                "associate-*l*.c",
+                "(* c (* c ?a ?b) ?c)",
+                "(* c ?a (* c ?b ?c))",
+            ),
+            (
+                "associate-*r/.c",
+                "(* c ?a (/ c ?b ?c))",
+                "(/ c (* c ?a ?b) ?c)",
+            ),
+            (
+                "associate-*l/.c",
+                "(* c (/ c ?a ?b) ?c)",
+                "(/ c (* c ?a ?c) ?b)",
+            ),
+            (
+                "associate-/r*.c",
+                "(/ c ?a (* c ?b ?c))",
+                "(/ c (/ c ?a ?b) ?c)",
+            ),
+            (
+                "associate-/l*.c",
+                "(/ c (* c ?b ?c) ?a)",
+                "(/ c ?b (/ c ?a ?c))",
+            ),
+            (
+                "associate-/r/.c",
+                "(/ c ?a (/ c ?b ?c))",
+                "(* c (/ c ?a ?b) ?c)",
+            ),
+            (
+                "associate-/l/.c",
+                "(/ c (/ c ?b ?c) ?a)",
+                "(/ c ?b (* c ?a ?c))",
+            ),
+            ("sub-neg.c", "(- c ?a ?b)", "(+ c ?a (neg c ?b))"),
+            ("unsub-neg.c", "(+ c ?a (neg c ?b))", "(- c ?a ?b)"),
+        ],
+    );
+    add(
+        "associativity",
+        &[
+            (
+                "associate-+r+",
+                "(+ f64 ?a (+ f64 ?b ?c))",
+                "(+ f64 (+ f64 ?a ?b) ?c)",
+            ),
+            (
+                "associate-+l+",
+                "(+ f64 (+ f64 ?a ?b) ?c)",
+                "(+ f64 ?a (+ f64 ?b ?c))",
+            ),
+            (
+                "associate-+r-",
+                "(+ f64 ?a (- f64 ?b ?c))",
+                "(- f64 (+ f64 ?a ?b) ?c)",
+            ),
+            (
+                "associate-+l-",
+                "(+ f64 (- f64 ?a ?b) ?c)",
+                "(- f64 ?a (- f64 ?b ?c))",
+            ),
+            (
+                "associate--r+",
+                "(- f64 ?a (+ f64 ?b ?c))",
+                "(- f64 (- f64 ?a ?b) ?c)",
+            ),
+            (
+                "associate--l+",
+                "(- f64 (+ f64 ?a ?b) ?c)",
+                "(+ f64 ?a (- f64 ?b ?c))",
+            ),
+            (
+                "associate--l-",
+                "(- f64 (- f64 ?a ?b) ?c)",
+                "(- f64 ?a (+ f64 ?b ?c))",
+            ),
+            (
+                "associate--r-",
+                "(- f64 ?a (- f64 ?b ?c))",
+                "(+ f64 (- f64 ?a ?b) ?c)",
+            ),
+            (
+                "associate-*r*",
+                "(* f64 ?a (* f64 ?b ?c))",
+                "(* f64 (* f64 ?a ?b) ?c)",
+            ),
+            (
+                "associate-*l*",
+                "(* f64 (* f64 ?a ?b) ?c)",
+                "(* f64 ?a (* f64 ?b ?c))",
+            ),
+            (
+                "associate-*r/",
+                "(* f64 ?a (/ f64 ?b ?c))",
+                "(/ f64 (* f64 ?a ?b) ?c)",
+            ),
+            (
+                "associate-*l/",
+                "(* f64 (/ f64 ?a ?b) ?c)",
+                "(/ f64 (* f64 ?a ?c) ?b)",
+            ),
+            (
+                "associate-/r*",
+                "(/ f64 ?a (* f64 ?b ?c))",
+                "(/ f64 (/ f64 ?a ?b) ?c)",
+            ),
+            (
+                "associate-/l*",
+                "(/ f64 (* f64 ?b ?c) ?a)",
+                "(/ f64 ?b (/ f64 ?a ?c))",
+            ),
+            (
+                "associate-/r/",
+                "(/ f64 ?a (/ f64 ?b ?c))",
+                "(* f64 (/ f64 ?a ?b) ?c)",
+            ),
+            (
+                "associate-/l/",
+                "(/ f64 (/ f64 ?b ?c) ?a)",
+                "(/ f64 ?b (* f64 ?a ?c))",
+            ),
+            ("sub-neg", "(- f64 ?a ?b)", "(+ f64 ?a (neg f64 ?b))"),
+            ("unsub-neg", "(+ f64 ?a (neg f64 ?b))", "(- f64 ?a ?b)"),
+        ],
+    );
+    add(
+        "commutativity.c",
+        &[
+            ("+ c-commutative", "(+ c ?a ?b)", "(+ c ?b ?a)"),
+            ("* c-commutative", "(* c ?a ?b)", "(* c ?b ?a)"),
+        ],
+    );
+    add(
+        "commutativity",
+        &[
+            ("+-commutative", "(+ f64 ?a ?b)", "(+ f64 ?b ?a)"),
+            ("*-commutative", "(* f64 ?a ?b)", "(* f64 ?b ?a)"),
+        ],
+    );
+
+    m
+}

--- a/egg-herbie/tests/tests.rs
+++ b/egg-herbie/tests/tests.rs
@@ -1,0 +1,26 @@
+use egg_math::{math::*, rules::math_rules};
+
+fn rules() -> Vec<Rewrite> {
+    math_rules()
+        .into_iter()
+        .flat_map(|(_group, rewrites)| rewrites)
+        .collect()
+}
+
+egg::test_fn! {
+    math_simplify_root, rules(),
+    // runner = Runner::default().with_node_limit(75_000),
+    r#"
+    (/ f64 1
+       (- f64 (/ f64 (+ f64 1 (sqrt f64 five))
+             2)
+          (/ f64 (- f64 1 (sqrt f64 five))
+             2)))"#
+    =>
+    "(/ f64 1 (sqrt f64 five))"
+}
+
+egg::test_fn! {
+    math_simplify_neg, rules(),
+    "(neg f64 1)" => "-1"
+}

--- a/egg-herbie/to-egg-pattern.rkt
+++ b/egg-herbie/to-egg-pattern.rkt
@@ -1,0 +1,54 @@
+#lang racket
+
+(provide to-egg-pattern extract-operator extract-symbol constant?)
+
+(module+ test (require rackunit))
+
+;; copy of constants from herbie/fpcore for egg-herbie
+(define constants
+  (append
+    '(E LOG2E LOG10E LN2 LN10
+        PI PI_2 PI_4 1_PI 2_PI 2_SQRTPI
+        SQRT2 SQRT1_2 MAXFLOAT HUGE_VAL
+        TRUE FALSE)))
+
+(define (constant? x)
+  (set-member? constants x))
+
+(define (extract-operator op)
+  (if (symbol? op)
+      (match (regexp-match #px"([^\\s^\\.]+)\\.([^\\s]+)" (~s op))
+        [(list _ op* prec)  (list op* prec)]
+        [#f (list (~s op) "real")])
+      #f))
+
+(define (extract-symbol sym)
+  (if (symbol? sym)
+      (match (regexp-match #px"([^\\s^\\.]+)\\.([^\\s]+)" (~s sym))
+        [(list _ constant prec) (~a (list constant prec))]
+        [#f (format (if (constant? sym) "(~a real)" "?~a") sym)])
+      #f))
+
+(define (to-egg-pattern datum)
+  (cond
+    [(list? datum)
+     (string-join
+      (append
+       (extract-operator (first datum))
+       (map (lambda (sub-expr) (to-egg-pattern sub-expr))
+            (rest datum)))
+      " "
+      #:before-first "("
+      #:after-last ")")]
+    [(symbol? datum)
+     (extract-symbol datum)]
+    [(number? datum)
+     (number->string datum)]
+    [else
+     (error "expected list, number, or symbol")]))
+
+(module+ test
+  (check-equal? (to-egg-pattern `(+ a b)) "(+ real ?a ?b)")
+  (check-equal? (to-egg-pattern `(/ c (- 2 a))) "(/ real ?c (- real 2 ?a))")
+  (check-equal? (to-egg-pattern `(cos.f64 PI.f64)) "(cos f64 (PI f64))")
+  (check-equal? (to-egg-pattern `(if TRUE x y)) "(if real (TRUE real) ?x ?y)"))

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -29,9 +29,7 @@
     "profile-lib"
     "rackunit-lib"
     "web-server-lib"
-    ("egg-herbie-windows" #:platform "win32\\x86_64" #:version "1.4")
-    ("egg-herbie-osx" #:platform "x86_64-macosx" #:version "1.4")
-    ("egg-herbie-linux" #:platform "x86_64-linux" #:version "1.4")
+    ("egg-herbie" #:version "1.4")
     ("regraph" #:version "1.4")
     ("rival" #:version "1.4")
     ("fpbench" #:version "2.0")))

--- a/www/doc/1.4/installing.html
+++ b/www/doc/1.4/installing.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html>
+
 <head>
   <meta charset="utf-8" />
   <title>Installing Herbie</title>
@@ -7,12 +8,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script type="text/javascript" src="toc.js"></script>
 </head>
+
 <body>
   <header>
     <a href="../../"><img class="logo" src="../../logo.png" /></a>
     <h1>Installing Herbie</h1>
   </header>
-  
+
   <p>
     <a href="../../">Herbie</a> supports Linux, macOS, and Windows. It
     can be installed from a package or from source. To start, install
@@ -26,7 +28,7 @@
   <p>
     Install Racket, version 7.0 or later, either using
     the <a href="http://download.racket-lang.org/racket-v7.7.html">official
-    installer</a> or distro-provided packages. Versions 7.5 and later
+      installer</a> or distro-provided packages. Versions 7.5 and later
     are significantly faster, and we recommend upgrading.
   </p>
 
@@ -37,7 +39,7 @@
   <pre class="shell">racket
 Welcome to Racket v7.7.
 > (exit)</pre>
-  
+
   <h2>Installing Herbie from a package</h2>
 
   <p>Once Racket is installed, install Herbie from a package with:</p>
@@ -65,7 +67,14 @@ Welcome to Racket v7.7.
   <h2>Installing Herbie from source</h2>
 
   <p>
-    Once Racket is installed, download the Herbie source
+    Install Rust, using <a href="https://rustup.rs/">rustup</a> or via
+    some other means. Also install Racket, version 7.0 or later, either using
+    the <a href="http://download.racket-lang.org/racket-v7.7.html">official
+      installer</a> or distro-provided packages.
+  </p>
+
+  <p>
+    Once Racket and Rust are installed, download the Herbie source
     <a href="https://github.com/uwplse/herbie">from GitHub</a> with:
   </p>
 
@@ -99,7 +108,7 @@ Welcome to Racket v7.7.
     your executable path. Once Herbie is installed and working
     correctly, check out the <a href="tutorial.html">tutorial</a>.
   </p>
-  
+
   <!-- End of copy -->
 
   <h2>Installing Herbie with Docker</h2>
@@ -110,11 +119,12 @@ Welcome to Racket v7.7.
     in Docker is more limited; we do not recommend using Herbie
     through Docker without prior Docker experience.
   </p>
-  
+
   <p>
     The <a href="docker.html">Docker documentation</a> describes how
     to install and run the official <code>uwplse/herbie</code> image.
   </p>
 
 </body>
+
 </html>


### PR DESCRIPTION
`egg-herbie`, the `egg` interface for Herbie, previously lived here: https://github.com/herbie-fp/egg-herbie
However, it has become clear that Herbie is tightly coupled to the rust code that runs the e-graph using `egg`, and also to the racket interface to that rust code.
So `egg-herbie` will now live as a package in the same repository.

Users of Herbie have two options for installing Herbie, and the README and website have been updated to reflect them.
One is to `raco pkg install` Herbie in the `src` directory. Installing this way uses the old `egg-herbie` repository to redirect to pre-built binaries for `egg-herbie`.
The second requires that Rust be installed. Running `make install` in the `herbie` directory will build the local `egg-herbie` and install it.