### PR TITLE
Series expand one variable at a time

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -6,7 +6,7 @@
 
 (provide reap define-table table-ref table-set! table-remove!
          string-prefix call-with-output-files
-         take-up-to flip-lists list/true find-duplicates all-partitions
+         take-up-to flip-lists list/true find-duplicates
          argmins argmaxs index-of set-disjoint? comparator
          parse-flag get-seed set-seed!
          quasisyntax syntax-e* dict sym-append
@@ -216,14 +216,6 @@
   (if name
       (build-path web-resource-path name)
       web-resource-path))
-
-(define (all-partitions n #:from [k 1])
-  (cond
-   [(= n 0) '(())]
-   [(< n k) '()]
-   [else
-    (append (map (curry cons k) (all-partitions (- n k) #:from k))
-            (all-partitions n #:from (+ k 1)))]))
 
 (define ((comparator test) . args)
   (for/and ([left args] [right (cdr args)])

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -26,8 +26,9 @@
           (next (+ iter 1))
           (simplify (make-sum (reverse terms))))]
      [_
-      (define term (simplify `(* ,coeff ,(make-monomial ((cdr tform) var) (- i offset 1)))))
-      (set! terms (cons term terms))
+      (define term `(* ,coeff ,(make-monomial var (- i offset 1))))
+      (define term* (simplify (replace-expression term var ((cdr tform) var))))
+      (set! terms (cons term* terms))
       (simplify (make-sum (reverse terms)))]))
 
   next)

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -374,9 +374,9 @@
           (λ (n)
             (hash-ref! hash n
                        (λ ()
-                         (define coeffs* (list->vector (map coeffs (range (+ n 1)))))
+                         (define coeffs* (list->vector (map coeffs (range 1 (+ n 1)))))
                          (define nums
-                           (for/list ([i (in-range (+ n 1))] [coeff (in-vector coeffs*)]
+                           (for/list ([i (in-range 1 (+ n 1))] [coeff (in-vector coeffs*)]
                                       #:unless (equal? coeff 0))
                              i))
                          (simplify
@@ -385,7 +385,7 @@
                                 (if (= (modulo (apply + (map car p)) 2) 1)
                                     `(* ,(if (= (modulo (apply + (map car p)) 4) 1) 1 -1)
                                         ,@(for/list ([(count num) (in-dict p)])
-                                            `(/ (pow ,(vector-ref coeffs* num) ,count)
+                                            `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
                                                 ,(factorial count))))
                                     0))))))))))
 
@@ -396,9 +396,9 @@
           (λ (n)
             (hash-ref! hash n
                        (λ ()
-                         (define coeffs* (list->vector (map coeffs (range (+ n 1)))))
+                         (define coeffs* (list->vector (map coeffs (range 1 (+ n 1)))))
                          (define nums
-                           (for/list ([i (in-range (+ n 1))] [coeff (in-vector coeffs*)]
+                           (for/list ([i (in-range 1 (+ n 1))] [coeff (in-vector coeffs*)]
                                       #:unless (equal? coeff 0))
                              i))
                          (simplify
@@ -407,7 +407,7 @@
                                 (if (= (modulo (apply + (map car p)) 2) 0)
                                     `(* ,(if (= (modulo (apply + (map car p)) 4) 0) 1 -1)
                                         ,@(for/list ([(count num) (in-dict p)])
-                                            `(/ (pow ,(vector-ref coeffs* num) ,count)
+                                            `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
                                                 ,(factorial count))))
                                     0))))))))))
 

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -356,7 +356,7 @@
                          (define coeffs* (list->vector (map coeffs (range (+ n 1)))))
                          (define nums
                            (for/list ([i (in-range (+ n 1))] [coeff (in-vector coeffs*)]
-                                      #:unless (= coeff 0))
+                                      #:unless (equal? coeff 0))
                              i))
                          (simplify
                           `(* (exp ,(coeffs 0))
@@ -377,7 +377,7 @@
                          (define coeffs* (list->vector (map coeffs (range (+ n 1)))))
                          (define nums
                            (for/list ([i (in-range (+ n 1))] [coeff (in-vector coeffs*)]
-                                      #:unless (= coeff 0))
+                                      #:unless (equal? coeff 0))
                              i))
                          (simplify
                           `(+
@@ -399,7 +399,7 @@
                          (define coeffs* (list->vector (map coeffs (range (+ n 1)))))
                          (define nums
                            (for/list ([i (in-range (+ n 1))] [coeff (in-vector coeffs*)]
-                                      #:unless (= coeff 0))
+                                      #:unless (equal? coeff 0))
                              i))
                          (simplify
                           `(+

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -334,19 +334,18 @@
   "This gets tricky, because the function might have a pole at 0.
    This happens if the inverted series doesn't have a constant term,
    so we extract that case out."
-  (match (cons (normalize-series num) (normalize-series denom))
-    [(cons (cons noff a) (cons doff b))
-     (let ([hash (make-hash)])
-       (hash-set! hash 0 (simplify `(/ ,(a 0) ,(b 0))))
-       (letrec ([f (λ (n)
-                      (hash-ref! hash n
-                                 (λ ()
-                                    (simplify
-                                     `(- (/ ,(a n) ,(b 0))
-                                         (+ ,@(for/list ([i (range n)])
-                                                `(* ,(f i) (/ ,(b (- n i)) ,(b 0))))))))))]
-                [offset (- noff doff)])
-         (cons offset f)))]))
+  (match-define (cons noff a) (normalize-series num))
+  (match-define (cons doff b) (normalize-series denom))
+  (define hash (make-hash))
+  (hash-set! hash 0 (simplify `(/ ,(a 0) ,(b 0))))
+  (define (f n)
+    (hash-ref! hash n
+               (λ ()
+                 (simplify
+                  `(- (/ ,(a n) ,(b 0))
+                      (+ ,@(for/list ([i (range n)])
+                             `(* ,(f i) (/ ,(b (- n i)) ,(b 0))))))))))
+  (cons (- noff doff) f))
 
 (define (taylor-sqrt num)
   (let* ([num* (normalize-series num)]

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -26,7 +26,7 @@
           (next (+ iter 1))
           (simplify (make-sum (reverse terms))))]
      [_
-      (define term (simplify `(* ,coeff ,(make-monomial var (- i offset 1)))))
+      (define term (simplify `(* ,coeff ,(make-monomial ((cdr tform) var) (- i offset 1)))))
       (set! terms (cons term terms))
       (simplify (make-sum (reverse terms)))]))
 

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -353,9 +353,9 @@
           (λ (n)
             (hash-ref! hash n
                        (λ ()
-                         (define coeffs* (list->vector (map coeffs (range (+ n 1)))))
+                         (define coeffs* (list->vector (map coeffs (range 1 (+ n 1)))))
                          (define nums
-                           (for/list ([i (in-range (+ n 1))] [coeff (in-vector coeffs*)]
+                           (for/list ([i (in-range 1 (+ n 1))] [coeff (in-vector coeffs*)]
                                       #:unless (equal? coeff 0))
                              i))
                          (simplify
@@ -364,7 +364,7 @@
                                ,@(for/list ([p (all-partitions n (sort nums >))])
                                    `(*
                                      ,@(for/list ([(count num) (in-dict p)])
-                                         `(/ (pow ,(vector-ref coeffs* num) ,count)
+                                         `(/ (pow ,(vector-ref coeffs* (- num 1)) ,count)
                                              ,(factorial count))))))))))))))
 
 (define (taylor-sin coeffs)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -149,33 +149,41 @@
 
 ; taylor uses older format, resugaring and desugaring needed
 ; not all taylor transforms are valid in a given repr, return false on failure
-(define (taylor-expr expr repr vars transformer)
+(define (taylor-expr expr repr var f finv)
   (define expr* (resugar-program expr repr #:full #f))
-  (with-handlers ([exn:fail? (const #f)]) 
-    (let ([approx (approximate expr* vars #:transform transformer #:terms 2)])
-      (desugar-program approx repr (*var-reprs*) #:full #f))))
+  ;(with-handlers ([exn:fail? (const #f)]) 
+    (define genexpr (approximate2 expr* var #:transform (cons f finv)))
+    (λ () (desugar-program (genexpr) repr (*var-reprs*) #:full #f)));)
+
+(define (exact-min x y)
+  (if (<= x y) x y))
+
+(define (much-< x y)
+  (< x (/ y 2)))
 
 (define (taylor-alt altn loc)
   (define expr (location-get loc (alt-program altn)))
-  (define repr (location-repr loc (alt-program altn) (*output-repr*) (*var-reprs*)))
+  (define repr (get-representation (repr-of expr (*output-repr*) (*var-reprs*))))
   (define vars (free-variables expr))
-  (if (or (null? vars) ;; `approximate` cannot be called with a null vars list
-          (not (set-member? '(binary64 binary32) ; currently taylor/reduce breaks with posits
-                            (repr-of expr (*output-repr*) (*var-reprs*)))))
+  ;; currently taylor/reduce breaks with posits 
+  (if (not (set-member? '(binary64 binary32) (representation-name repr)))
       (list altn)
-      (for*/fold ([alts '()] #:result (reverse alts)) ; filter out failed taylor transforms
-          ([var vars] [transform-type transforms-to-try])
-        (match-define (list name f finv) transform-type)
-        (define transformer (list (cons f finv)))
-        (define valid? #t)
-        (define altn*
-          (alt (location-do loc (alt-program altn) 
-                            (λ (x) (let ([expr* (taylor-expr x repr (list var) transformer)])
-                                      (unless expr* (set! valid? #f))
-                                      expr*)))
-              `(taylor ,name ,loc)
-              (list altn)))
-        (if valid? (cons altn* alts) alts))))
+      (reap [sow]
+        (for* ([var vars] [transform-type transforms-to-try])
+          (match-define (list name f finv) transform-type)
+          (define genexpr (taylor-expr expr repr var f finv))
+
+          #;(define pts (for/list ([(p e) (in-pcontext (*pcontext*))]) p))
+          (let loop ([last (for/list ([(p e) (in-pcontext (*pcontext*))]) +inf.0)] [i 0])
+            (define expr* (location-do loc (alt-program altn) (const (genexpr))))
+            (when expr*
+              (define errs (errors expr* (*pcontext*) (*output-repr*)))
+              (define altn* (alt expr* `(taylor ,name ,loc) (list altn)))
+              (when (ormap much-< errs last)
+                #;(eprintf "Better on ~a\n" (ormap (λ (pt x y) (and (much-< x y) (list pt x y))) pts errs last))
+                (sow altn*)
+                (when (< i 3)
+                  (loop (map exact-min errs last) (+ i 1))))))))))
 
 (define (gen-series!)
   (unless (^locs^)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -152,7 +152,7 @@
 (define (taylor-expr expr repr vars transformer)
   (define expr* (resugar-program expr repr #:full #f))
   (with-handlers ([exn:fail? (const #f)]) 
-    (let ([approx (approximate expr* vars #:transform transformer)])
+    (let ([approx (approximate expr* vars #:transform transformer #:terms 2)])
       (desugar-program approx repr (*var-reprs*) #:full #f))))
 
 (define (taylor-alt altn loc)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -149,7 +149,7 @@
 (define (taylor-expr expr repr var f finv)
   (define expr* (resugar-program expr repr #:full #f))
   (with-handlers ([exn:fail? (const #f)]) 
-    (define genexpr (approximate2 expr* var #:transform (cons f finv)))
+    (define genexpr (approximate expr* var #:transform (cons f finv)))
     (λ () (desugar-program (genexpr) repr (*var-reprs*) #:full #f))))
 
 (define (exact-min x y)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -163,14 +163,14 @@
           (not (set-member? '(binary64 binary32) ; currently taylor/reduce breaks with posits
                             (repr-of expr (*output-repr*) (*var-reprs*)))))
       (list altn)
-      (for/fold ([alts '()] #:result (reverse alts)) ; filter out failed taylor transforms
-                ([transform-type transforms-to-try])
+      (for*/fold ([alts '()] #:result (reverse alts)) ; filter out failed taylor transforms
+          ([var vars] [transform-type transforms-to-try])
         (match-define (list name f finv) transform-type)
-        (define transformer (map (const (cons f finv)) vars))
+        (define transformer (list (cons f finv)))
         (define valid? #t)
         (define altn*
           (alt (location-do loc (alt-program altn) 
-                            (λ (x) (let ([expr* (taylor-expr x repr vars transformer)])
+                            (λ (x) (let ([expr* (taylor-expr x repr (list var) transformer)])
                                       (unless expr* (set! valid? #f))
                                       expr*)))
               `(taylor ,name ,loc)

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -155,6 +155,9 @@
 (define (exact-min x y)
   (if (<= x y) x y))
 
+(define (much-< x y)
+  (< x (/ y 2)))
+
 (define (taylor-alt altn loc)
   (define expr (location-get loc (alt-program altn)))
   (define repr (get-representation (repr-of expr (*output-repr*) (*var-reprs*))))
@@ -167,17 +170,17 @@
           (match-define (list name f finv) transform-type)
           (define genexpr (taylor-expr expr repr var f finv))
 
-          (define pts (for/list ([(p e) (in-pcontext (*pcontext*))]) p))
+          #;(define pts (for/list ([(p e) (in-pcontext (*pcontext*))]) p))
           (let loop ([last (for/list ([(p e) (in-pcontext (*pcontext*))]) +inf.0)] [i 0])
             (define expr* (location-do loc (alt-program altn) (const (genexpr))))
-            #;(eprintf "~a ~~ ~a[~a]: ~a\n" var name i (program-body expr*))
             (when expr*
               (define errs (errors expr* (*pcontext*) (*output-repr*)))
               (define altn* (alt expr* `(taylor ,name ,loc) (list altn)))
-              (sow altn*)
-              #;(eprintf "Better on ~a\n" (count (λ (pt x y) (and (< x y) (list pt x y))) pts errs last))
-              (when (and (ormap < errs last) (< i 5))
-                (loop (map exact-min errs last) (+ i 1)))))))))
+              (when (ormap much-< errs last)
+                #;(eprintf "Better on ~a\n" (ormap (λ (pt x y) (and (much-< x y) (list pt x y))) pts errs last))
+                (sow altn*)
+                (when (< i 3)
+                  (loop (map exact-min errs last) (+ i 1))))))))))
 
 (define (gen-series!)
   (unless (^locs^)


### PR DESCRIPTION
One of Herbie's core rewrites is taking the series expansion of an expression (like a Taylor expansion, though we actually use bounded Laurant series). Right now, Herbie uses a multivariate series expansion, but it seems that this is actually unnecessary: successive Herbie iterations can handle multiple variables if it's really necessary, and in practice it seems like it basically never is.

This commit switches Herbie from multi-variate to univariate series expansions. It also adds support for "streaming" expansions, which do more or fewer terms based on what helps the most. That turns out to be necessary because univariate expansions let us get more terms, which isn't always a win. A final bonus from this branch is the ability to delete the large, ugly `approximate` function, which did the multivariate expansion in the first place.

The overall results suggest that `taylor-one-var` is _significantly_ better (350b over the full benchmark suite) than regular Herbie, and may also be somewhat faster.