### PR TITLE
Egg interface fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,13 @@ jobs:
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v0.5
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: make install
@@ -33,9 +40,16 @@ jobs:
         uses: Bogdanp/setup-racket@v0.5
         with:
           version: ${{ matrix.racket-version }}
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
       - uses: actions/checkout@master
       - name: "Install dependencies"
-        run: raco pkg install --name herbie --no-cache --auto src/
+        run: make install
       - run: racket infra/travis.rkt --precision ${{ matrix.precision }} --seed 0 bench/hamming/
 
   softposit:
@@ -47,9 +61,16 @@ jobs:
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v0.5
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
       - uses: actions/checkout@master
       - name: "Install dependencies"
-        run: raco pkg install --name herbie --no-cache --auto src/
+        run: make install
       - name: "Check out softposit-herbie master"
         uses: actions/checkout@master
         with:
@@ -68,9 +89,16 @@ jobs:
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v0.5
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
       - uses: actions/checkout@master
       - name: "Install dependencies"
-        run: raco pkg install --name herbie --no-cache --auto src/
+        run: make install
       - name: "Check out complex-herbie master"
         uses: actions/checkout@master
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         uses: Bogdanp/setup-racket@v0.5
       - uses: actions/checkout@master
       - name: "Install dependencies"
-        run: raco pkg install --name herbie --no-cache --auto src/
+        run: make install
       - run: raco test src/ infra/
 
   hamming:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -14,9 +14,16 @@ jobs:
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v0.5
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
       - uses: actions/checkout@master
       - name: "Install dependencies"
-        run: raco pkg install --name herbie --no-cache --auto src/
+        run: make install
       - run: <bench/tutorial.fpcore racket src/herbie.rkt shell >/tmp/out.fpcore
       - run: test `grep -c :herbie-time /tmp/out.fpcore` -eq 3
         name: "Test that shell output had three :herbie-time lines"
@@ -28,9 +35,16 @@ jobs:
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v0.5
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
       - uses: actions/checkout@master
       - name: "Install dependencies"
-        run: raco pkg install --name herbie --no-cache --auto src/
+        run: make install
       - run: racket src/herbie.rkt improve bench/tutorial.fpcore /tmp/out.fpcore
       - run: test `grep -c :herbie-time /tmp/out.fpcore` -eq 3
         name: "Test that improve output had three :herbie-time lines"
@@ -42,9 +56,16 @@ jobs:
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
         uses: Bogdanp/setup-racket@v0.5
+      - name: Install Rust compiler
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+            override: true
+            components: rustfmt, clippy
       - uses: actions/checkout@master
       - name: "Install dependencies"
-        run: raco pkg install --name herbie --no-cache --auto src/
+        run: make install
       - run: racket src/herbie.rkt report bench/tutorial.fpcore /tmp/out/
       - run: test -d /tmp/out/
         name: "Test that report created a directory"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	raco pkg remove --force egg-herbie-windows && echo "Warning: uninstalling egg-herbie and reinstalling local version" || :
 	raco pkg remove --force egg-herbie-osx && echo "Warning: uninstalling egg-herbie and reinstalling local version" || :
 	raco pkg install ./egg-herbie
-	raco pkg install --skip-installed --name herbie src/
+	raco pkg install --skip-installed --auto --name herbie src/
 	raco pkg update --name herbie src/
 
 nightly: install

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -52,6 +52,8 @@
 (define-eggmath destroy_egraphiters (_fun _uint _EGraphIter-pointer -> _void))
 
 
+(define-eggmath egraph_is_unsound_detected (_fun _egraph-pointer -> _bool))
+
 (define-eggmath egraph_run (_fun _egraph-pointer
                                  (len : (_ptr o _uint)) ;; pointer to size of resulting array
                                  _uint ;; node limit

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -7,6 +7,7 @@
 (provide egraph_create egraph_destroy egraph_add_expr
          egraph_addresult_destroy egraph_run egraph_get_simplest
          _EGraphIter destroy_egraphiters egraph_get_cost
+         egraph_is_unsound_detected
          (struct-out EGraphAddResult)
          (struct-out EGraphIter)
          (struct-out FFIRule))

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -6,7 +6,7 @@
 
 (provide egraph_create egraph_destroy egraph_add_expr
          egraph_addresult_destroy egraph_run egraph_get_simplest
-         _EGraphIter destroy_egraphiters
+         _EGraphIter destroy_egraphiters egraph_get_cost
          (struct-out EGraphAddResult)
          (struct-out EGraphIter)
          (struct-out FFIRule))
@@ -29,7 +29,8 @@
 
 (define-cstruct _EGraphIter
   ([numnodes _uint]
-   [numeclasses _uint]))
+   [numeclasses _uint]
+   [time _double]))
 
 (define-cstruct _FFIRule ; The pointers are pointers to strings, but types hidden for allocation
   ([name _pointer]
@@ -61,4 +62,12 @@
                                 -> (values iters len)))
 
 ;; node number -> s-expr string
-(define-eggmath egraph_get_simplest (_fun _egraph-pointer _uint -> _string/utf-8))
+(define-eggmath egraph_get_simplest (_fun _egraph-pointer
+                                         _uint ;; node id
+                                         _uint ;; iteration
+                                         -> _string/utf-8))
+
+(define-eggmath egraph_get_cost (_fun _egraph-pointer
+                                     _uint ;; node id
+                                     _uint ;; iteration
+                                     -> _uint))

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -6,7 +6,9 @@
 
 (provide egraph_create egraph_destroy egraph_add_expr
          egraph_addresult_destroy egraph_run egraph_get_simplest
+         _EGraphIter
          (struct-out EGraphAddResult)
+         (struct-out EGraphIter)
          (struct-out FFIRule))
 
 
@@ -53,7 +55,7 @@
                                 (ffi-rules : (_list i _FFIRule-pointer))
                                 _bool
                                 (_uint = (length ffi-rules))
-                                -> (_list j _EGraphIter)))
+                                -> _EGraphIter-pointer))
 
 ;; node number -> s-expr string
 (define-eggmath egraph_get_simplest (_fun _egraph-pointer _uint -> _string/utf-8))

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -6,7 +6,7 @@
 
 (provide egraph_create egraph_destroy egraph_add_expr
          egraph_addresult_destroy egraph_run egraph_get_simplest
-         _EGraphIter
+         _EGraphIter destroy_egraphiters
          (struct-out EGraphAddResult)
          (struct-out EGraphIter)
          (struct-out FFIRule))
@@ -47,6 +47,8 @@
 (define-eggmath egraph_add_expr (_fun _egraph-pointer _string/utf-8 -> _EGraphAddResult-pointer))
 
 (define-eggmath egraph_addresult_destroy (_fun _EGraphAddResult-pointer -> _void))
+
+(define-eggmath destroy_egraphiters (_fun _uint _EGraphIter-pointer -> _void))
 
 
 (define-eggmath egraph_run (_fun _egraph-pointer

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -5,8 +5,8 @@
 (require racket/runtime-path)
 
 (provide egraph_create egraph_destroy egraph_add_expr
-         egraph_addresult_destroy egraph_run_iter egraph_get_simplest
-         egraph_get_cost egraph_get_size (struct-out EGraphAddResult)
+         egraph_addresult_destroy egraph_run egraph_get_simplest
+         (struct-out EGraphAddResult)
          (struct-out FFIRule))
 
 
@@ -24,6 +24,10 @@
 (define-cstruct _EGraphAddResult
   ([id _uint]
    [successp _bool]))
+
+(define-cstruct _EGraphIter
+  ([numnodes _uint]
+   [numeclasses _uint]))
 
 (define-cstruct _FFIRule ; The pointers are pointers to strings, but types hidden for allocation
   ([name _pointer]
@@ -44,15 +48,12 @@
 
 
 ;; egraph pointer, a node limit, a pointer to an array of ffirule, a bool for constant folding, and the size of the ffirule array
-(define-eggmath egraph_run_iter (_fun _egraph-pointer
-                                      _uint
-                                      (ffi-rules : (_list i _FFIRule-pointer))
-                                      _bool
-                                      (_uint = (length ffi-rules))
-                                      -> _void))
+(define-eggmath egraph_run (_fun _egraph-pointer
+                                 _uint
+                                (ffi-rules : (_list i _FFIRule-pointer))
+                                _bool
+                                (_uint = (length ffi-rules))
+                                -> (_list j _EGraphIter)))
 
 ;; node number -> s-expr string
 (define-eggmath egraph_get_simplest (_fun _egraph-pointer _uint -> _string/utf-8))
-
-(define-eggmath egraph_get_cost (_fun _egraph-pointer _uint -> _uint))
-(define-eggmath egraph_get_size (_fun _egraph-pointer -> _uint))

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -7,7 +7,7 @@
 (provide egraph_create egraph_destroy egraph_add_expr
          egraph_addresult_destroy egraph_run egraph_get_simplest
          _EGraphIter destroy_egraphiters egraph_get_cost
-         egraph_is_unsound_detected
+         egraph_is_unsound_detected egraph_get_times_applied
          (struct-out EGraphAddResult)
          (struct-out EGraphIter)
          (struct-out FFIRule))
@@ -74,3 +74,8 @@
                                      _uint ;; node id
                                      _uint ;; iteration
                                      -> _uint))
+
+(define-eggmath egraph_get_times_applied (_fun _egraph-pointer
+                                               _pointer ;; name of the rule
+                                               -> _uint))
+                                               

--- a/egg-herbie/egg-interface.rkt
+++ b/egg-herbie/egg-interface.rkt
@@ -49,13 +49,14 @@
 (define-eggmath egraph_addresult_destroy (_fun _EGraphAddResult-pointer -> _void))
 
 
-;; egraph pointer, a node limit, a pointer to an array of ffirule, a bool for constant folding, and the size of the ffirule array
 (define-eggmath egraph_run (_fun _egraph-pointer
-                                 _uint
-                                (ffi-rules : (_list i _FFIRule-pointer))
-                                _bool
+                                 (len : (_ptr o _uint)) ;; pointer to size of resulting array
+                                 _uint ;; node limit
+                                (ffi-rules : (_list i _FFIRule-pointer)) ;; ffi rules
+                                _bool ;; constant folding enabled?
                                 (_uint = (length ffi-rules))
-                                -> _EGraphIter-pointer))
+                                -> (iters : _EGraphIter-pointer)
+                                -> (values iters len)))
 
 ;; node number -> s-expr string
 (define-eggmath egraph_get_simplest (_fun _egraph-pointer _uint -> _string/utf-8))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -24,7 +24,9 @@
 
 (define (egraph-get-cost egraph-data node-id iteration)
   (egraph_get_cost (egraph-data-egraph-pointer egraph-data) node-id iteration))
-    
+
+(define (egraph-is-unsound-detected egraph-data)
+  (egraph_is_unsound_detected (egraph-data-egraph-pointer egraph-data)))  
 
 (define (make-raw-string s)
   (define b (string->bytes/utf-8 s))

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -8,7 +8,7 @@
 
 (provide egraph-run egraph-add-exprs with-egraph
          egraph-get-simplest egg-expr->expr egg-add-exn?
-         make-ffi-rules free-ffi-rules
+         make-ffi-rules free-ffi-rules egraph-get-cost
          (struct-out iteration-data))
 
 ;; the first hash table maps all symbols and non-integer values to new names for egg
@@ -16,10 +16,15 @@
 (struct egraph-data (egraph-pointer egg->herbie-dict herbie->egg-dict))
 ;; interface struct for accepting rules
 (struct irule (name input output) #:prefab)
-(struct iteration-data (num-nodes num-eclasses))
+(struct iteration-data (num-nodes num-eclasses time))
 
-(define (egraph-get-simplest egraph-data node-id)
-  (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id))
+
+(define (egraph-get-simplest egraph-data node-id iteration)
+  (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id iteration))
+
+(define (egraph-get-cost egraph-data node-id iteration)
+  (egraph_get_cost (egraph-data-egraph-pointer egraph-data) node-id iteration))
+    
 
 (define (make-raw-string s)
   (define b (string->bytes/utf-8 s))
@@ -46,7 +51,7 @@
 (define (convert-iteration-data egraphiters size)
   (cond
     [(> size 0)
-     (cons (iteration-data (EGraphIter-numnodes egraphiters) (EGraphIter-numeclasses egraphiters))
+     (cons (iteration-data (EGraphIter-numnodes egraphiters) (EGraphIter-numeclasses egraphiters) (EGraphIter-time egraphiters))
            (convert-iteration-data (ptr-add egraphiters 1 _EGraphIter) (- size 1)))]
     [else empty]))
 

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -9,6 +9,7 @@
 (provide egraph-run egraph-add-exprs with-egraph
          egraph-get-simplest egg-expr->expr egg-add-exn?
          make-ffi-rules free-ffi-rules egraph-get-cost
+         egraph-is-unsound-detected
          (struct-out iteration-data))
 
 ;; the first hash table maps all symbols and non-integer values to new names for egg

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -44,22 +44,17 @@
     (free rule)))
 
 (define (convert-iteration-data egraphiters size)
-  (println egraphiters)
   (cond
     [(> size 0)
      (cons (iteration-data (EGraphIter-numnodes egraphiters) (EGraphIter-numeclasses egraphiters))
            (convert-iteration-data (ptr-add egraphiters 1 _EGraphIter) (- size 1)))]
     [else empty]))
 
-;; TODO implement
-(define (free-egraphiters egraphiters)
-  void)
 
 (define (egraph-run egraph-data node-limit ffi-rules precompute?)
   (define-values (egraphiters res-len) (egraph_run (egraph-data-egraph-pointer egraph-data) node-limit ffi-rules precompute?))
-  (println res-len)
   (define res (convert-iteration-data egraphiters res-len))
-  (free-egraphiters egraphiters)
+  (destroy_egraphiters res-len egraphiters)
   res)
 
 

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -9,7 +9,7 @@
 (provide egraph-run egraph-add-exprs with-egraph
          egraph-get-simplest egg-expr->expr egg-add-exn?
          make-ffi-rules free-ffi-rules egraph-get-cost
-         egraph-is-unsound-detected
+         egraph-is-unsound-detected egraph-get-times-applied
          (struct-out iteration-data))
 
 ;; the first hash table maps all symbols and non-integer values to new names for egg
@@ -36,6 +36,10 @@
   (memcpy ptr b n)
   (ptr-set! ptr _byte n 0)
   ptr)
+
+(define (egraph-get-times-applied egraph-data rule-name)
+  (egraph_get_times_applied (egraph-data-egraph-pointer egraph-data)
+                            (make-raw-string (symbol->string rule-name))))
 
 (define (make-ffi-rules rules)
   (for/list [(rule rules)]

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -43,11 +43,12 @@
     (free (FFIRule-right rule))
     (free rule)))
 
-(define (convert-iteration-data egraphiters)
+(define (convert-iteration-data egraphiters size)
+  (println egraphiters)
   (cond
-    [egraphiters
+    [(> size 0)
      (cons (iteration-data (EGraphIter-numnodes egraphiters) (EGraphIter-numeclasses egraphiters))
-           (convert-iteration-data (ptr-add egraphiters 1 _EGraphIter)))]
+           (convert-iteration-data (ptr-add egraphiters 1 _EGraphIter) (- size 1)))]
     [else empty]))
 
 ;; TODO implement
@@ -55,8 +56,9 @@
   void)
 
 (define (egraph-run egraph-data node-limit ffi-rules precompute?)
-  (define egraphiters (egraph_run (egraph-data-egraph-pointer egraph-data) node-limit ffi-rules precompute?))
-  (define res (convert-iteration-data egraphiters))
+  (define-values (egraphiters res-len) (egraph_run (egraph-data-egraph-pointer egraph-data) node-limit ffi-rules precompute?))
+  (println res-len)
+  (define res (convert-iteration-data egraphiters res-len))
   (free-egraphiters egraphiters)
   res)
 

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -8,7 +8,7 @@
 
 (provide egraph-run egraph-add-exprs with-egraph
          egraph-get-simplest egg-expr->expr egg-add-exn?
-         make-ffi-rules free-ffi-rules egraph-get-cost egraph-get-size
+         make-ffi-rules free-ffi-rules
          (struct-out iteration-data))
 
 ;; the first hash table maps all symbols and non-integer values to new names for egg

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -19,7 +19,6 @@
 (struct irule (name input output) #:prefab)
 (struct iteration-data (num-nodes num-eclasses time))
 
-
 (define (egraph-get-simplest egraph-data node-id iteration)
   (egraph_get_simplest (egraph-data-egraph-pointer egraph-data) node-id iteration))
 

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -238,6 +238,18 @@ pub unsafe extern "C" fn egraph_get_simplest(ptr: *mut Context, node_id: u32, it
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn egraph_is_unsound_detected(ptr: *mut Context) -> bool {
+    ffirun(|| {
+        let ctx = &*ptr;
+        let runner = ctx
+            .runner
+            .as_ref()
+            .unwrap_or_else(|| panic!("Runner has been invalidated"));
+        runner.egraph.analysis.unsound.load(Ordering::SeqCst)
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn egraph_get_cost(ptr: *mut Context, node_id: u32, iter: u32) -> u32 {
     ffirun(|| {
         let ctx = &*ptr;

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -149,6 +149,7 @@ unsafe fn ffirule_to_tuple(rule_ptr: *mut FFIRule) -> (String, String, String) {
 #[no_mangle]
 pub unsafe extern "C" fn egraph_run(
     ptr: *mut Context,
+    output_size: *mut u32,
     limit: u32,
     rules_array_ptr: *const *mut FFIRule,
     is_constant_folding_enabled: bool,
@@ -188,8 +189,8 @@ pub unsafe extern "C" fn egraph_run(
                     }
                 })
                 .run(&rules);
-            
         }
+        std::ptr::write(output_size, runner.iterations.len() as u32);
         let res = runner_egraphiters(&runner);
         ctx.runner = Some(runner);
         res

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -46,8 +46,9 @@ pub unsafe extern "C" fn egraph_addresult_destroy(ptr: *mut EGraphAddResult) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_egraphiter_destroy(ptr: *mut EGraphIter) {
-    std::mem::drop(Box::from_raw(ptr))
+pub unsafe extern "C" fn destroy_egraphiters(size: u32, ptr: *mut EGraphIter) {
+    let array: &[EGraphIter] = slice::from_raw_parts(ptr, size as usize);
+    std::mem::drop(array)
 }
 
 // a struct to report failure if the add fails

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -7,6 +7,7 @@ use math::*;
 use std::cmp::min;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use std::time::Duration;
 use std::{slice, sync::atomic::Ordering};
 
 unsafe fn cstring_to_recexpr(c_string: *const c_char) -> Option<RecExpr> {
@@ -190,7 +191,8 @@ pub unsafe extern "C" fn egraph_run(
             runner.egraph.analysis.constant_fold = is_constant_folding_enabled;
             runner = runner
                 .with_node_limit(limit as usize)
-                .with_iter_limit(100_000_000) // should never hit
+                .with_iter_limit(usize::MAX) // should never hit
+                .with_time_limit(Duration::from_secs(u64::MAX))
                 .with_hook(|r| {
                     if r.egraph.analysis.unsound.load(Ordering::SeqCst) {
                         Err("Unsoundness detected".into())

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -45,11 +45,22 @@ pub unsafe extern "C" fn egraph_addresult_destroy(ptr: *mut EGraphAddResult) {
     std::mem::drop(Box::from_raw(ptr))
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn egraph_egraphiter_destroy(ptr: *mut EGraphIter) {
+    std::mem::drop(Box::from_raw(ptr))
+}
+
 // a struct to report failure if the add fails
 #[repr(C)]
 pub struct EGraphAddResult {
     id: u32,
     successp: bool,
+}
+
+#[repr(C)]
+pub struct EGraphIter {
+    numnodes: u32,
+    numiters: u32,
 }
 
 // a struct for loading rules from external source

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -4,10 +4,10 @@ pub mod rules;
 use egg::{Id, Iteration};
 use math::*;
 
+use std::cmp::min;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::{slice, sync::atomic::Ordering};
-use std::cmp::{min};
 
 unsafe fn cstring_to_recexpr(c_string: *const c_char) -> Option<RecExpr> {
     match CStr::from_ptr(c_string).to_str() {
@@ -92,14 +92,16 @@ fn convert_iter(iter: &Iteration<IterData>) -> EGraphIter {
     EGraphIter {
         numnodes: iter.egraph_nodes as u32,
         numclasses: iter.egraph_classes as u32,
-        time: iter.total_time
+        time: iter.total_time,
     }
 }
 
 unsafe fn runner_egraphiters(runner: &Runner) -> *mut EGraphIter {
-    let mut result: Vec<EGraphIter> = runner.iterations.iter()
-                                                       .map(|iter| convert_iter(&iter))
-                                                       .collect();
+    let mut result: Vec<EGraphIter> = runner
+        .iterations
+        .iter()
+        .map(|iter| convert_iter(&iter))
+        .collect();
     let ptr = result.as_mut_ptr();
     std::mem::forget(result);
     ptr
@@ -220,7 +222,11 @@ fn find_extracted(runner: &Runner, id: u32, iter: u32) -> &Extracted {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_get_simplest(ptr: *mut Context, node_id: u32, iter: u32) -> *const c_char {
+pub unsafe extern "C" fn egraph_get_simplest(
+    ptr: *mut Context,
+    node_id: u32,
+    iter: u32,
+) -> *const c_char {
     ffirun(|| {
         let ctx = &*ptr;
         let runner = ctx

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -190,6 +190,7 @@ pub unsafe extern "C" fn egraph_run(
             runner.egraph.analysis.constant_fold = is_constant_folding_enabled;
             runner = runner
                 .with_node_limit(limit as usize)
+                .with_iter_limit(100_000_000) // should never hit
                 .with_hook(|r| {
                     if r.egraph.analysis.unsound.load(Ordering::SeqCst) {
                         Err("Unsoundness detected".into())

--- a/src/alternative.rkt
+++ b/src/alternative.rkt
@@ -1,7 +1,8 @@
 #lang racket
 
 (provide (struct-out change) (struct-out alt) make-alt alt?
-         alt-program alt-add-event *start-prog* *all-alts*)
+         alt-program alt-add-event *start-prog* *all-alts*
+         alt-equal?)
 
 ;; Alts are a lightweight audit trail.
 ;; An alt records a low-level view of how Herbie got
@@ -17,6 +18,9 @@
 
 (define (make-alt prog)
   (alt prog 'start '()))
+
+(define (alt-equal? x y)
+  (equal? (alt-program x) (alt-program y)))
 
 (define (alt-add-event altn event)
   (alt (alt-program altn) event (list altn)))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -194,8 +194,7 @@
 
 
 (define (atab-add-altns atab altns repr)
-  (define altns* (filter-not (compose program-has-nan? alt-program)
-                             (remove-duplicates altns alt-equal?)))
+  (define altns* (remove-duplicates altns alt-equal?))
   (define progs (map alt-program altns*))
   (define errss (apply vector-map list (batch-errors progs (alt-table-context atab) repr)))
   (for/fold ([atab atab]) ([altn (in-list altns*)] [errs (in-vector errss)])

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -192,10 +192,13 @@
                [alt->points (hash-remove* alt->points altns)]
                [alt->done? (hash-remove* alt->done? altns)]))
 
+
 (define (atab-add-altns atab altns repr)
-  (define progs (map alt-program altns))
+  (define altns* (filter-not (compose program-has-nan? alt-program)
+                             (remove-duplicates altns alt-equal?)))
+  (define progs (map alt-program altns*))
   (define errss (apply vector-map list (batch-errors progs (alt-table-context atab) repr)))
-  (for/fold ([atab atab]) ([altn (in-list altns)] [errs (in-vector errss)])
+  (for/fold ([atab atab]) ([altn (in-list altns*)] [errs (in-vector errss)])
     (atab-add-altn atab altn errs repr)))
 
 (define (atab-add-altn atab altn errs repr)

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -194,10 +194,9 @@
 
 
 (define (atab-add-altns atab altns repr)
-  (define altns* (remove-duplicates altns alt-equal?))
-  (define progs (map alt-program altns*))
+  (define progs (map alt-program altns))
   (define errss (apply vector-map list (batch-errors progs (alt-table-context atab) repr)))
-  (for/fold ([atab atab]) ([altn (in-list altns*)] [errs (in-vector errss)])
+  (for/fold ([atab atab]) ([altn (in-list altns)] [errs (in-vector errss)])
     (atab-add-altn atab altn errs repr)))
 
 (define (atab-add-altn atab altn errs repr)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -209,7 +209,7 @@
      (string-append "Rule failed: " (symbol->string (rule-name rule)))))
   
   (define (test-simplify . args)
-    (simplify-batch args #:rules (*simplify-rules*) #:precompute true))
+    (map last (simplify-batch args #:rules (*simplify-rules*) #:precompute true)))
 
   (define test-exprs
     #hash([1 . 1]

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -126,9 +126,14 @@
       exprs
       (lambda (node-ids)
         (define iter-data (egg-run-rules egg-graph (*node-limit*) irules node-ids (and precompute? true)))
+        
         (when ((egg egraph-is-unsound-detected) egg-graph)
           (warn 'unsound-rules #:url "faq.html#unsound-rules"
                "Unsound rule application detected in e-graph. Results from simplify may not be sound."))
+        
+        (for ([rule rls])
+             (timeline-push! 'rules (~a (rule-name rule)) ((egg egraph-get-times-applied) egg-graph (rule-name rule))))
+        
         (map
          (lambda (id)
            (for/list ([iter (in-range (length iter-data))])

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -121,7 +121,8 @@
     (debug #:from 'simplify #:depth 2 "iteration " iter ": " cnt " enodes " "(cost " cost ")")
     (timeline-push! 'egraph iter cnt cost (- (current-inexact-milliseconds) start-time)))
   
-  (for/and ([iter (in-naturals 0)])
+  ((egg egraph-run) egg-graph node-limit ffi-rules precompute?)
+  #;(for/and ([iter (in-naturals 0)])
     (define old-cnt ((egg egraph-get-size )egg-graph))
     ((egg egraph-run-iter) egg-graph node-limit ffi-rules precompute?)
     (timeline-cost iter)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -39,10 +39,15 @@
 ;; given an alt, locations, and a hash from expr to simplification options
 ;; make all combinations of the alt using the simplification options available
 (define (make-simplification-combinations child locs simplify-hash)
-  (define location-options
+  ;; use this for simplify streaming
+  #;(define location-options
     (apply cartesian-product
      (for/list ([loc locs])
        (hash-ref simplify-hash (location-get loc (alt-program child))))))
+  (define location-options
+    (apply cartesian-product
+     (for/list ([loc locs])
+       (list (last (hash-ref simplify-hash (location-get loc (alt-program child))))))))
   
   (define options
     (for/list ([option location-options])

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -126,6 +126,9 @@
       exprs
       (lambda (node-ids)
         (define iter-data (egg-run-rules egg-graph (*node-limit*) irules node-ids (and precompute? true)))
+        (when ((egg egraph-is-unsound-detected) egg-graph)
+          (warn 'unsound-rules #:url "faq.html#unsound-rules"
+               "Unsound rule application detected in e-graph. Results from simplify may not be sound." n))
         (map
          (lambda (id)
            (for/list ([iter (in-range (length iter-data))])

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -128,7 +128,7 @@
         (define iter-data (egg-run-rules egg-graph (*node-limit*) irules node-ids (and precompute? true)))
         (when ((egg egraph-is-unsound-detected) egg-graph)
           (warn 'unsound-rules #:url "faq.html#unsound-rules"
-               "Unsound rule application detected in e-graph. Results from simplify may not be sound." n))
+               "Unsound rule application detected in e-graph. Results from simplify may not be sound."))
         (map
          (lambda (id)
            (for/list ([iter (in-range (length iter-data))])

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -122,15 +122,9 @@
     (timeline-push! 'egraph iter cnt cost (- (current-inexact-milliseconds) start-time)))
   
   (define iteration-data ((egg egraph-run) egg-graph node-limit ffi-rules precompute?))
-  (println iteration-data)
-  
-  #;(for/and ([iter (in-naturals 0)])
-    (define old-cnt ((egg egraph-get-size )egg-graph))
-    ((egg egraph-run-iter) egg-graph node-limit ffi-rules precompute?)
-    (timeline-cost iter)
-    (define cnt ((egg egraph-get-size) egg-graph))
-    (define is_stop (or (>= cnt node-limit) (<= cnt old-cnt)))
-    (not is_stop))
+
+  (for ([iter iteration-data] [counter (in-naturals 0)])
+       (timeline-push! 'egraph counter (iteration-data-num-nodes iter) 0 0)) ;; TODO fill in cost and time
 
   ((egg free-ffi-rules) ffi-rules))
 

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -113,7 +113,7 @@
   (define ffi-rules ((egg make-ffi-rules) irules))
   (define start-time (current-inexact-milliseconds))
 
-  (define (timeline-cost iter)
+  #;(define (timeline-cost iter)
     (define cost
       (apply +
              (map (lambda (node-id) ((egg egraph-get-cost) egg-graph node-id)) node-ids)))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -98,7 +98,7 @@
   (timeline-push! 'method "egg-herbie")
   (define irules (rules->irules rls))
 
-  ((egg egraph-run)
+  ((egg with-egraph)
    (lambda (egg-graph)
      ((egg egraph-add-exprs)
       egg-graph
@@ -121,7 +121,9 @@
     (debug #:from 'simplify #:depth 2 "iteration " iter ": " cnt " enodes " "(cost " cost ")")
     (timeline-push! 'egraph iter cnt cost (- (current-inexact-milliseconds) start-time)))
   
-  ((egg egraph-run) egg-graph node-limit ffi-rules precompute?)
+  (define iteration-data ((egg egraph-run) egg-graph node-limit ffi-rules precompute?))
+  (println iteration-data)
+  
   #;(for/and ([iter (in-naturals 0)])
     (define old-cnt ((egg egraph-get-size )egg-graph))
     ((egg egraph-run-iter) egg-graph node-limit ffi-rules precompute?)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -40,7 +40,7 @@
 ;; make all combinations of the alt using the simplification options available
 (define (make-simplification-combinations child locs simplify-hash)
   (define location-options
-    (cartesian-product
+    (apply cartesian-product
      (for/list ([loc locs])
        (hash-ref simplify-hash (location-get loc (alt-program child))))))
   

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -35,12 +35,29 @@
       (list)))
 
 
+;; given an alt, locations, and a hash from expr -> simplification options
+;; make all combinations of the alt using the simplification options available
+(define (make-simplification-combinations child locs simplify-hash)
+  (define location-options
+    (cartesian-product
+     (for/list ([loc locs])
+       (hash-ref simplify-hash (location-get loc (alt-program child))))))
+  
+  (for/list ([option location-options])
+    (for/fold ([child child]) ([replacement option] [loc locs])
+              (define child* (location-do loc (alt-program child) (lambda (expr) replacement)))
+              (if (not (equal? (alt-program child child*)))
+                  (alt child* (list 'simplify loc) (list child))
+                  child))))
+
 (define/contract (simplify-expr expr #:rules rls #:precompute [precompute? false])
   (->* (expr? #:rules (listof rule?)) (#:precompute boolean?) expr?)
-  (first (simplify-batch (list expr) #:rules rls #:precompute precompute?)))
+  (last (first (simplify-batch (list expr) #:rules rls #:precompute precompute?))))
 
+;; for each expression, returns a list of simplified versions corresponding to egraph iterations
+;; the last expression is the simplest unless something went wrong due to unsoundness
 (define/contract (simplify-batch exprs #:rules rls #:precompute [precompute? false])
-  (->* (expr? #:rules (listof rule?)) (#:precompute boolean?) expr?)
+  (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? (listof (listof expr?)))
 
   (define driver
     (cond
@@ -52,8 +69,11 @@
       simplify-batch-regraph]))
 
   (debug #:from 'simplify "Simplifying using " driver ":\n  " (string-join (map ~a exprs) "\n  "))
-  (define out (driver exprs #:rules rls #:precompute precompute?))
-  (debug #:from 'simplify "Simplified to:\n  " (string-join (map ~a out) "\n  "))
+  (define resulting-lists (driver exprs #:rules rls #:precompute precompute?))
+  (define out
+    (for/list ([results resulting-lists] [expr exprs])
+             (remove-duplicates (cons expr results))))
+  (debug #:from 'simplify "Simplified to:\n  " (string-join (map ~a (map last out)) "\n  "))
     
   out)
 
@@ -61,7 +81,7 @@
   (dynamic-require 'regraph 'method))
 
 (define/contract (simplify-batch-regraph exprs #:rules rls #:precompute precompute?)
-  (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? (listof expr?))
+  (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? (listof (listof expr?)))
   (timeline-push! 'method "regraph")
 
   (define start-time (current-inexact-milliseconds))
@@ -88,13 +108,13 @@
     (and (< initial-cnt ((regraph regraph-count) rg) (*node-limit*))))
 
   (log rg "done")
-  (map unmunge ((regraph regraph-extract) rg)))
+  (map list (map unmunge ((regraph regraph-extract) rg))))
 
 (define-syntax-rule (egg method)
   (dynamic-require 'egg-herbie 'method))
 
 (define/contract (simplify-batch-egg exprs #:rules rls #:precompute precompute?)
-  (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? (listof expr?))
+  (-> (listof expr?) #:rules (listof rule?) #:precompute boolean? (listof (listof expr?)))
   (timeline-push! 'method "egg-herbie")
   (define irules (rules->irules rls))
 
@@ -106,7 +126,11 @@
       (lambda (node-ids)
         (define iter-data (egg-run-rules egg-graph (*node-limit*) irules node-ids (and precompute? true)))
         (map
-         (lambda (id) ((egg egg-expr->expr) ((egg egraph-get-simplest) egg-graph id (- (length iter-data) 1)) egg-graph))
+         (lambda (id)
+           (for/list ([iter (in-range (range (length iter-data)))])
+                      ((egg egg-expr->expr)
+                       ((egg egraph-get-simplest) egg-graph id iter)
+                       egg-graph)))
          node-ids))))))
 
 (define (egg-run-rules egg-graph node-limit irules node-ids precompute?)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -1,9 +1,10 @@
 #lang racket
 
 (require pkg/lib)
-(require "../common.rkt" "../programs.rkt" "../timeline.rkt" "../errors.rkt" "../syntax/rules.rkt")
+(require "../common.rkt" "../programs.rkt" "../timeline.rkt" "../errors.rkt"
+         "../syntax/rules.rkt" "../alternative.rkt")
 
-(provide simplify-expr simplify-batch)
+(provide simplify-expr simplify-batch make-simplification-combinations)
 (module+ test (require rackunit))
 
 ;; One module to rule them all, the great simplify. It uses egg-herbie
@@ -46,7 +47,7 @@
   (for/list ([option location-options])
     (for/fold ([child child]) ([replacement option] [loc locs])
               (define child* (location-do loc (alt-program child) (lambda (expr) replacement)))
-              (if (not (equal? (alt-program child child*)))
+              (if (not (equal? (alt-program child) child*))
                   (alt child* (list 'simplify loc) (list child))
                   child))))
 
@@ -127,7 +128,7 @@
         (define iter-data (egg-run-rules egg-graph (*node-limit*) irules node-ids (and precompute? true)))
         (map
          (lambda (id)
-           (for/list ([iter (in-range (range (length iter-data)))])
+           (for/list ([iter (in-range (length iter-data))])
                       ((egg egg-expr->expr)
                        ((egg egraph-get-simplest) egg-graph id iter)
                        egg-graph)))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -279,19 +279,16 @@
                  #:when true [loc locs])
         (location-get loc (alt-program child))))
 
-    (define simplifications
+    (define simplifications-opotions
       (simplify-batch to-simplify #:rules (*simplify-rules*) #:precompute true))
 
     (define simplify-hash
-      (make-immutable-hash (map cons to-simplify simplifications)))
+      (make-immutable-hash (map cons to-simplify simplifications-options)))
 
     (define simplified
-      (for/list ([child (in-list children)] [locs locs-list])
-        (for/fold ([child child]) ([loc locs])
-          (define child* (location-do loc (alt-program child) (λ (expr) (hash-ref simplify-hash expr))))
-          (if (not (equal? (alt-program child) child*))
-              (alt child* (list 'simplify loc) (list child))
-              child))))
+      (apply append
+             (for/list ([child (^children^)] [locs locs-list])
+               (make-simplification-combinations child locs simplify-hash))))
 
     (timeline-push! 'alts (length locs-list) (length simplified))
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -287,7 +287,7 @@
 
     (define simplified
       (apply append
-             (for/list ([child (^children^)] [locs locs-list])
+             (for/list ([child (in-list children)] [locs locs-list])
                (make-simplification-combinations child locs simplify-hash))))
 
     (timeline-push! 'alts (length locs-list) (length simplified))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -279,11 +279,11 @@
                  #:when true [loc locs])
         (location-get loc (alt-program child))))
 
-    (define simplifications-opotions
+    (define simplification-options
       (simplify-batch to-simplify #:rules (*simplify-rules*) #:precompute true))
 
     (define simplify-hash
-      (make-immutable-hash (map cons to-simplify simplifications-options)))
+      (make-immutable-hash (map cons to-simplify simplification-options)))
 
     (define simplified
       (apply append

--- a/src/symmetry.rkt
+++ b/src/symmetry.rkt
@@ -27,7 +27,7 @@
             (index-of vars b)
             '()
             'real)))
-  (define groups (simplify-batch (range (length vars)) #:rules rules*))
+  (define groups (simplify-batch (range (length vars)) #:precompute true #:rules rules*))
   (map (lambda (group) (map car group)) (group-by cdr (map cons vars groups))))
 
 

--- a/src/symmetry.rkt
+++ b/src/symmetry.rkt
@@ -27,7 +27,7 @@
             (index-of vars b)
             '()
             'real)))
-  (define groups (simplify-batch (range (length vars)) #:precompute true #:rules rules*))
+  (define groups (simplify-batch (range (length vars)) #:precompute false #:rules rules*))
   (map (lambda (group) (map car group)) (group-by cdr (map cons vars groups))))
 
 

--- a/src/symmetry.rkt
+++ b/src/symmetry.rkt
@@ -8,7 +8,7 @@
     (for/list ([swap (in-combinations vars 2)])
       (match-define (list a b) swap)
       (replace-vars (list (cons a b) (cons b a)) expr)))
-  (define out (simplify-batch (cons expr swapt) #:precompute true #:rules (*simplify-rules*)))
+  (define out (map last (simplify-batch (cons expr swapt) #:precompute true #:rules (*simplify-rules*))))
   (match-define (cons orig swapt*) out)
   (for/list ([swap* swapt*] [swap (in-combinations vars 2)]
              #:when (equal? swap* orig))
@@ -27,7 +27,7 @@
             (index-of vars b)
             '()
             'real)))
-  (define groups (simplify-batch (range (length vars)) #:precompute false #:rules rules*))
+  (define groups (map last (simplify-batch (range (length vars)) #:precompute false #:rules rules*)))
   (map (lambda (group) (map car group)) (group-by cdr (map cons vars groups))))
 
 

--- a/www/doc/1.5/faq.html
+++ b/www/doc/1.5/faq.html
@@ -112,6 +112,15 @@
     Install <code>egg-herbie</code> with <code>raco</code>.
   </p>
 
+  <h3 id="unsound-rules">Unsound rule application detected</h3>
+  
+  <p>
+    Herbie uses a set of algebraic rewrite rules in order to simplify expressions.
+    Herbie can sometimes detect when these rewrite rules produce a contradiction.
+    Specifically, if it proves two constants or variables are equal, the rewrite rules
+    have been applied in an unsound way.
+  </p>
+
 
   <h2>Known bugs</h2>
 

--- a/www/doc/1.5/faq.html
+++ b/www/doc/1.5/faq.html
@@ -115,10 +115,10 @@
   <h3 id="unsound-rules">Unsound rule application detected</h3>
   
   <p>
-    Herbie uses a set of algebraic rewrite rules in order to simplify expressions.
-    Herbie can sometimes detect when these rewrite rules produce a contradiction.
-    Specifically, if it proves two constants or variables are equal, the rewrite rules
-    have been applied in an unsound way.
+    Herbie uses a set of algebraic rewrite rules in order to simplify expressions, but these
+    rules can sometimes lead to a contradiction.
+    Herbie will automatically compensate for this, and in most cases nothing needs to be done.
+    However, Herbie may have failed to simplify the output.
   </p>
 
 

--- a/www/doc/1.5/installing.html
+++ b/www/doc/1.5/installing.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html>
+
 <head>
   <meta charset="utf-8" />
   <title>Installing Herbie</title>
@@ -7,12 +8,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script type="text/javascript" src="toc.js"></script>
 </head>
+
 <body>
   <header>
     <a href="../../"><img class="logo" src="../../logo.png" /></a>
     <h1>Installing Herbie</h1>
   </header>
-  
+
   <p>
     <a href="../../">Herbie</a> supports Linux, macOS, and Windows. It
     can be installed from a package or from source. To start, install
@@ -26,7 +28,7 @@
   <p>
     Install Racket, version 7.0 or later, either using
     the <a href="http://download.racket-lang.org/racket-v7.7.html">official
-    installer</a> or distro-provided packages. Versions 7.5 and later
+      installer</a> or distro-provided packages. Versions 7.5 and later
     are significantly faster, and we recommend upgrading.
   </p>
 
@@ -37,7 +39,7 @@
   <pre class="shell">racket
 Welcome to Racket v7.7.
 > (exit)</pre>
-  
+
   <h2>Installing Herbie from a package</h2>
 
   <p>Once Racket is installed, install Herbie from a package with:</p>
@@ -65,7 +67,14 @@ Welcome to Racket v7.7.
   <h2>Installing Herbie from source</h2>
 
   <p>
-    Once Racket is installed, download the Herbie source
+    Install Rust, using <a href="https://rustup.rs/">rustup</a> or via
+    some other means. Also install Racket, version 7.0 or later, either using
+    the <a href="http://download.racket-lang.org/racket-v7.7.html">official
+      installer</a> or distro-provided packages.
+    </p>
+    
+    <p>
+      Once Racket and Rust are installed, download the Herbie source
     <a href="https://github.com/uwplse/herbie">from GitHub</a> with:
   </p>
 
@@ -99,7 +108,7 @@ Welcome to Racket v7.7.
     your executable path. Once Herbie is installed and working
     correctly, check out the <a href="tutorial.html">tutorial</a>.
   </p>
-  
+
   <!-- End of copy -->
 
   <h2>Installing Herbie with Docker</h2>
@@ -110,11 +119,12 @@ Welcome to Racket v7.7.
     in Docker is more limited; we do not recommend using Herbie
     through Docker without prior Docker experience.
   </p>
-  
+
   <p>
     The <a href="docker.html">Docker documentation</a> describes how
     to install and run the official <code>uwplse/herbie</code> image.
   </p>
 
 </body>
+
 </html>


### PR DESCRIPTION
This PR enhances Herbie's use of egg-herbie. It improves the information shown in the report and also streams values from each egraph iteration as alt programs, so that intermediate simplifications are also candidate programs.
Todo:
- [x] Add counts for how much each rewrite was applied
- [x] Check nightlies
- [x] Figure out weird unit test error