### PR TITLE
Faster eval prog and series

### DIFF
--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -74,11 +74,14 @@
   (register-ruleset! rulename4 '(arithmetic simplify) (list (cons 'a prec2))
     (list (list rulename4 `(,conv1 (,conv2 a)) 'a))))
 
+;; First, generate the repr 
 (define (generate-conversions convs)
   (define reprs
     (for/fold ([reprs '()]) ([conv convs])
       (define prec1 (first conv))
       (define prec2 (last conv))
+      (generate-repr prec1) ; manually generate the representation
+      (generate-repr prec2)
       (generate-conversion prec1 prec2)
       (hash-update! (*conversions*) prec1 (λ (x) (cons prec2 x)) '())
       (hash-update! (*conversions*) prec2 (λ (x) (cons prec1 x)) '())

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -140,11 +140,14 @@
     (for/list ([alt alts]) (errors (alt-program alt) pcontext* repr)))
   (define bit-err-lsts (map (curry map ulps->bits) err-lsts))
   (define split-indices (err-lsts->split-indices bit-err-lsts can-split?))
-  (option split-indices alts pts expr (pick-errors split-indices pts err-lsts)))
+  (option split-indices alts pts expr (pick-errors split-indices pts err-lsts repr)))
 
-(define/contract (pick-errors split-indices pts err-lsts)
-  (-> (listof si?) (listof (listof value?)) (listof (listof real?))
-      (listof nonnegative-integer?))
+(define/contract (pick-errors split-indices pts err-lsts repr)
+  (->i ([sis (listof si?)] 
+        [vss (r) (listof (listof (representation-repr? r)))]
+        [errss (listof (listof real?))]
+        [r representation?])
+       [idxs (listof nonnegative-integer?)])
   (for/list ([i (in-naturals)] [pt pts] [errs (flip-lists err-lsts)])
     (for/first ([si split-indices] #:when (< i (si-pidx si)))
       (list-ref errs (si-cidx si)))))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -50,6 +50,7 @@
 (define (get-representation name)
   (hash-ref representations name
             (λ () (raise-herbie-error "Could not find support for ~a representation" name))))
+
 (define (register-representation! name type repr? . args)
   (hash-set! representations name
             (apply representation name (get-type type) repr? args)))
@@ -110,7 +111,8 @@
 ;; Predicates
 
 (define (value? x)
-  (for/or ([(name repr) (in-hash representations)]) ((representation-repr? repr) x)))
+  (for/or ([(name repr) (in-hash representations)])
+    ((representation-repr? repr) x)))
 
 (define (special-value? x repr)
   ((representation-special-values repr) x))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -6,7 +6,8 @@
 (provide (struct-out representation) get-representation representation-name?
           *output-repr* *var-reprs* *needed-reprs* *reprs-with-rules*
           real->repr repr->real
-          value? special-value?)
+          value? special-value?
+          generate-repr)
 
 (module+ internals 
   (provide define-representation register-generator! register-representation!))
@@ -40,20 +41,15 @@
   (-> (-> any/c boolean?))
   (set! repr-generators (cons proc repr-generators)))
 
+;; Queries each plugin to generate the representation
 (define (generate-repr repr-name)
-  (for/or ([proc repr-generators])
-    (proc repr-name)))
+  (or (hash-has-key? representations repr-name)
+      (for/or ([proc repr-generators])
+        (proc repr-name))))
 
-;; The set of reprs that Herbie comes across is collected here. This is the best place to guarantee 
-;; that all the correct rules are generated but it'll collect more reprs than is necessary.
-;; TODO: Find a better place to put this. Watch out for problems with multithreading / parameters. 
 (define (get-representation name)
-  (if (or (hash-has-key? representations name) ; check existing
-          (generate-repr name)) ; ask plugins to try generating this repr
-    (hash-ref representations name)
-    (raise-herbie-error "Could not find builtin or plugin support for ~a representation"
-                        name))) ; else fail
-
+  (hash-ref representations name
+            (λ () (raise-herbie-error "Could not find support for ~a representation" name))))
 (define (register-representation! name type repr? . args)
   (hash-set! representations name
             (apply representation name (get-type type) repr? args)))
@@ -62,9 +58,7 @@
   (register-representation! 'name 'type repr? args ...))
 
 (define (representation-name? x)
-  (with-handlers ([exn:fail? (const #f)])
-    (get-representation x)
-    true))
+  (hash-has-key? representations x))
 
 (define-representation (bool bool boolean?)
   identity

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -204,11 +204,14 @@
                      (λ ()
                       (define atypes
                         (match (operator-info op 'itype)
-                         [(? representation-name? a) (make-list (length args) a)]
-                         [(? list? as) as]))
-                      (define impl (operator-info op mode))
-                      (cons impl (map get-representation atypes)))))
-        (cons (car op-info) (map munge args (cdr op-info)))]
+                         [(? representation-name? a) (list #f (get-representation a))]
+                         [(? list? as) (map get-representation as)]))
+                      (cons (operator-info op mode) atypes))))
+        (define atypes
+          (if (cadr op-info) ; handle variadic operators
+              (cdr op-info)
+              (make-list (length args) (caddr op-info))))
+        (cons (car op-info) (map munge args atypes))]
        [_ (raise-argument-error 'eval-prog "expr?" prog)]))
     (hash-ref! exprhash expr
               (λ ()

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -183,15 +183,21 @@
   (define exprc 0)
   (define varc (length vars))
 
-  ;; Local cache of operator info
+  ;; Local cache of operator, constants, and numbers
   (define cached-ops (make-hash))
+  (define cached-consts (make-hash))
+  (define cached-nums (make-hash))
 
   (define (munge prog repr)
     (set! size (+ 1 size))
     (define expr
       (match prog
-       [(? real?) (list (const (real->precision repr prog)))]
-       [(? constant?) (list (constant-info prog mode))]
+       [(? real?)
+        (list (hash-ref! cached-nums (cons prog repr)
+                         (λ () (const (real->precision repr prog)))))]
+       [(? constant?)
+        (list (hash-ref! cached-consts prog
+                         (λ () (constant-info prog mode))))]
        [(? variable?) prog]
        [`(if ,c ,t ,f)
         (list (operator-info 'if mode)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -183,21 +183,15 @@
   (define exprc 0)
   (define varc (length vars))
 
-  ;; Local cache of operator, constants, and numbers
+  ;; Local cache of operator info
   (define cached-ops (make-hash))
-  (define cached-consts (make-hash))
-  (define cached-nums (make-hash))
 
   (define (munge prog repr)
     (set! size (+ 1 size))
     (define expr
       (match prog
-       [(? real?)
-        (list (hash-ref! cached-nums (cons prog repr)
-                         (λ () (const (real->precision repr prog)))))]
-       [(? constant?)
-        (list (hash-ref! cached-consts prog
-                         (λ () (constant-info prog mode))))]
+       [(? real?) (list (const (real->precision repr prog)))]
+       [(? constant?) (list (constant-info prog mode))]
        [(? variable?) prog]
        [`(if ,c ,t ,f)
         (list (operator-info 'if mode)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -45,7 +45,7 @@
 (define (type-of expr repr env)
   (match expr
    [(? real?) (get-type 'real)]
-   [(? value?) (representation-type repr)]
+   [(? (representation-repr? repr)) (representation-type repr)]
    [(? constant?) 
     (representation-type (get-representation (constant-info expr 'type)))]
    [(? variable?) (representation-type (dict-ref env expr))]
@@ -58,7 +58,7 @@
 (define (repr-of expr repr env)
   (match expr
    [(? real?) (representation-name repr)]
-   [(? value?) (representation-name repr)]
+   [(? (representation-repr? repr)) (representation-name repr)]
    [(? constant?) (constant-info expr 'type)]
    [(? variable?) (representation-name (dict-ref env expr))]
    [(list 'if cond ift iff) (repr-of ift repr env)]

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -188,6 +188,9 @@
   ;; Local cache of operator info
   (define cached-ops (make-hash))
 
+  ;; Known representations
+  (define bool-repr (get-representation 'bool))
+
   (define (munge prog repr)
     (set! size (+ 1 size))
     (define expr
@@ -197,7 +200,7 @@
        [(? variable?) prog]
        [`(if ,c ,t ,f)
         (list (operator-info 'if mode)
-              (munge c (get-representation 'bool))
+              (munge c bool-repr)
               (munge t repr)
               (munge f repr))]
        [(list op args ...)
@@ -223,7 +226,7 @@
 
   (define progc (length progs))
   (define names
-    (for/list ([prog progs] [i (in-naturals 1)])
+    (for/list ([prog progs])
       (munge (program-body prog) repr)))
   (define lt (+ exprc varc))
 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -580,8 +580,10 @@
            (dict-has-key? (cdr operators) op))))
 
 (define (constant? var)
-  (or (real? var) (value? var) (and (symbol? var) (or (hash-has-key? parametric-constants var) 
-                                                      (dict-has-key? (cdr constants) var)))))
+  (or (real? var)
+      (and (symbol? var)
+           (or (hash-has-key? parametric-constants var) 
+               (dict-has-key? (cdr constants) var)))))
 
 (define (variable? var)
   (and (symbol? var) (not (constant? var))))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -151,13 +151,15 @@
     (format "couldn't find ~a and no default implementation defined" 'operator)
     (current-continuation-marks))))
 
-(define (get-parametric-operator name . actual-types)
+(define (get-parametric-operator name #:fail-fast? [fail-fast? #t] . actual-types)
   (let ([op-info (hash-ref parametric-operators name)])
-    (or (car (hash-ref op-info actual-types (cons #f #f))) ; dumb way to car the value
+    (or (car (hash-ref op-info actual-types (cons #f #f))) ; dumb way to fail with #f
         (car (hash-ref op-info (car actual-types) (cons #f #f)))
-        (error 'get-parametric-operator
-              "parametric operator with op ~a and type(s) ~a not found"
-              name actual-types))))
+        (if fail-fast?
+            (error 'get-parametric-operator
+                   "parametric operator with op ~a and input types ~a not found"
+                   name actual-types)
+            #f))))
 
 ;; mainly useful for getting arg count of an unparameterized operator
 ;; TODO: hopefully will be fixed when the way operators are declared

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -550,12 +550,11 @@
   (and (symbol? expr) (regexp-match? #px"^(<-)[\\S]+$" (symbol->string expr))))
 
 (define (get-repr-conv iprec oprec)
-  (for/or ([(name sig) (in-hash parametric-operators)]
-           #:when (repr-conv? name))
-    (match-define (list* true-name rtype atypes) (car sig))
-    (and (equal? rtype oprec)
-         (equal? (first atypes) iprec)
-         name)))
+  (for/or ([(op table) (in-hash parametric-operators)] #:when (repr-conv? op))
+    (for/first ([(atypes info) (in-hash table)] #:when #t)
+      (and (equal? (cdr info) oprec)
+           (equal? (car atypes) iprec)
+           (car info)))))
 
 (define-operator (cast cast.f64 binary64) binary64
   [fl identity] [bf identity] [ival #f]

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -71,7 +71,7 @@
         (expression->type body env type error!)])]
     [#`(- #,arg)
      (define actual-type (expression->type arg env type error!))
-     (define op* (get-parametric-operator '- actual-type))
+     (define op* (get-parametric-operator '- actual-type #:fail-fast? #f))
      (if op*
          (operator-info op* 'otype)
          (begin
@@ -108,7 +108,7 @@
      'complex]
     [#`(,(? (curry hash-has-key? parametric-operators) op) #,exprs ...)
      (define actual-types (for/list ([arg exprs]) (expression->type arg env type error!)))
-     (define op* (apply get-parametric-operator op actual-types))
+     (define op* (apply get-parametric-operator op actual-types #:fail-fast? #f))
      (if op*
          (operator-info op* 'otype)
          (begin

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -77,12 +77,10 @@
          (begin
           (error! stx "Invalid arguments to -; expects ~a but got (- <~a>)"
                   (string-join
-                   (for/list ([sig (hash-ref parametric-operators '-)])
-                     (match sig
-                       [(list _ rtype atypes ...)
-                        (format "(- ~a)" (string-join (map (curry format "<~a>") atypes) " "))]
-                       [(list* _ rtype atype)
-                        (format "(- <~a> ...)" atype)]))
+                   (for/list ([(atypes info) (hash-ref parametric-operators '-)])
+                     (if (list? atypes)
+                         (format "(- ~a)" (string-join (map (curry format "<~a>") atypes) " "))
+                         (format "(- <~a> ...)" atypes)))
                    " or "))
           #f))]    
     [#`(,(and (or '+ '- '* '/) op) #,exprs ...)
@@ -116,12 +114,10 @@
          (begin
           (error! stx "Invalid arguments to ~a; expects ~a but got (~a ~a)" op
                   (string-join
-                    (for/list ([sig (hash-ref parametric-operators op)])
-                      (match sig
-                        [(list _ rtype atypes ...)
-                        (format "(~a ~a)" op (string-join (map (curry format "<~a>") atypes) " "))]
-                        [(list* _ rtype atype)
-                        (format "(~a <~a> ...)" op atype)]))
+                    (for/list ([(atypes info) (hash-ref parametric-operators '-)])
+                     (if (list? atypes)
+                         (format "(~a ~a)" op (string-join (map (curry format "<~a>") atypes) " "))
+                         (format "(~a <~a> ...)" op atypes)))
                     " or ")
                   op (string-join (map (curry format "<~a>") actual-types) " "))
           #f))]))

--- a/src/web/make-graph.rkt
+++ b/src/web/make-graph.rkt
@@ -160,17 +160,18 @@
             (render-history end-alt (mk-pcontext newpoints newexacts)
                             (mk-pcontext points exacts) repr))))
       (section ([id "alternatives"] [style "margin: 2em 0;"])
-       `(h1 "Alternatives")
+       (h1 "Alternatives")
       ,@(for/list ([alt other-alts] [cost (cdr costs)] [errs other-errors] [idx (in-naturals 1)])
-          `(table
-            (tr (th ([style "font-weight:bold"]) ,(format "Alternative ~a" idx)))
-            (tr (th "Error") (td ,(format-bits (errors-score errs))))
-            (tr (th "Cost") (td ,(format-bits cost))))
-          `(div ([class "math"])
+          `(div ([class "entry"])
+            (table
+              (tr (th ([style "font-weight:bold"]) ,(format "Alternative ~a" idx)))
+              (tr (th "Error") (td ,(format-bits (errors-score errs))))
+              (tr (th "Cost") (td ,(format-bits cost))))
+            (div ([class "math"])
               "\\[" ,(core->tex
                       (program->fpcore
                         (resugar-program (alt-program alt) repr)))
-              "\\]")))
+              "\\]"))))
                                       
       ,(if (not (null? other-alts))
           `(section ([id "cost-accuracy"])

--- a/src/web/report.css
+++ b/src/web/report.css
@@ -285,7 +285,7 @@ pre.shell code:before { content: "$ "; font-weight: bold; }
 #alternatives table { width: 275px; display: inline-table; vertical-align: top; }
 #alternatives table th { text-align: left; font-weight: normal; }
 #alternatives table td { text-align: left; width: 75px; }
-#alternatives div { display: inline-block; width: 500px; }
+#alternatives .entry div { display: inline-block; width: 500px; }
 
 /* Formatting backtraces */
 


### PR DESCRIPTION
This PR speeds up Herbie by ~1.5x by making the representation interface a little saner and adding operator info caching in batch-eval-prog. Other changes include: cleaner rule names, more specific errors for bad parametric operators, and other small fixes.
Also caught a few bugs in the plugins with these changes.