### PR TITLE
Split operator and constant table

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -4,7 +4,8 @@
 (require "config.rkt" "debug.rkt")
 (module+ test (require rackunit))
 
-(provide reap define-table table-ref table-set! table-remove!
+(provide reap define-table table-ref table-ref-all
+         table-set! table-remove!
          call-with-output-files
          take-up-to flip-lists list/true find-duplicates
          argmins argmaxs index-of set-disjoint? comparator
@@ -43,6 +44,11 @@
 
 (define (table-remove! tbl key)
   (hash-remove! (cdr tbl) key))
+
+(define (table-ref-all tbl key)
+  (match-let ([(cons header rows) tbl])
+    (and (hash-has-key? rows key)
+         (map cons (map car header) (hash-ref rows key)))))
 
 ;; Utility list functions
 

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -8,8 +8,7 @@
          table-set! table-remove!
          call-with-output-files
          take-up-to flip-lists list/true find-duplicates
-         argmins argmaxs index-of set-disjoint?
-         comparator inv-comparator
+         argmins argmaxs index-of set-disjoint? comparator
          parse-flag get-seed set-seed!
          quasisyntax syntax-e* dict sym-append
          format-time format-bits in-sorted-dict web-resource
@@ -222,11 +221,6 @@
 (define ((comparator test) . args)
   (for/and ([left args] [right (cdr args)])
     (test left right)))
-
-(define ((inv-comparator test) . args)
-  (for/or ([left args] [right (cdr args)])
-    ((negate test) left right)))
-
 
 (define (syntax-e* stx)
   (match (syntax-e stx)

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -225,7 +225,7 @@
 
 (define ((inv-comparator test) . args)
   (for/or ([left args] [right (cdr args)])
-    (not (test left right))))
+    ((negate test) left right)))
 
 
 (define (syntax-e* stx)

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -8,7 +8,8 @@
          table-set! table-remove!
          call-with-output-files
          take-up-to flip-lists list/true find-duplicates
-         argmins argmaxs index-of set-disjoint? comparator
+         argmins argmaxs index-of set-disjoint?
+         comparator inv-comparator
          parse-flag get-seed set-seed!
          quasisyntax syntax-e* dict sym-append
          format-time format-bits in-sorted-dict web-resource
@@ -221,6 +222,11 @@
 (define ((comparator test) . args)
   (for/and ([left args] [right (cdr args)])
     (test left right)))
+
+(define ((inv-comparator test) . args)
+  (for/or ([left args] [right (cdr args)])
+    (not (test left right))))
+
 
 (define (syntax-e* stx)
   (match (syntax-e stx)

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -33,14 +33,14 @@
 
   (unless (hash-has-key? parametric-operators conv1)
     (define impl (compose (representation-bf->repr repr2) (representation-repr->bf repr1)))
-    (register-real-operator! conv1 (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi impl)))
-    (register-operator! conv1 conv1 (list prec1) prec2  ; fallback implementation
+    (register-operator! conv1 (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi impl)))
+    (register-operator-impl! conv1 conv1 (list prec1) prec2  ; fallback implementation
       (list (cons 'fl impl))))
   
   (unless (hash-has-key? parametric-operators conv2)
     (define impl (compose (representation-bf->repr repr1) (representation-repr->bf repr2)))
-    (register-real-operator! conv2 (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi impl)))
-    (register-operator! conv2 conv2 (list prec2) prec1  ; fallback implementation
+    (register-operator! conv2 (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi impl)))
+    (register-operator-impl! conv2 conv2 (list prec2) prec1  ; fallback implementation
       (list (cons 'fl impl))))
 
   ;; Repr rewrites, e.g. <-repr
@@ -48,15 +48,15 @@
   (define repr-rewrite2 (sym-append '<- prec2*))
 
   (unless (hash-has-key? parametric-operators repr-rewrite1)
-    (register-real-operator! repr-rewrite1
+    (register-operator! repr-rewrite1
       (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi identity)))
-    (register-operator! repr-rewrite1 repr-rewrite1 (list prec1) prec1
+    (register-operator-impl! repr-rewrite1 repr-rewrite1 (list prec1) prec1
       (list (cons 'fl identity))))
 
   (unless (hash-has-key? parametric-operators repr-rewrite2)
-    (register-real-operator! repr-rewrite2
+    (register-operator! repr-rewrite2
       (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi identity)))
-    (register-operator! repr-rewrite2 repr-rewrite2 (list prec2) prec2
+    (register-operator-impl! repr-rewrite2 repr-rewrite2 (list prec2) prec2
       (list (cons 'fl identity))))
 
   ;; Repr rewrite/conversion rules

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -33,29 +33,31 @@
 
   (unless (hash-has-key? parametric-operators conv1)
     (define impl (compose (representation-bf->repr repr2) (representation-repr->bf repr1)))
+    (register-real-operator! conv1 (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi impl)))
     (register-operator! conv1 conv1 (list prec1) prec2  ; fallback implementation
-      (list (cons 'fl impl) (cons 'bf identity)
-            (cons 'ival identity) (cons 'nonffi impl))))
+      (list (cons 'fl impl))))
   
   (unless (hash-has-key? parametric-operators conv2)
     (define impl (compose (representation-bf->repr repr1) (representation-repr->bf repr2)))
+    (register-real-operator! conv2 (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi impl)))
     (register-operator! conv2 conv2 (list prec2) prec1  ; fallback implementation
-      (list (cons 'fl impl) (cons 'bf identity)
-            (cons 'ival identity) (cons 'nonffi impl))))
+      (list (cons 'fl impl))))
 
   ;; Repr rewrites, e.g. <-repr
   (define repr-rewrite1 (sym-append '<- prec1*))
   (define repr-rewrite2 (sym-append '<- prec2*))
 
   (unless (hash-has-key? parametric-operators repr-rewrite1)
+    (register-real-operator! repr-rewrite1
+      (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi identity)))
     (register-operator! repr-rewrite1 repr-rewrite1 (list prec1) prec1
-      (list (cons 'fl identity) (cons 'bf identity)
-            (cons 'ival identity) (cons 'nonffi identity))))
+      (list (cons 'fl identity))))
 
   (unless (hash-has-key? parametric-operators repr-rewrite2)
+    (register-real-operator! repr-rewrite2
+      (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi identity)))
     (register-operator! repr-rewrite2 repr-rewrite2 (list prec2) prec2
-      (list (cons 'fl identity) (cons 'bf identity)
-            (cons 'ival identity) (cons 'nonffi identity))))
+      (list (cons 'fl identity))))
 
   ;; Repr rewrite/conversion rules
   (define rulename1 (sym-append 'rewrite '- prec2* '/ prec1*))

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -15,6 +15,9 @@
       [_ (let ([change (car changes)])
            (loop (string-replace str (car change) (cdr change)) (cdr changes)))])))
 
+(define (operator-exists? op)
+  (table-ref-all operator-impls op))
+
 (define (get-rewrite-operator prec)
   (define replace-table `((" " . "_") ("(" . "") (")" . "")))
   (define prec* (string->symbol (string-replace* (~a prec) replace-table)))
@@ -31,14 +34,14 @@
   (define conv1 (sym-append prec1* '-> prec2*))
   (define conv2 (sym-append prec2* '-> prec1*))
 
-  (unless (hash-has-key? parametric-operators conv1)
+  (unless (operator-exists? conv1)
     (define impl (compose (representation-bf->repr repr2) (representation-repr->bf repr1)))
-    (register-operator-impl! conv1 conv1 (list prec1) prec2  ; fallback implementation
+    (register-operator-impl! 'cast conv1 (list prec1) prec2  ; fallback implementation
       (list (cons 'fl impl) (cons 'inherit 'cast))))
   
-  (unless (hash-has-key? parametric-operators conv2)
+  (unless (operator-exists? conv2)
     (define impl (compose (representation-bf->repr repr1) (representation-repr->bf repr2)))
-    (register-operator-impl! conv2 conv2 (list prec2) prec1  ; fallback implementation
+    (register-operator-impl! 'cast conv2 (list prec2) prec1  ; fallback implementation
       (list (cons 'fl impl) (cons 'inherit 'cast))))
 
   ;; Repr rewrites, e.g. <-repr
@@ -46,10 +49,14 @@
   (define repr-rewrite2 (sym-append '<- prec2*))
 
   (unless (hash-has-key? parametric-operators repr-rewrite1)
+    (register-operator! repr-rewrite1 (list 'real) 'real
+      (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi identity)))
     (register-operator-impl! repr-rewrite1 repr-rewrite1 (list prec1) prec1
       (list (cons 'fl identity) (cons 'inherit 'cast))))
 
   (unless (hash-has-key? parametric-operators repr-rewrite2)
+    (register-operator! repr-rewrite2 (list 'real) 'real
+      (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi identity)))
     (register-operator-impl! repr-rewrite2 repr-rewrite2 (list prec2) prec2
       (list (cons 'fl identity) (cons 'inherit 'cast))))
 

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -33,31 +33,25 @@
 
   (unless (hash-has-key? parametric-operators conv1)
     (define impl (compose (representation-bf->repr repr2) (representation-repr->bf repr1)))
-    (register-operator! conv1 (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi impl)))
     (register-operator-impl! conv1 conv1 (list prec1) prec2  ; fallback implementation
-      (list (cons 'fl impl))))
+      (list (cons 'fl impl) (cons 'inherit 'cast))))
   
   (unless (hash-has-key? parametric-operators conv2)
     (define impl (compose (representation-bf->repr repr1) (representation-repr->bf repr2)))
-    (register-operator! conv2 (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi impl)))
     (register-operator-impl! conv2 conv2 (list prec2) prec1  ; fallback implementation
-      (list (cons 'fl impl))))
+      (list (cons 'fl impl) (cons 'inherit 'cast))))
 
   ;; Repr rewrites, e.g. <-repr
   (define repr-rewrite1 (sym-append '<- prec1*))
   (define repr-rewrite2 (sym-append '<- prec2*))
 
   (unless (hash-has-key? parametric-operators repr-rewrite1)
-    (register-operator! repr-rewrite1
-      (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi identity)))
     (register-operator-impl! repr-rewrite1 repr-rewrite1 (list prec1) prec1
-      (list (cons 'fl identity))))
+      (list (cons 'fl identity) (cons 'inherit 'cast))))
 
   (unless (hash-has-key? parametric-operators repr-rewrite2)
-    (register-operator! repr-rewrite2
-      (list (cons 'bf identity) (cons 'ival identity) (cons 'nonffi identity)))
     (register-operator-impl! repr-rewrite2 repr-rewrite2 (list prec2) prec2
-      (list (cons 'fl identity))))
+      (list (cons 'fl identity) (cons 'inherit 'cast))))
 
   ;; Repr rewrite/conversion rules
   (define rulename1 (sym-append 'rewrite '- prec2* '/ prec1*))

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -26,7 +26,7 @@
     [`(lambda ,vars ,body)
      `(λ ,vars ,(simplify body))]
     [`(neg ,arg)
-     (define op* (get-parametric-operator '- (representation-name (*output-repr*))))
+     (define op* (get-parametric-operator 'neg (representation-name (*output-repr*))))
      (define arg* (simplify arg))
      (define val (eval-application op* arg*))
      (or val (simplify-node (list 'neg arg*)))]

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -56,14 +56,28 @@
         [bf->repr (representation-bf->repr repr)])
     (bfinfinite? (repr->bf (bf->repr +inf.bf)))))
 
+;; If the representation uses saturation instead of overflow
+(define (probably-saturated? ordinal repr)
+  (define bfval (ordinal->bigfloat ordinal))
+  (define bfval2 (bf* bfval 2.bf))
+  (define ->repr (representation-bf->repr repr))
+  (define ->ordinal (representation-repr->ordinal repr))
+  (= (->ordinal (->repr bfval))
+     (->ordinal (->repr bfval2))))
+
 (define (bound-ordinary-values repr)
-  (if (has-infinite-value? repr)
+  (if (has-infinite-value? repr) ; bail if representation does not have +inf
       (parameterize ([bf-rounding-mode 'nearest])
-        (let loop ([ordinal (bigfloat->ordinal (largest-ordinary-value repr))] [stepsize 1])
-          (define bfval (ordinal->bigfloat ordinal))
-          (if (bfinfinite? ((representation-repr->bf repr) ((representation-bf->repr repr) bfval)))
-              bfval
-              (loop (+ ordinal stepsize) (* stepsize 2)))))
+        (define hi-ordinal (bigfloat->ordinal (largest-ordinary-value repr)))
+        (if (probably-saturated? hi-ordinal repr) ; bail if representation uses saturation
+            (ordinal->bigfloat hi-ordinal)
+            (let loop ([ordinal hi-ordinal] [stepsize 1])
+              (define bfval (ordinal->bigfloat ordinal))
+              (define ->repr (representation-bf->repr repr))
+              (define ->bf (representation-repr->bf repr))
+              (if (bfinfinite? (->bf (->repr bfval)))
+                  bfval
+                  (loop (+ ordinal stepsize) (* stepsize 2))))))
       (largest-ordinary-value repr)))
 
 (module+ test

--- a/src/float.rkt
+++ b/src/float.rkt
@@ -57,9 +57,10 @@
     (bfinfinite? (repr->bf (bf->repr +inf.bf)))))
 
 ;; If the representation uses saturation instead of overflow
+;; if x * x != inf when x is +max, probably saturated
 (define (probably-saturated? ordinal repr)
   (define bfval (ordinal->bigfloat ordinal))
-  (define bfval2 (bf* bfval 2.bf))
+  (define bfval2 (bf* bfval bfval)) ;; squaring is probably good enough
   (define ->repr (representation-bf->repr repr))
   (define ->ordinal (representation-repr->ordinal repr))
   (= (->ordinal (->repr bfval))

--- a/src/float32.rkt
+++ b/src/float32.rkt
@@ -83,10 +83,10 @@
   (begin (float32-fun name op) ...))
 
 (float32-funs
-  [fl32+  fl+]
-  [fl32-  fl-]
-  [fl32*  fl*]
-  [fl32/  fl/])
+  [fl32+  +]
+  [fl32-  -]
+  [fl32*  *]
+  [fl32/  /])
     
 (module+ test
   (require rackunit)

--- a/src/float32.rkt
+++ b/src/float32.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require math/bigfloat)
+(require racket/flonum math/bigfloat)
 
 ; Racket CS made single-flonums a little confusing
 ; All single-precision code is here to make things easier
@@ -83,10 +83,10 @@
   (begin (float32-fun name op) ...))
 
 (float32-funs
-  [fl32+  +]
-  [fl32-  -]
-  [fl32*  *]
-  [fl32/  /])
+  [fl32+  fl+]
+  [fl32-  fl-]
+  [fl32*  fl*]
+  [fl32/  fl/])
     
 (module+ test
   (require rackunit)

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -47,9 +47,12 @@
       (for/or ([proc repr-generators])
         (proc repr-name))))
 
+;; Returns the representation associated with `name`
+;; attempts to generate the repr if not initially found
 (define (get-representation name)
-  (hash-ref representations name
-            (λ () (raise-herbie-error "Could not find support for ~a representation" name))))
+  (or (hash-ref representations name #f)
+      (and (generate-repr name) (hash-ref representations name))
+      (raise-herbie-error "Could not find support for ~a representation" name)))
 
 (define (register-representation! name type repr? . args)
   (hash-set! representations name

--- a/src/plugin.rkt
+++ b/src/plugin.rkt
@@ -2,10 +2,10 @@
 (require setup/getinfo)
 (require (submod "syntax/types.rkt" internals) (submod "interface.rkt" internals)
          (submod "syntax/rules.rkt" internals) (submod "syntax/syntax.rkt" internals))
-(provide define-type define-representation define-constant define-operator
-         define-real-constant define-real-operator define-ruleset define-ruleset*
-         register-ruleset! register-constant! register-operator! register-representation! 
-         register-generator! register-real-constant! register-real-operator!
+(provide define-type define-representation define-constant-impl define-operator-impl
+         define-constant define-operator define-ruleset define-ruleset*
+         register-ruleset! register-constant-impl! register-operator-impl! register-representation! 
+         register-generator! register-impl! register-operator!
          load-herbie-plugins)
 
 (define (module-exists? module)

--- a/src/plugin.rkt
+++ b/src/plugin.rkt
@@ -3,8 +3,9 @@
 (require (submod "syntax/types.rkt" internals) (submod "interface.rkt" internals)
          (submod "syntax/rules.rkt" internals) (submod "syntax/syntax.rkt" internals))
 (provide define-type define-representation define-constant define-operator
-         define-ruleset define-ruleset* register-ruleset!
-         register-generator! register-representation! register-constant! register-operator!
+         define-real-constant define-real-operator define-ruleset define-ruleset*
+         register-ruleset! register-constant! register-operator! register-representation! 
+         register-generator! register-real-constant! register-real-operator!
          load-herbie-plugins)
 
 (define (module-exists? module)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -57,7 +57,7 @@
          (values (list conv iexpr*) prec)]
         [(list (or 'neg '-) arg) ; unary minus
          (define-values (arg* atype) (loop arg prec))
-         (define op* (get-parametric-operator '- atype))
+         (define op* (get-parametric-operator 'neg atype))
          (values (list op* arg*) (operator-info op* 'otype))]
         [(list (? repr-conv? op) body) ; conversion (e.g. posit16->f64)
          (define iprec (first (operator-info op 'itype)))
@@ -130,7 +130,7 @@
      (define args*
        (for/list ([arg args] [type atypes])
          (expand-parametric-reverse arg (get-representation type) full?)))
-     (if (and (not full?) (equal? op* '-) (= (length args) 1))
+     (if (and (not full?) (equal? op* 'neg) (= (length args) 1))
          (cons 'neg args*) ; if only unparameterizing, leave 'neg' alone
          (cons op* args*))]
     [(? (conjoin complex? (negate real?)))
@@ -138,7 +138,7 @@
     [(? real?)
      (if full?
          (match expr
-           [-inf.0 '(- INFINITY)] ; not '(neg INFINITY) because this is post-resugaring
+           [-inf.0 (if full? '(- INFINITY) '(neg INFINITY))] ; not '(neg INFINITY) because this is post-resugaring
            [+inf.0 'INFINITY]
            [+nan.0 'NAN]
            [x

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -4,11 +4,6 @@
 (require "../common.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt")
 (provide assert-program!)
 
-(define (within x c)
-  (match c
-   [(cons #f #f)  #t]
-   [(cons l h)    (<= l x h)]))
-
 (define (check-expression* stx vars error!)
   (match stx
     [#`,(? constant?) (void)]
@@ -52,13 +47,10 @@
     [#`(#,f-syntax #,args ...)
      (define f (syntax->datum f-syntax))
      (if (hash-has-key? parametric-operators f)
-         (let ([arity (get-operator-arity f)])
-           (unless (within (length args) arity)
-             (if (= (car arity) (cdr arity))
-                 (error! stx "Operator ~a given ~a arguments (expects ~a)"
-                         f (length args) (car arity))
-                 (error! stx "Operator ~a given ~a arguments (expects [~a, ~a])"
-                         f (length args) (car arity) (cdr arity)))))
+         (let ([arity (get-operator-arity f)]) ;; variary is (#f . #f)
+           (unless (or (not arity) (= arity (length args)))
+             (error! stx "Operator ~a given ~a arguments (expects ~a)"
+                     f (length args) (car arity))))
          (error! stx "Unknown operator ~a" f))
      (for ([arg args]) (check-expression* arg vars error!))]
     [_ (error! stx "Unknown syntax ~a" (syntax->datum stx))]))

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -50,7 +50,7 @@
          (let ([arity (get-operator-arity f)]) ;; variary is (#f . #f)
            (unless (or (not arity) (= arity (length args)))
              (error! stx "Operator ~a given ~a arguments (expects ~a)"
-                     f (length args) (car arity))))
+                     f (length args) arity)))
          (error! stx "Unknown operator ~a" f))
      (for ([arg args]) (check-expression* arg vars error!))]
     [_ (error! stx "Unknown syntax ~a" (syntax->datum stx))]))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require racket/flonum math/base math/bigfloat math/special-functions rival)
+(require math/flonum math/base math/bigfloat math/special-functions rival)
 (require "../common.rkt" "../interface.rkt" "../errors.rkt" "../float32.rkt" "types.rkt")
 
 (provide constant? variable? operator? operator-info constant-info get-operator-arity
@@ -256,11 +256,11 @@
     (if (type-name? itypes) #f (length itypes))))
   
 ;; binary64 4-function ;;
-(define-operator-impl (neg neg.f64 binary64) binary64 [fl fl-])
-(define-operator-impl (+ +.f64 binary64 binary64) binary64 [fl fl+])
-(define-operator-impl (- -.f64 binary64 binary64) binary64 [fl fl-])
-(define-operator-impl (* *.f64 binary64 binary64) binary64 [fl fl*])
-(define-operator-impl (/ /.f64 binary64 binary64) binary64 [fl fl/])
+(define-operator-impl (neg neg.f64 binary64) binary64 [fl -])
+(define-operator-impl (+ +.f64 binary64 binary64) binary64 [fl +])
+(define-operator-impl (- -.f64 binary64 binary64) binary64 [fl -])
+(define-operator-impl (* *.f64 binary64 binary64) binary64 [fl *])
+(define-operator-impl (/ /.f64 binary64 binary64) binary64 [fl /])
  
 ;; binary32 4-function ;;
 (define-operator-impl (neg neg.f32 binary32) binary32 [fl fl32-])
@@ -529,16 +529,16 @@
   [nonffi (negate (comparator =))])
 
 (define-operator (<) real
-  [itype 'real] [bf (comparator bf>)] [ival ival-<] [nonffi (comparator <)])
+  [itype 'real] [bf (comparator bf<)] [ival ival-<] [nonffi (comparator <)])
 
 (define-operator (>) real
-  [itype 'real] [bf (comparator bf<)] [ival ival->] [nonffi (comparator >)])
+  [itype 'real] [bf (comparator bf>)] [ival ival->] [nonffi (comparator >)])
 
 (define-operator (<=) real
   [itype 'real] [bf (comparator bf<=)] [ival ival-<=] [nonffi (comparator <=)])
 
 (define-operator (>=) real
-  [itype 'real] [bf (comparator bf<=)] [ival ival->=] [nonffi (comparator >=)])
+  [itype 'real] [bf (comparator bf>=)] [ival ival->=] [nonffi (comparator >=)])
 
 ;; binary64 comparators ;;
 (define-operator-impl (== ==.f64 binary64 binary64) bool

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -10,11 +10,11 @@
          repr-conv? rewrite-repr-op? get-repr-conv)
 
 (module+ internals 
-  (provide operators constants infix-joiner
+  (provide operator-impls constant-impls infix-joiner
+           define-constant-impl define-operator-impl
+           register-constant-impl! register-operator-impl!
            define-constant define-operator
-           register-constant! register-operator!
-           define-real-constant define-real-operator
-           register-real-constant! register-real-operator!))
+           register-impl! register-operator!))
 
 
 (module+ test (require rackunit))
@@ -22,43 +22,43 @@
 ;; Abstract constant table
 ;; Implementations inherit attributes
 
-(define-table real-constants
+(define-table constants
   [bf (->* () bigvalue?)]
   [ival (or/c (->* () ival?) #f)])
 
-(define (register-real-constant! name attrib-dict)
-  (table-set! real-constants name (make-hash attrib-dict)))
+(define (register-impl! name attrib-dict)
+  (table-set! constants name (make-hash attrib-dict)))
 
-(define-syntax-rule (define-real-constant name [key value] ...)
-  (register-real-constant! 'name (list (cons 'key value) ...)))
+(define-syntax-rule (define-constant name [key value] ...)
+  (register-impl! 'name (list (cons 'key value) ...)))
 
-(define-real-constant PI
+(define-constant PI
   [bf (λ () pi.bf)] 
   [ival ival-pi])
 
-(define-real-constant E
+(define-constant E
   [bf (λ () (bfexp 1.bf))]
   [ival ival-e])
 
-(define-real-constant INFINITY
+(define-constant INFINITY
   [bf (λ () +inf.bf)]
   [ival (λ () (mk-ival +inf.bf))])
 
-(define-real-constant NAN
+(define-constant NAN
   [bf (λ () +nan.bf)]
   [ival (λ () (mk-ival +nan.bf))])
 
-(define-real-constant TRUE
+(define-constant TRUE
   [bf (const true)]
   [ival (const (ival-bool true))])
 
-(define-real-constant FALSE
+(define-constant FALSE
   [bf (const false)]
   [ival (const (ival-bool false))])
 
 ;; Constant implementations
 
-(define-table constants
+(define-table constant-impls
   [type type-name?]
   [bf (->* () bigvalue?)]
   [fl (->* () value?)]
@@ -71,24 +71,24 @@
   (with-handlers ([exn:fail?
                    (λ (e) (error 'constant-info "Unknown constant or field: ~a ~a"
                                                 constant field))])
-    (table-ref constants constant field)))
+    (table-ref constant-impls constant field)))
 
 (define (dict-merge dict dict2)
   (for/fold ([dict dict]) ([(key value) (in-dict dict2)])
     (dict-set dict key value)))
 
-(define (register-constant! constant name ctype attrib-dict)
-  (define default-attrib (table-ref-all real-constants constant))
+(define (register-constant-impl! constant name ctype attrib-dict)
+  (define default-attrib (table-ref-all constants constant))
   (unless default-attrib
-    (error 'register-constant! "Real constant does not exist: ~a" constant))
+    (error 'register-constant-impl! "Real constant does not exist: ~a" constant))
   (define attrib-dict* (dict-merge default-attrib attrib-dict))
-  (table-set! constants name
+  (table-set! constant-impls name
               (make-hash (cons (cons 'type ctype) attrib-dict*)))
   (hash-update! parametric-constants constant (curry cons (list* name ctype)) '())
   (hash-set! parametric-constants-reverse name constant))
 
-(define-syntax-rule (define-constant (constant name) ctype [key value] ...)
-  (register-constant! 'constant 'name 'ctype (list (cons 'key value) ...)))
+(define-syntax-rule (define-constant-impl (constant name) ctype [key value] ...)
+  (register-constant-impl! 'constant 'name 'ctype (list (cons 'key value) ...)))
 
 (define (get-parametric-constant name type)
   (for/first ([(true-name rtype) (in-dict (hash-ref parametric-constants name))]
@@ -96,36 +96,36 @@
     true-name))
 
 ;; binary64 ;;
-(define-constant (PI PI.f64) binary64
+(define-constant-impl (PI PI.f64) binary64
   [fl (const pi)])
 
-(define-constant (E E.f64) binary64
+(define-constant-impl (E E.f64) binary64
   [fl (const (exp 1.0))])
 
-(define-constant (INFINITY INFINITY.f64) binary64
+(define-constant-impl (INFINITY INFINITY.f64) binary64
   [fl (const +inf.0)])
 
-(define-constant (NAN NAN.f64) binary64
+(define-constant-impl (NAN NAN.f64) binary64
   [fl (const +nan.0)])
 
 ;; binary32 ;;
-(define-constant (PI PI.f32) binary32
+(define-constant-impl (PI PI.f32) binary32
   [fl (const (->float32 pi))])
 
-(define-constant (E E.f32) binary32
+(define-constant-impl (E E.f32) binary32
   [fl (const (->float32 (exp 1.0)))])
 
-(define-constant (INFINITY INFINITY.f32) binary32
+(define-constant-impl (INFINITY INFINITY.f32) binary32
   [fl (const (->float32 +inf.0))])
 
-(define-constant (NAN NAN.f32) binary32
+(define-constant-impl (NAN NAN.f32) binary32
   [fl (const (->float32 +nan.0))])
 
 ;; bool ;;
-(define-constant (TRUE TRUE) bool
+(define-constant-impl (TRUE TRUE) bool
   [fl (const true)])
 
-(define-constant (FALSE FALSE) bool
+(define-constant-impl (FALSE FALSE) bool
   [fl (const false)])
 
 ;; TODO: The contracts for operators are tricky because the number of arguments is unknown
@@ -136,28 +136,28 @@
 ;; Abstract operator table
 ;; Implementations inherit attributes
 
-(define-table real-operators
+(define-table operators
   [bf    (unconstrained-argument-number-> bigvalue? bigvalue?)]
   [nonffi (unconstrained-argument-number-> value? value?)]
   [ival (or/c #f (unconstrained-argument-number-> ival? ival?))]) 
 
-(define (register-real-operator! name attrib-dict)
-  (table-set! real-operators name (make-hash attrib-dict)))
+(define (register-operator! name attrib-dict)
+  (table-set! operators name (make-hash attrib-dict)))
 
-(define-syntax-rule (define-real-operator name [key value] ...)
-  (register-real-operator! 'name (list (cons 'key value) ...)))
+(define-syntax-rule (define-operator name [key value] ...)
+  (register-operator! 'name (list (cons 'key value) ...)))
 
 (define (ival-sub/neg x [y #f])
   (if y (ival-sub x y) (ival-neg x)))
 
-(define-real-operator + [bf bf+] [ival ival-add] [nonffi +])
-(define-real-operator - [bf bf-] [ival ival-sub/neg] [nonffi -])
-(define-real-operator * [bf bf*] [ival ival-mult] [nonffi *])
-(define-real-operator / [bf bf/] [ival ival-div] [nonffi /])
+(define-operator + [bf bf+] [ival ival-add] [nonffi +])
+(define-operator - [bf bf-] [ival ival-sub/neg] [nonffi -])
+(define-operator * [bf bf*] [ival ival-mult] [nonffi *])
+(define-operator / [bf bf/] [ival ival-div] [nonffi /])
 
 ;; Operator implementations
 
-(define-table operators
+(define-table operator-impls
   [itype (or/c (listof type-name?) type-name?)]
   [otype type-name?]
   [bf    (unconstrained-argument-number-> bigvalue? bigvalue?)]
@@ -172,30 +172,30 @@
   (with-handlers ([exn:fail? 
                    (λ (e) (error 'operator-info "Unknown operator or field: ~a ~a"
                                                 operator field))])
-    (table-ref operators operator field)))
+    (table-ref operator-impls operator field)))
 
 (define (operator-remove! operator)
-  (table-remove! operators operator))
+  (table-remove! operator-impls operator))
 
 (define (*loaded-ops*)
   (hash-keys parametric-operators-reverse))
 
-(define (register-operator! operator name atypes rtype attrib-dict)
-  (define default-attrib (table-ref-all real-operators operator))
+(define (register-operator-impl! operator name atypes rtype attrib-dict)
+  (define default-attrib (table-ref-all operators operator))
   (unless default-attrib
-    (error 'register-operator! "Real operator does not exist: ~a" operator))
+    (error 'register-operator-impl! "Real operator does not exist: ~a" operator))
   (define attrib-dict* (dict-merge default-attrib attrib-dict))
   (define itypes (dict-ref attrib-dict* 'itype atypes))
   (define otype (dict-ref attrib-dict* 'otype rtype))
-  (table-set! operators name
+  (table-set! operator-impls name
               (make-hash (append (list (cons 'itype itypes) (cons 'otype otype)) attrib-dict*)))
   (hash-update! parametric-operators operator
                 (λ (h) (hash-set h itypes (cons name otype)))
                 (hash))
   (hash-set! parametric-operators-reverse name operator))
 
-(define-syntax-rule (define-operator (operator name atypes ...) rtype [key value] ...)
-  (register-operator! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...)))
+(define-syntax-rule (define-operator-impl (operator name atypes ...) rtype [key value] ...)
+  (register-operator-impl! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...)))
 
 (define (no-complex fun)
   (λ xs
@@ -236,18 +236,18 @@
   
 
 ;; binary64 4-function ;;
-(define-operator (- neg.f64 binary64) binary64 [fl -])
-(define-operator (+ +.f64 binary64 binary64) binary64 [fl +])
-(define-operator (- -.f64 binary64 binary64) binary64 [fl -])
-(define-operator (* *.f64 binary64 binary64) binary64 [fl *])
-(define-operator (/ /.f64 binary64 binary64) binary64 [fl /])
+(define-operator-impl (- neg.f64 binary64) binary64 [fl -])
+(define-operator-impl (+ +.f64 binary64 binary64) binary64 [fl +])
+(define-operator-impl (- -.f64 binary64 binary64) binary64 [fl -])
+(define-operator-impl (* *.f64 binary64 binary64) binary64 [fl *])
+(define-operator-impl (/ /.f64 binary64 binary64) binary64 [fl /])
  
 ;; binary32 4-function ;;
-(define-operator (- neg.f32 binary32) binary32 [fl -])
-(define-operator (+ +.f32 binary32 binary32) binary32 [fl +])
-(define-operator (- -.f32 binary32 binary32) binary32 [fl -])
-(define-operator (* *.f32 binary32 binary32) binary32 [fl *])
-(define-operator (/ /.f32 binary32 binary32) binary32 [fl /])
+(define-operator-impl (- neg.f32 binary32) binary32 [fl -])
+(define-operator-impl (+ +.f32 binary32 binary32) binary32 [fl +])
+(define-operator-impl (- -.f32 binary32 binary32) binary32 [fl -])
+(define-operator-impl (* *.f32 binary32 binary32) binary32 [fl *])
+(define-operator-impl (/ /.f32 binary32 binary32) binary32 [fl /])
 
 (define *unknown-ops* (make-parameter '()))
 
@@ -257,7 +257,7 @@
      (for-each operator-remove! (*unknown-ops*)))))
 
 (require ffi/unsafe)
-(define-syntax (define-operator/libm stx)
+(define-syntax (define-libm-operator stx)
   (syntax-case stx (real libm)
     [(_ (op opf64 opf32 real ...) real [libm id_d id_f] [key value] ...)
      (let* ([num-args (length (cdddr (syntax-e (cadr (syntax-e stx)))))])
@@ -274,88 +274,88 @@
                                             (lambda () (*unknown-ops* (cons 'opf64 (*unknown-ops*))) (curry fallback #'double))))
            (define float-proc (get-ffi-obj 'id_f #f (_fun #,@(build-list num-args (λ (_) #'_float)) -> _float)
                                            (lambda () (*unknown-ops* (cons 'opf32 (*unknown-ops*))) (curry fallback #'float))))
-           (define-real-operator op [key value] ...)
-           (define-operator (op opf64 #,@(build-list num-args (λ (_) #'binary64))) binary64
+           (define-operator op [key value] ...)
+           (define-operator-impl (op opf64 #,@(build-list num-args (λ (_) #'binary64))) binary64
              [fl (λ args (apply double-proc args))])
-           (define-operator (op opf32 #,@(build-list num-args (λ (_) #'binary32))) binary32
+           (define-operator-impl (op opf32 #,@(build-list num-args (λ (_) #'binary32))) binary32
              [fl (λ args (->float32 (apply float-proc args)))])
        ))]))
 
-(define-operator/libm (acos acos.f64 acos.f32 real) real
+(define-libm-operator (acos acos.f64 acos.f32 real) real
   [libm acos acosf] [bf bfacos] [ival ival-acos]
   [nonffi (no-complex acos)])
 
-(define-operator/libm (acosh acosh.f64 acosh.f32 real) real
+(define-libm-operator (acosh acosh.f64 acosh.f32 real) real
   [libm acosh acoshf] [bf bfacosh] [ival ival-acosh]
   [nonffi (no-complex acosh)])
 
-(define-operator/libm (asin asin.f64 asin.f32 real) real
+(define-libm-operator (asin asin.f64 asin.f32 real) real
   [libm asin asinf] [bf bfasin] [ival ival-asin]
   [nonffi (no-complex asin)])
 
-(define-operator/libm (asinh asinh.f64 asinh.f32 real) real
+(define-libm-operator (asinh asinh.f64 asinh.f32 real) real
   [libm asinh asinhf] [bf bfasinh] [ival ival-asinh]
   [nonffi (no-complex asinh)])
 
-(define-operator/libm (atan atan.f64 atan.f32 real) real
+(define-libm-operator (atan atan.f64 atan.f32 real) real
   [libm atan atanf] [bf bfatan] [ival ival-atan]
   [nonffi (no-complex atan)])
 
-(define-operator/libm (atan2 atan2.f64 atan2.f32 real real) real
+(define-libm-operator (atan2 atan2.f64 atan2.f32 real real) real
   [libm atan2 atan2f] [bf bfatan2] [ival ival-atan2]
   [nonffi (no-complex atan)])
 
-(define-operator/libm (atanh atanh.f64 atanh.f32 real) real
+(define-libm-operator (atanh atanh.f64 atanh.f32 real) real
   [libm atanh atanhf] [bf bfatanh] [ival ival-atanh]
   [nonffi (no-complex atanh)])
 
-(define-operator/libm (cbrt cbrt.f64 cbrt.f32 real) real
+(define-libm-operator (cbrt cbrt.f64 cbrt.f32 real) real
   [libm cbrt cbrtf] [bf bfcbrt] [ival ival-cbrt]
   [nonffi (no-complex (λ (x) (expt x (/ 1 3))))])
 
-(define-operator/libm (ceil ceil.f64 ceil.f32 real) real
+(define-libm-operator (ceil ceil.f64 ceil.f32 real) real
   [libm ceil ceilf] [bf bfceiling] [ival ival-ceil]
   [nonffi ceiling])
 
 (define (bfcopysign x y)
   (bf* (bfabs x) (bf (expt -1 (bigfloat-signbit y)))))
 
-(define-operator/libm (copysign copysign.f64 copysign.f32 real real) real
+(define-libm-operator (copysign copysign.f64 copysign.f32 real real) real
   [libm copysign copysignf] [bf bfcopysign] [ival ival-copysign]
   [nonffi (λ (x y) (if (>= y 0) (abs x) (- (abs x))))])
 
-(define-operator/libm (cos cos.f64 cos.f32 real) real
+(define-libm-operator (cos cos.f64 cos.f32 real) real
   [libm cos cosf] [bf bfcos] [ival ival-cos]
   [nonffi cos])
 
-(define-operator/libm (cosh cosh.f64 cosh.f32 real) real
+(define-libm-operator (cosh cosh.f64 cosh.f32 real) real
   [libm cosh coshf] [bf bfcosh] [ival ival-cosh]
   [nonffi cosh])
 
-(define-operator/libm (erf erf.f64 erf.f32 real) real
+(define-libm-operator (erf erf.f64 erf.f32 real) real
   [libm erf erff] [bf bferf] [ival ival-erf]
   [nonffi (no-complex erf)])
 
-(define-operator/libm (erfc erfc.f64 erfc.f32 real) real
+(define-libm-operator (erfc erfc.f64 erfc.f32 real) real
   [libm erfc erfcf] [bf bferfc] [ival ival-erfc]
   [nonffi erfc])
 
-(define-operator/libm (exp exp.f64 exp.f32 real) real
+(define-libm-operator (exp exp.f64 exp.f32 real) real
   [libm exp expf] [bf bfexp] [ival ival-exp]
   [nonffi exp])
 
-(define-operator/libm (exp2 exp2.f64 exp2.f32 real) real
+(define-libm-operator (exp2 exp2.f64 exp2.f32 real) real
   [libm exp2 exp2f] [bf bfexp2] [ival ival-exp2]
   [nonffi (no-complex (λ (x) (expt 2 x)))])
 
 (define (from-bigfloat bff)
   (λ args (bigfloat->flonum (apply bff (map bf args)))))
 
-(define-operator/libm (expm1 expm1.f64 expm1.f32 real) real
+(define-libm-operator (expm1 expm1.f64 expm1.f32 real) real
   [libm expm1 expm1f] [bf bfexpm1] [ival ival-expm1]
   [nonffi (from-bigfloat bfexpm1)])
 
-(define-operator/libm (fabs fabs.f64 fabs.f32 real) real
+(define-libm-operator (fabs fabs.f64 fabs.f32 real) real
   [libm fabs fabsf] [bf bfabs] [ival ival-fabs]
   [nonffi abs])
 
@@ -364,127 +364,127 @@
     (bf- x y)
     0.bf))
 
-(define-operator/libm (fdim fdim.f64 fdim.f32 real real) real
+(define-libm-operator (fdim fdim.f64 fdim.f32 real real) real
   [libm fdim fdimf] [bf bffdim] [ival ival-fdim]
   [nonffi (λ (x y) (max (- x y) 0))])
 
-(define-operator/libm (floor floor.f64 floor.f32 real) real
+(define-libm-operator (floor floor.f64 floor.f32 real) real
   [libm floor floorf] [bf bffloor] [ival ival-floor]
   [nonffi (λ (x) (floor x))])
 
 (define (bffma x y z)
   (bf+ (bf* x y) z))
 
-(define-operator/libm (fma fma.f64 fma.f32 real real real) real
+(define-libm-operator (fma fma.f64 fma.f32 real real real) real
   [libm fma fmaf] [bf bffma] [ival ival-fma]
   [nonffi (λ (x y z) (bigfloat->flonum (bf+ (bf* (bf x) (bf y)) (bf z))))])
 
-(define-operator/libm (fmax fmax.f64 fmax.f32 real real) real
+(define-libm-operator (fmax fmax.f64 fmax.f32 real real) real
   [libm fmax fmaxf] [bf bfmax] [ival ival-fmax]
   [nonffi (λ (x y) (cond  [(nan? x) y] [(nan? y) x] [else (max x y)]))])
 
-(define-operator/libm (fmin fmin.f64 fmin.f32 real real) real
+(define-libm-operator (fmin fmin.f64 fmin.f32 real real) real
   [libm fmin fminf] [bf bfmin] [ival ival-fmin]
   [nonffi (λ (x y) (cond  [(nan? x) y] [(nan? y) x] [else (min x y)]))])
 
 (define (bffmod x mod)
   (bf- x (bf* (bftruncate (bf/ x mod)) mod)))
 
-(define-operator/libm (fmod fmod.f64 fmod.f32 real real) real
+(define-libm-operator (fmod fmod.f64 fmod.f32 real real) real
   [libm fmod fmodf] [bf bffmod] [ival ival-fmod]
   [nonffi (from-bigfloat bffmod)])
 
-(define-operator/libm (hypot hypot.f64 hypot.f32 real real) real
+(define-libm-operator (hypot hypot.f64 hypot.f32 real real) real
   [libm hypot hypotf] [bf bfhypot] [ival ival-hypot]
   [nonffi (from-bigfloat bfhypot)])
 
-(define-operator/libm (j0 j0.f64 j0.f32 real) real
+(define-libm-operator (j0 j0.f64 j0.f32 real) real
   [libm j0 j0f] [bf bfbesj0] [ival #f]
   [nonffi (from-bigfloat bfbesj0)])
 
-(define-operator/libm (j1 j1.f64 j1.f32 real) real
+(define-libm-operator (j1 j1.f64 j1.f32 real) real
   [libm j1 j1f] [bf bfbesj1] [ival #f]
   [nonffi (from-bigfloat bfbesj1)])
 
-(define-operator/libm (lgamma lgamma.f64 lgamma.f32 real) real
+(define-libm-operator (lgamma lgamma.f64 lgamma.f32 real) real
   [libm lgamma lgammaf] [bf bflog-gamma] [ival #f]
   [nonffi log-gamma])
 
-(define-operator/libm (log log.f64 log.f32 real) real
+(define-libm-operator (log log.f64 log.f32 real) real
   [libm log logf] [bf bflog] [ival ival-log]
   [nonffi (no-complex log)])
 
-(define-operator/libm (log10 log10.f64 log10.f32 real) real
+(define-libm-operator (log10 log10.f64 log10.f32 real) real
   [libm log10 log10f] [bf bflog10] [ival ival-log10]
   [nonffi (no-complex (λ (x) (log x 10)))])
 
-(define-operator/libm (log1p log1p.f64 log1p.f32 real) real
+(define-libm-operator (log1p log1p.f64 log1p.f32 real) real
   [libm log1p log1pf] [bf bflog1p] [ival ival-log1p]
   [nonffi (from-bigfloat bflog1p)])
 
-(define-operator/libm (log2 log2.f64 log2.f32 real) real
+(define-libm-operator (log2 log2.f64 log2.f32 real) real
   [libm log2 log2f] [bf bflog2] [ival ival-log2]
   [nonffi (from-bigfloat bflog2)])
 
 (define (bflogb x)
   (bffloor (bflog2 (bfabs x))))
 
-(define-operator/libm (logb logb.f64 logb.f32 real) real
+(define-libm-operator (logb logb.f64 logb.f32 real) real
   [libm logb logbf] [bf bflogb] [ival ival-logb]
   [nonffi (λ (x) (floor (bigfloat->flonum (bflog2 (bf (abs x))))))])
 
-(define-operator/libm (pow pow.f64 pow.f32 real real) real
+(define-libm-operator (pow pow.f64 pow.f32 real real) real
   [libm pow powf] [bf bfexpt] [ival ival-pow]
   [nonffi (no-complex expt)])
 
 (define (bfremainder x mod)
   (bf- x (bf* (bfround (bf/ x mod)) mod)))
 
-(define-operator/libm (remainder remainder.f64 remainder.f32 real real) real
+(define-libm-operator (remainder remainder.f64 remainder.f32 real real) real
   [libm remainder remainderf] [bf bfremainder] [ival ival-remainder] 
   [nonffi remainder])
 
-(define-operator/libm (rint rint.f64 rint.f32 real) real
+(define-libm-operator (rint rint.f64 rint.f32 real) real
   [libm rint rintf] [bf bfrint] [ival ival-rint]
   [nonffi round])
 
-(define-operator/libm (round round.f64 round.f32 real) real
+(define-libm-operator (round round.f64 round.f32 real) real
   [libm round roundf] [bf bfround] [ival ival-round]
   [nonffi round])
 
-(define-operator/libm (sin sin.f64 sin.f32 real) real
+(define-libm-operator (sin sin.f64 sin.f32 real) real
   [libm sin sinf] [bf bfsin] [ival ival-sin]
   [nonffi sin])
 
-(define-operator/libm (sinh sinh.f64 sinh.f32 real) real
+(define-libm-operator (sinh sinh.f64 sinh.f32 real) real
   [libm sinh sinhf] [bf bfsinh] [ival ival-sinh]
   [nonffi sinh])
 
-(define-operator/libm (sqrt sqrt.f64 sqrt.f32 real) real
+(define-libm-operator (sqrt sqrt.f64 sqrt.f32 real) real
   [libm sqrt sqrtf] [bf bfsqrt] [ival ival-sqrt]
   [nonffi (no-complex sqrt)])
 
-(define-operator/libm (tan tan.f64 tan.f32 real) real
+(define-libm-operator (tan tan.f64 tan.f32 real) real
   [libm tan tanf] [bf bftan] [ival ival-tan]
   [nonffi tan])
 
-(define-operator/libm (tanh tanh.f64 tanh.f32 real) real
+(define-libm-operator (tanh tanh.f64 tanh.f32 real) real
   [libm tanh tanhf] [bf bftanh] [ival ival-tanh]
   [nonffi tanh])
 
-(define-operator/libm (tgamma tgamma.f64 tgamma.f32 real) real
+(define-libm-operator (tgamma tgamma.f64 tgamma.f32 real) real
   [libm tgamma tgammaf] [bf bfgamma] [ival #f]
   [nonffi gamma])
 
-(define-operator/libm (trunc trunc.f64 trunc.f32 real) real
+(define-libm-operator (trunc trunc.f64 trunc.f32 real) real
   [libm trunc truncf] [bf bftruncate] [ival ival-trunc]
   [nonffi truncate])
 
-(define-operator/libm (y0 y0.f64 y0.f32 real) real
+(define-libm-operator (y0 y0.f64 y0.f32 real) real
   [libm y0 y0f] [bf bfbesy0] [ival #f] 
   [nonffi (from-bigfloat bfbesy0)])
 
-(define-operator/libm (y1 y1.f64 y1.f32 real) real
+(define-libm-operator (y1 y1.f64 y1.f32 real) real
   [libm y1 y1f] [bf bfbesy1] [ival #f]
   [nonffi (from-bigfloat bfbesy1)])
 
@@ -492,67 +492,67 @@
 
 (define (if-fn test if-true if-false) (if test if-true if-false))
 
-(define-real-operator if [bf if-fn] [ival ival-if] [nonffi if-fn])
-(define-operator (if if bool real real) real [fl if-fn]) ; types not used
+(define-operator if [bf if-fn] [ival ival-if] [nonffi if-fn])
+(define-operator-impl (if if bool real real) real [fl if-fn]) ; types not used
 
 (define ((infix-joiner x) . args)
   (string-join args x))
 
 ;; real operators
-(define-real-operator == [bf (comparator bf=)] [ival ival-==] [nonffi (comparator =)])
-(define-real-operator != [bf (inv-comparator bf=)] [ival ival-!=] [nonffi (inv-comparator =)])
-(define-real-operator < [bf (comparator bf>)] [ival ival-<] [nonffi (comparator <)])
-(define-real-operator > [bf (comparator bf<)] [ival ival->] [nonffi (comparator >)])
-(define-real-operator <= [bf (comparator bf<=)] [ival ival-<=] [nonffi (comparator <=)])
-(define-real-operator >= [bf (comparator bf<=)] [ival ival->=] [nonffi (comparator >=)])
+(define-operator == [bf (comparator bf=)] [ival ival-==] [nonffi (comparator =)])
+(define-operator != [bf (inv-comparator bf=)] [ival ival-!=] [nonffi (inv-comparator =)])
+(define-operator < [bf (comparator bf>)] [ival ival-<] [nonffi (comparator <)])
+(define-operator > [bf (comparator bf<)] [ival ival->] [nonffi (comparator >)])
+(define-operator <= [bf (comparator bf<=)] [ival ival-<=] [nonffi (comparator <=)])
+(define-operator >= [bf (comparator bf<=)] [ival ival->=] [nonffi (comparator >=)])
 
 ;; binary64 comparators ;;
-(define-operator (== ==.f64 binary64 binary64) bool
+(define-operator-impl (== ==.f64 binary64 binary64) bool
   [itype 'binary64] [otype 'bool] ; Override number of arguments
   [fl (comparator =)])
 
-(define-operator (!= !=.f64 binary64 binary64) bool
+(define-operator-impl (!= !=.f64 binary64 binary64) bool
   [itype 'binary64] [otype 'bool] ; Override number of arguments
   [fl (inv-comparator =)])
 
-(define-operator (< <.f64 binary64 binary64) bool
+(define-operator-impl (< <.f64 binary64 binary64) bool
   [itype 'binary64] [otype 'bool] ; Override number of arguments
   [fl (comparator <)])
 
-(define-operator (> >.f64 binary64 binary64) bool
+(define-operator-impl (> >.f64 binary64 binary64) bool
   [itype 'binary64] [otype 'bool] ; Override number of arguments
   [fl (comparator >)])
 
-(define-operator (<= <=.f64 binary64 binary64) bool
+(define-operator-impl (<= <=.f64 binary64 binary64) bool
   [itype 'binary64] [otype 'bool] ; Override number of arguments
   [fl (comparator <=)])
 
-(define-operator (>= >=.f64 binary64 binary64) bool
+(define-operator-impl (>= >=.f64 binary64 binary64) bool
   [itype 'binary64] [otype 'bool] ; Override number of arguments
   [fl (comparator >=)])
 
 ;; binary32 comparators
-(define-operator (== ==.f32 binary32 binary32) bool
+(define-operator-impl (== ==.f32 binary32 binary32) bool
   [itype 'binary32] [otype 'bool] ; Override number of arguments
   [fl (comparator =)])
 
-(define-operator (!= !=.f32 binary32 binary32) bool
+(define-operator-impl (!= !=.f32 binary32 binary32) bool
   [itype 'binary32] [otype 'bool] ; Override number of arguments
   [fl (inv-comparator =)])
 
-(define-operator (< <.f32 binary32 binary32) bool
+(define-operator-impl (< <.f32 binary32 binary32) bool
   [itype 'binary32] [otype 'bool] ; Override number of arguments
   [fl (comparator <)])
 
-(define-operator (> >.f32 binary32 binary32) bool
+(define-operator-impl (> >.f32 binary32 binary32) bool
   [itype 'binary32] [otype 'bool] ; Override number of arguments
   [fl (comparator >)])
 
-(define-operator (<= <=.f32 binary32 binary32) bool
+(define-operator-impl (<= <=.f32 binary32 binary32) bool
   [itype 'binary32] [otype 'bool] ; Override number of arguments
   [fl (comparator <=)])
 
-(define-operator (>= >=.f32 binary32 binary32) bool
+(define-operator-impl (>= >=.f32 binary32 binary32) bool
   [itype 'binary32] [otype 'bool] ; Override number of arguments
   [fl (comparator >=)])
 
@@ -561,16 +561,16 @@
 (define (and-fn . as) (andmap identity as))
 (define (or-fn  . as) (ormap identity as))
 
-(define-real-operator not [bf not] [ival ival-not] [nonffi not])
-(define-operator (not not bool) bool [fl not])
+(define-operator not [bf not] [ival ival-not] [nonffi not])
+(define-operator-impl (not not bool) bool [fl not])
 
-(define-real-operator and [bf and-fn] [ival ival-and] [nonffi and-fn])
-(define-operator (and and bool bool) bool
+(define-operator and [bf and-fn] [ival ival-and] [nonffi and-fn])
+(define-operator-impl (and and bool bool) bool
   [itype 'bool] [otype 'bool] ; Override number of arguments
   [fl and-fn])
 
-(define-real-operator or [bf or-fn] [ival ival-or] [nonffi or-fn])
-(define-operator (or or bool bool) bool
+(define-operator or [bf or-fn] [ival ival-or] [nonffi or-fn])
+(define-operator-impl (or or bool bool) bool
   [itype 'bool] [otype 'bool] ; Override number of arguments
   [fl or-fn])
 
@@ -590,30 +590,30 @@
            (car info)))))
 
 ;; Casts
-(define-real-operator cast [bf identity] [ival identity] [nonffi identity])
-(define-operator (cast cast.f64 binary64) binary64 [fl identity])
-(define-operator (cast cast.f32 binary32) binary32 [fl identity])
+(define-operator cast [bf identity] [ival identity] [nonffi identity])
+(define-operator-impl (cast cast.f64 binary64) binary64 [fl identity])
+(define-operator-impl (cast cast.f32 binary32) binary32 [fl identity])
 
 ;; Conversions
 
-(define-real-operator binary64->binary32 [bf identity] [ival identity] [nonffi (curryr ->float32)])
-(define-operator (binary64->binary32 binary64->binary32 binary64) binary32 [fl (curryr ->float32)])
+(define-operator binary64->binary32 [bf identity] [ival identity] [nonffi (curryr ->float32)])
+(define-operator-impl (binary64->binary32 binary64->binary32 binary64) binary32 [fl (curryr ->float32)])
 
-(define-real-operator binary32->binary64 [bf identity] [ival identity] [nonffi identity])
-(define-operator (binary32->binary64 binary32->binary64 binary32) binary64 [fl identity])
+(define-operator binary32->binary64 [bf identity] [ival identity] [nonffi identity])
+(define-operator-impl (binary32->binary64 binary32->binary64 binary32) binary64 [fl identity])
 
 ;; Expression predicates ;;
 
 (define (operator? op)
   (and (symbol? op) (not (equal? op 'if))
        (or (hash-has-key? parametric-operators op)
-           (dict-has-key? (cdr operators) op))))
+           (dict-has-key? (cdr operator-impls) op))))
 
 (define (constant? var)
   (or (real? var)
       (and (symbol? var)
            (or (hash-has-key? parametric-constants var) 
-               (dict-has-key? (cdr constants) var)))))
+               (dict-has-key? (cdr constant-impls) var)))))
 
 (define (variable? var)
   (and (symbol? var) (not (constant? var))))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require math/flonum math/base math/bigfloat math/special-functions rival)
+(require racket/flonum math/base math/bigfloat math/special-functions rival)
 (require "../common.rkt" "../interface.rkt" "../errors.rkt" "../float32.rkt" "types.rkt")
 
 (provide constant? variable? operator? operator-info constant-info get-operator-arity
@@ -204,8 +204,7 @@
            (map (λ (x y) (equal? (prec->type x) y)) itypes itypes*))))
 
 (define (register-operator-impl! operator name atypes rtype attrib-dict)
-  (define inherit (dict-ref attrib-dict 'inherit operator)) ; possibly override operator we inherit from
-  (define default-attrib (table-ref-all operators inherit))
+  (define default-attrib (table-ref-all operators operator))
   (unless default-attrib
     (error 'register-operator-impl! "Real operator does not exist: ~a" operator))
   ;; merge inherited and explicit attributes
@@ -257,18 +256,18 @@
     (if (type-name? itypes) #f (length itypes))))
   
 ;; binary64 4-function ;;
-(define-operator-impl (- neg.f64 binary64) binary64 [fl -] [inherit 'neg])
-(define-operator-impl (+ +.f64 binary64 binary64) binary64 [fl +])
-(define-operator-impl (- -.f64 binary64 binary64) binary64 [fl -])
-(define-operator-impl (* *.f64 binary64 binary64) binary64 [fl *])
-(define-operator-impl (/ /.f64 binary64 binary64) binary64 [fl /])
+(define-operator-impl (neg neg.f64 binary64) binary64 [fl fl-])
+(define-operator-impl (+ +.f64 binary64 binary64) binary64 [fl fl+])
+(define-operator-impl (- -.f64 binary64 binary64) binary64 [fl fl-])
+(define-operator-impl (* *.f64 binary64 binary64) binary64 [fl fl*])
+(define-operator-impl (/ /.f64 binary64 binary64) binary64 [fl fl/])
  
 ;; binary32 4-function ;;
-(define-operator-impl (- neg.f32 binary32) binary32 [fl -] [inherit 'neg])
-(define-operator-impl (+ +.f32 binary32 binary32) binary32 [fl +])
-(define-operator-impl (- -.f32 binary32 binary32) binary32 [fl -])
-(define-operator-impl (* *.f32 binary32 binary32) binary32 [fl *])
-(define-operator-impl (/ /.f32 binary32 binary32) binary32 [fl /])
+(define-operator-impl (neg neg.f32 binary32) binary32 [fl fl32-])
+(define-operator-impl (+ +.f32 binary32 binary32) binary32 [fl fl32+])
+(define-operator-impl (- -.f32 binary32 binary32) binary32 [fl fl32-])
+(define-operator-impl (* *.f32 binary32 binary32) binary32 [fl fl32*])
+(define-operator-impl (/ /.f32 binary32 binary32) binary32 [fl fl32/])
 
 (define *unknown-ops* (make-parameter '()))
 
@@ -642,11 +641,11 @@
 
 ;; Conversions
 
-(define-operator-impl (binary64->binary32 binary64->binary32 binary64) binary32
-  [fl (curryr ->float32)] [inherit 'cast])
+(define-operator-impl (cast binary64->binary32 binary64) binary32
+  [fl (curryr ->float32)])
 
-(define-operator-impl (binary32->binary64 binary32->binary64 binary32) binary64
-  [fl identity] [inherit 'cast])
+(define-operator-impl (cast binary32->binary64 binary32) binary64
+  [fl identity])
 
 ;; Expression predicates ;;
 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -10,8 +10,12 @@
          repr-conv? rewrite-repr-op? get-repr-conv)
 
 (module+ internals 
-  (provide operators constants define-constant define-operator infix-joiner
-           register-constant! register-operator!))
+  (provide operators constants infix-joiner
+           define-constant define-operator
+           register-constant! register-operator!
+           define-real-constant define-real-operator
+           register-real-constant! register-real-operator!))
+
 
 (module+ test (require rackunit))
 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -37,7 +37,7 @@
   [ival ival-pi])
 
 (define-real-constant E
-  [bf (λ () (exp 1.0))] 
+  [bf (λ () (bfexp 1.bf))]
   [ival ival-e])
 
 (define-real-constant INFINITY
@@ -97,29 +97,29 @@
 
 ;; binary64 ;;
 (define-constant (PI PI.f64) binary64
-  [fl (λ () pi)])
+  [fl (const pi)])
 
 (define-constant (E E.f64) binary64
-  [fl (λ () (exp 1.0))])
+  [fl (const (exp 1.0))])
 
 (define-constant (INFINITY INFINITY.f64) binary64
-  [fl (λ () +inf.0)])
+  [fl (const +inf.0)])
 
 (define-constant (NAN NAN.f64) binary64
-  [fl (λ () +nan.0)])
+  [fl (const +nan.0)])
 
 ;; binary32 ;;
 (define-constant (PI PI.f32) binary32
-  [fl (λ () pi)])
+  [fl (const (->float32 pi))])
 
 (define-constant (E E.f32) binary32
-  [fl (λ () (exp 1.0))])
+  [fl (const (->float32 (exp 1.0)))])
 
 (define-constant (INFINITY INFINITY.f32) binary32
-  [fl (λ () +inf.0)])
+  [fl (const (->float32 +inf.0))])
 
 (define-constant (NAN NAN.f32) binary32
-  [fl (λ () +nan.0)])
+  [fl (const (->float32 +nan.0))])
 
 ;; bool ;;
 (define-constant (TRUE TRUE) bool
@@ -488,11 +488,10 @@
   [libm y1 y1f] [bf bfbesy1] [ival #f]
   [nonffi (from-bigfloat bfbesy1)])
 
-(define (if-fn test if-true if-false) (if test if-true if-false))
-(define (and-fn . as) (andmap identity as))
-(define (or-fn  . as) (ormap identity as))
-
 ;; If
+
+(define (if-fn test if-true if-false) (if test if-true if-false))
+
 (define-real-operator if [bf if-fn] [ival ival-if] [nonffi if-fn])
 (define-operator (if if bool real real) real [fl if-fn]) ; types not used
 
@@ -558,6 +557,10 @@
   [fl (comparator >=)])
 
 ;; logical operators ;;
+
+(define (and-fn . as) (andmap identity as))
+(define (or-fn  . as) (ormap identity as))
+
 (define-real-operator not [bf not] [ival ival-not] [nonffi not])
 (define-operator (not not bool) bool [fl not])
 

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -147,6 +147,7 @@
 (define-syntax-rule (define-operator name [key value] ...)
   (register-operator! 'name (list (cons 'key value) ...)))
 
+;; Slower fallback for (- x) and (- x y)
 (define (ival-sub/neg x [y #f])
   (if y (ival-sub x y) (ival-neg x)))
 
@@ -236,16 +237,16 @@
   
 
 ;; binary64 4-function ;;
-(define-operator-impl (- neg.f64 binary64) binary64 [fl -])
+(define-operator-impl (- neg.f64 binary64) binary64 [fl -] [ival ival-neg])
 (define-operator-impl (+ +.f64 binary64 binary64) binary64 [fl +])
-(define-operator-impl (- -.f64 binary64 binary64) binary64 [fl -])
+(define-operator-impl (- -.f64 binary64 binary64) binary64 [fl -] [ival ival-sub])
 (define-operator-impl (* *.f64 binary64 binary64) binary64 [fl *])
 (define-operator-impl (/ /.f64 binary64 binary64) binary64 [fl /])
  
 ;; binary32 4-function ;;
-(define-operator-impl (- neg.f32 binary32) binary32 [fl -])
+(define-operator-impl (- neg.f32 binary32) binary32 [fl -] [ival ival-neg])
 (define-operator-impl (+ +.f32 binary32 binary32) binary32 [fl +])
-(define-operator-impl (- -.f32 binary32 binary32) binary32 [fl -])
+(define-operator-impl (- -.f32 binary32 binary32) binary32 [fl -] [ival ival-sub])
 (define-operator-impl (* *.f32 binary32 binary32) binary32 [fl *])
 (define-operator-impl (/ /.f32 binary32 binary32) binary32 [fl /])
 

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -71,17 +71,18 @@
         (expression->type body env type error!)])]
     [#`(- #,arg)
      (define actual-type (expression->type arg env type error!))
-     (define op* (get-parametric-operator '- actual-type #:fail-fast? #f))
+     (define op* (get-parametric-operator 'neg actual-type #:fail-fast? #f))
      (if op*
          (operator-info op* 'otype)
          (begin
           (error! stx "Invalid arguments to -; expects ~a but got (- <~a>)"
                   (string-join
-                   (for/list ([(atypes info) (hash-ref parametric-operators '-)])
+                   (for/list ([(atypes info) (hash-ref parametric-operators 'neg)])
                      (if (list? atypes)
                          (format "(- ~a)" (string-join (map (curry format "<~a>") atypes) " "))
                          (format "(- <~a> ...)" atypes)))
-                   " or "))
+                   " or ")
+                  actual-type)
           #f))]    
     [#`(,(and (or '+ '- '* '/) op) #,exprs ...)
      (define t #f)

--- a/src/web/plot.rkt
+++ b/src/web/plot.rkt
@@ -248,7 +248,7 @@
     (let ([name (representation-name repr)])
       (values
         (operator-info (get-parametric-operator '< name name) 'fl)
-        (operator-info (get-parametric-operator '- name) 'fl))))
+        (operator-info (get-parametric-operator 'neg name) 'fl))))
   (define max (λ (x y) (if (lt x y) y x))) 
   (define min (λ (x y) (if (lt x y) x y)))
 


### PR DESCRIPTION
This PR splits the operator table (and constant table) into two distinct tables: "abstract" and "implementations". Each operator in the abstract table defines the bigfloat, interval, nonffi functions associated with each operator so we don't need to redefine those each time. Every implementation defines the float functions and input/return types and inherits from the abstract operator it implements. Implementations can override a property. All plugins have been updated and are no longer compatible with older versions of Herbie. Includes some bug fixes.
