### PR TITLE
Change constant? to not include literal numbers

### DIFF
--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -16,11 +16,10 @@
   (hash-ref! cache expr
              (λ ()
                 (match expr
+                  [(? number?)
+                   (cons (repeat (bf expr)) (repeat 1))]
                   [(? constant?)
-                   (define val
-                     (if (symbol? expr)
-                         ((constant-info expr 'bf))
-                         (bf expr)))
+                   (define val ((constant-info expr 'bf)))
                    (cons (repeat val) (repeat 1))]
                   [(? variable?)
                    (cons (map (curryr representation-repr->bf (dict-ref (*var-reprs*) expr))
@@ -82,6 +81,7 @@
          (unless (andmap (curry = 1) err)
            (sow (cons err (reverse loc))))
          (match expr
+           [(? number?) (void)]
            [(? constant?) (void)]
            [(? variable?) (void)]
            [(list 'if cond ift iff)

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -30,6 +30,8 @@
   (define (fail . irr) #f)
 
   (match pattern
+   [(? number?)
+    (and (equal? pattern expr) '())]
    [(? constant?)
     (and (equal? pattern expr) '())]
    [(? variable?)
@@ -45,6 +47,7 @@
 (define (pattern-substitute pattern bindings)
   ; pattern binding -> expr
   (match pattern
+   [(? number?) pattern]
    [(? constant?) pattern]
    [(? variable?)
     (dict-ref bindings pattern)]
@@ -120,6 +123,9 @@
       (match pattern
         [(? variable?)
          (sow (cons '() (list (cons pattern expr))))]
+        [(? number?)
+         (when (equal? expr pattern)
+           (sow (cons '() '())))]
         [(? constant?)
          (when (equal? expr pattern)
            (sow (cons '() '())))]

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -19,6 +19,7 @@
 (define (simplify expr*)
   (define expr ((get-evaluator) expr*))
   (match expr
+    [(? number?) expr]
     [(? constant?) expr]
     [(? variable?) expr]
     [`(λ ,vars ,body)
@@ -47,6 +48,7 @@
 
 (define (simplify-node expr)
   (match expr
+    [(? number?) expr]
     [(? constant?) expr]
     [(? variable?) expr]
     [(or `(+ ,_ ...) `(- ,_ ...) `(neg ,_))

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -185,12 +185,9 @@
 (define (munge expr)
   ;; Despite the name, `expr` might be an expression OR a pattern
   (match expr
-    [(? constant?)
-     (if (symbol? expr)
-         (list expr)
-         expr)]
-    [(? variable?)
-     expr]
+    [(? number?) expr]
+    [(? constant?) (list expr)]
+    [(? variable?) expr]
     [(list head subs ...)
      (cons head (map munge subs))]))
 

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -106,6 +106,8 @@
   (match expr
     [(? (curry equal? var))
      (taylor-exact 0 1)]
+    [(? number?)
+     (taylor-exact expr)]
     [(? constant?)
      (taylor-exact expr)]
     [(? variable?)

--- a/src/function-definitions.rkt
+++ b/src/function-definitions.rkt
@@ -13,6 +13,7 @@
 
 (define (all-ops expr good?)
   (match expr
+    [(? number?) #t]
     [(? constant?) #t]
     [(? variable?) #t]
     [(list f args ...)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -40,7 +40,7 @@
 ;; standards, this will have to have more information passed in
 (define (type-of expr repr env)
   (match expr
-   [(? real?) (get-type 'real)]
+   [(? number?) (get-type 'real)]
    [(? (representation-repr? repr)) (representation-type repr)]
    [(? constant?) 
     (representation-type (get-representation (constant-info expr 'type)))]
@@ -53,7 +53,7 @@
 ;; Fast version does not recurse into functions applications
 (define (repr-of expr repr env)
   (match expr
-   [(? real?) repr]
+   [(? number?) repr]
    [(? (representation-repr? repr)) repr]
    [(? constant?) (get-representation (constant-info expr 'type))]
    [(? variable?) (dict-ref env expr)]
@@ -66,7 +66,8 @@
       [(list op args ...)
        (and (operator-info op field) (andmap loop args))]
       [(? variable?) true]
-      [(? constant?) (or (not (symbol? expr)) (constant-info expr field))])))
+      [(? number?) true]
+      [(? constant?) (constant-info expr field)])))
 
 (define (expr-contains? expr pred)
   (let loop ([expr expr])
@@ -78,6 +79,7 @@
 
 (define (free-variables prog)
   (match prog
+    [(? number?) '()]
     [(? constant?) '()]
     [(? variable?) (list prog)]
     [`(,op ,args ...)
@@ -157,7 +159,7 @@
     (set! size (+ 1 size))
     (define expr
       (match prog
-       [(? real?) (list (const (real->precision prog repr)))]
+       [(? number?) (list (const (real->precision prog repr)))]
        [(? constant?) (list (constant-info prog mode))]
        [(? variable?) prog]
        [`(if ,c ,t ,f)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -91,7 +91,7 @@
          ;; Match guaranteed to succeed because we ran type-check first
          (define op* (apply get-parametric-operator op atypes))
          (values (cons op* args*) (operator-info op* 'otype))]
-        [(? real?) 
+        [(? number?) 
          (values
            (match expr
              [(or +inf.0 -inf.0 +nan.0) expr]
@@ -146,7 +146,7 @@
          (cons op* args*))]
     [(? (conjoin complex? (negate real?)))
      `(complex ,(real-part expr) ,(imag-part expr))]
-    [(? real?)
+    [(? number?)
      (if full?
          (match expr
            [-inf.0 (if full? '(- INFINITY) '(neg INFINITY))] ; not '(neg INFINITY) because this is post-resugaring

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -6,6 +6,7 @@
 
 (define (check-expression* stx vars error!)
   (match stx
+    [#`,(? number?) (void)]
     [#`,(? constant?) (void)]
     [#`,(? variable? var)
      (unless (set-member? vars stx)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -689,10 +689,9 @@
            (dict-has-key? (cdr operator-impls) op))))
 
 (define (constant? var)
-  (or (real? var)
-      (and (symbol? var)
-           (or (hash-has-key? parametric-constants var) 
-               (dict-has-key? (cdr constant-impls) var)))))
+  (and (symbol? var)
+       (or (hash-has-key? parametric-constants var) 
+           (dict-has-key? (cdr constant-impls) var))))
 
 (define (variable? var)
   (and (symbol? var) (not (constant? var))))

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -33,7 +33,7 @@
 
 (define (expression->type stx env type error!)
   (match stx
-    [#`,(? real?) type]
+    [#`,(? number?) type]
     [#`,(? constant? x)
      (if (set-member? '(TRUE FALSE) x)
          (constant-info x 'type)


### PR DESCRIPTION
Basically only use `constant?` inside a big match statement anyway, and then often need a nested `if` to check for numeric constants separately.