### PR TITLE
Ensure thread-safe operations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: [ '7.8', '8.0', '8.1' ]
+        racket-version: [ '8.0', '8.0', '8.2' ]
         precision: [ 'binary32', 'binary64' ]
     steps:
       - name: "Install Packages"
@@ -62,7 +62,9 @@ jobs:
       - name: "Install Packages"
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v0.5
+        uses: Bogdanp/setup-racket@v1.3.1
+        with:
+          version: '8.0'
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:
@@ -90,7 +92,9 @@ jobs:
       - name: "Install Packages"
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v0.5
+        uses: Bogdanp/setup-racket@v1.3.1
+        with:
+          version: '8.0'
       - name: Install Rust compiler
         uses: actions-rs/toolchain@v1
         with:
@@ -116,15 +120,14 @@ jobs:
     needs: [ 'hamming' ]
     strategy:
       matrix: # this takes a while: don't run too many
-        racket-version: [ '7.9' ]
         precision: [ 'binary32', 'binary64' ]
     steps:
       - name: "Install Packages"
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v0.5
+        uses: Bogdanp/setup-racket@v1.3.1
         with:
-          version: ${{ matrix.racket-version }}
+          version: '8.0'
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: make install

--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -5,7 +5,7 @@
          (submod "syntax/rules.rkt" internals) (submod "syntax/syntax.rkt" internals))
 (provide generate-conversions generate-prec-rewrites get-rewrite-operator *conversions*)
 
-(define *conversions* (make-parameter (make-hash)))
+(define *conversions* (make-parameter (hash)))
 
 (define/contract (string-replace* str changes)
   (-> string? (listof (cons/c string? string?)) string?)
@@ -104,8 +104,8 @@
     (for/fold ([reprs '()]) ([conv convs])
       (define prec1 (first conv))
       (define prec2 (last conv))
-      (hash-update! (*conversions*) prec1 (λ (x) (cons prec2 x)) '())
-      (hash-update! (*conversions*) prec2 (λ (x) (cons prec1 x)) '())
+      (*conversions* (hash-update (*conversions*) prec1 (λ (x) (cons prec2 x)) '()))
+      (*conversions* (hash-update (*conversions*) prec2 (λ (x) (cons prec1 x)) '()))
       (generate-prec-rewrite prec1 prec2)
       (set-union reprs (list (get-representation prec1) (get-representation prec2)))))
   (*needed-reprs* (set-union reprs (*needed-reprs*))))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -60,7 +60,7 @@
 (register-reset
  (λ ()
   (*analyze-context* (*pcontext*))
-  (hash-clear! *analyze-cache*)))
+  (set! *analyze-cache* (make-hash))))
 
 (define (localize-error prog repr)
   (define varmap (map cons (program-variables prog)

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -93,9 +93,8 @@
 
 (register-reset
  (λ ()
-  (hash-clear! n-sum-to-cache)
-  (hash-clear! logcache)
-  (hash-set! logcache 1 '((1 -1 1)))))
+  (set! n-sum-to-cache (make-hash))
+  (set! logcache (make-hash '((1 . ((1 -1 1))))))))
 
 (define (taylor var expr*)
   "Return a pair (e, n), such that expr ~= e var^n"

--- a/src/debug.rkt
+++ b/src/debug.rkt
@@ -29,7 +29,7 @@
       (= val1 val2)
       (equal? val1 val2)))
 
-(define *cur-debug-levels* (make-hash))
+(define *cur-debug-levels* (make-hasheq))
 ;; To understand this it might be useful to understand the system.
 ;; The current level of any debug flag is fluid, within a range.
 ;; It's "setting" determines the range, or a fixed value,

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -81,5 +81,5 @@
 
 (register-reset
  (λ ()
-   (set-clear! warnings-seen)
+   (set! warnings-seen (mutable-set))
    (set! warning-log '())))

--- a/src/function-definitions.rkt
+++ b/src/function-definitions.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "config.rkt" "syntax/rules.rkt" "core/matcher.rkt" "programs.rkt" "interface.rkt" "syntax/sugar.rkt")
+(require "config.rkt" "syntax/rules.rkt" "core/matcher.rkt""programs.rkt" "interface.rkt" "syntax/sugar.rkt")
 (provide get-expander get-evaluator)
 
 (define (evaluation-rule? rule)
@@ -21,6 +21,11 @@
 
 (define expanders (make-hash))
 (define evaluators (make-hash))
+
+(register-reset
+ (λ ()
+  (hash-clear! expanders)
+  (hash-clear! evaluators)))
 
 (define (make-expander primitives)
   (define known-functions (make-hash))

--- a/src/function-definitions.rkt
+++ b/src/function-definitions.rkt
@@ -24,8 +24,8 @@
 
 (register-reset
  (λ ()
-  (hash-clear! expanders)
-  (hash-clear! evaluators)))
+  (set! expanders (make-hash))
+  (set! evaluators (make-hash))))
 
 (define (make-expander primitives)
   (define known-functions (make-hash))

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -25,7 +25,7 @@
   [(define (write-proc repr port mode)
      (fprintf port "#<representation ~a>" (representation-name repr)))])
 
-(define representations (make-hash))
+(define representations (hash))
 
 ;; Repr / operator generation
 ;; Some plugins might define 'templated' reprs (e.g. fixed point with
@@ -55,8 +55,9 @@
       (raise-herbie-error "Could not find support for ~a representation" name)))
 
 (define (register-representation! name type repr? . args)
-  (hash-set! representations name
-            (apply representation name (get-type type) repr? args)))
+  (set! representations
+    (hash-set representations name
+              (apply representation name (get-type type) repr? args))))
 
 (define-syntax-rule (define-representation (name type repr?) args ...)
   (register-representation! 'name 'type repr? args ...))

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -25,6 +25,12 @@
 (define *reeval-pts* (make-parameter 8000))
 (define *timeout* (make-parameter (* 1000 60 5/2)))
 
+;; true if Racket CS <= 8.2
+(define cs-places-workaround?
+  (let ([major (string->number (substring (version) 0 1))]
+        [minor (string->number (substring (version) 2 3))])
+    (or (< major 8) (and (= major 8) (<= minor 2)))))
+
 (define (get-p&es context)
   (for/lists (pts exs)
       ([(pt ex) (in-pcontext context)])
@@ -123,6 +129,11 @@
            #:render (λ (p order) (write-json (profile->json p)))))
         (compute-result test)))
 
+  ; CS versions <= 8.2: problems with scheduler
+  ; cause places to stay in a suspended state
+  (when cs-places-workaround?
+    (thread (lambda () (sync (system-idle-evt)))))
+  
   (define eng (engine in-engine))
   (if (engine-run (*timeout*) eng)
       (engine-result eng)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -6,7 +6,7 @@
 (module+ test (require rackunit))
 
 ;; name -> (vars repr body)
-(define *functions* (make-parameter (make-hash)))
+(define *functions* (make-parameter (make-hasheq)))
 
 (define (register-function! name args repr body)
   (hash-set! (*functions*) name (list args repr body)))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -20,7 +20,7 @@
 ;; The new, contracts-using version of the above
 
 (define-syntax-rule (define-table name [field type] ...)
-  (define name (cons (list (cons 'field type) ...) (make-hash))))
+  (define name (cons (list (cons 'field type) ...) (make-hasheq))))
 
 (define (table-ref tbl key field)
   (match-let ([(cons header rows) tbl])
@@ -56,7 +56,7 @@
   [ival (or/c (->* () ival?) #f)])
 
 (define (register-constant! name attrib-dict)
-  (table-set! constants name (make-hash attrib-dict)))
+  (table-set! constants name (make-hasheq attrib-dict)))
 
 (define-syntax-rule (define-constant name [key value] ...)
   (register-constant! 'name (list (cons 'key value) ...)))
@@ -93,8 +93,8 @@
   [fl (->* () value?)]
   [ival (or/c (->* () ival?) #f)])
 
-(define parametric-constants (make-hash))
-(define parametric-constants-reverse (make-hash))
+(define parametric-constants (hash))
+(define parametric-constants-reverse (hash))
 
 (define (constant-info constant field)
   (with-handlers ([exn:fail?
@@ -112,9 +112,13 @@
     (error 'register-constant-impl! "Real constant does not exist: ~a" constant))
   (define attrib-dict* (dict-merge default-attrib attrib-dict))
   (table-set! constant-impls name
-              (make-hash (cons (cons 'type ctype) attrib-dict*)))
-  (hash-update! parametric-constants constant (curry cons (list* name ctype)) '())
-  (hash-set! parametric-constants-reverse name constant))
+              (make-hasheq (cons (cons 'type ctype) attrib-dict*)))
+  (set! parametric-constants
+    (hash-update parametric-constants constant
+                 (curry cons (list* name ctype))
+                 '()))
+  (set! parametric-constants-reverse
+    (hash-set parametric-constants-reverse name constant)))
 
 (define-syntax-rule (define-constant-impl (constant name) ctype [key value] ...)
   (register-constant-impl! 'constant 'name 'ctype (list (cons 'key value) ...)))
@@ -176,8 +180,8 @@
   (define itypes* (dict-ref attrib-dict 'itype itypes))
   (define otype* (dict-ref attrib-dict 'otype otype))
   (table-set! operators name
-              (make-hash (append (list (cons 'itype itypes*) (cons 'otype otype*))
-                         attrib-dict))))
+              (make-hasheq (append (list (cons 'itype itypes*) (cons 'otype otype*))
+                           attrib-dict))))
 
 (define-syntax-rule (define-operator (name itypes ...) otype [key value] ...)
   (register-operator! 'name '(itypes ...) 'otype
@@ -208,8 +212,8 @@
   [nonffi (unconstrained-argument-number-> value? value?)]
   [ival (or/c #f (unconstrained-argument-number-> ival? ival?))])
 
-(define parametric-operators (make-hash))
-(define parametric-operators-reverse (make-hash))
+(define parametric-operators (hash))
+(define parametric-operators-reverse (hash))
 
 (define (operator-info operator field)
   (with-handlers ([exn:fail? 
@@ -248,14 +252,16 @@
   (unless (equal? operator 'if) ;; if does not work here
     (check-operator-types! default-attrib itypes otype))
   ;; Convert attributes to hash, update tables
-  (define fields (make-hash attrib-dict*))
+  (define fields (make-hasheq attrib-dict*))
   (hash-set! fields 'itype itypes)
   (hash-set! fields 'otype otype)
   (table-set! operator-impls name fields)
-  (hash-update! parametric-operators operator
-                (curry cons (list* name otype (operator-info name 'itype)))
-                '())
-  (hash-set! parametric-operators-reverse name operator))
+  (set! parametric-operators
+    (hash-update parametric-operators operator
+                 (curry cons (list* name otype (operator-info name 'itype)))
+                 '()))
+  (set! parametric-operators-reverse
+    (hash-set parametric-operators-reverse name operator)))
   
 
 (define-syntax-rule (define-operator-impl (operator name atypes ...) rtype [key value] ...)

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -7,7 +7,8 @@
 
 (struct type (name exact? inexact? exact->inexact inexact->exact))
 
-(define type-dict (make-hash))
+(define type-dict (make-hasheq))
+
 (define-syntax-rule (define-type name (exact? inexact?) e->i i->e)
   (hash-set! type-dict 'name (type 'name exact? inexact? e->i i->e)))
 

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -51,7 +51,7 @@
           (values k (map (λ (p) (path->string (build-path link p))) v))
           (values k v)))))
 
-(define timeline-types (make-hash))
+(define timeline-types (make-hasheq))
 
 (define-syntax define-timeline
   (syntax-rules ()
@@ -68,7 +68,7 @@
 (define (make-merger . fields)
   (λ tables
     (define rows (apply append tables))
-    (define groups (make-hash))
+    (define groups (make-hasheq))
     (for ([row rows])
       (define-values (values key*) (partition cdr (map cons row fields)))
       (define key (map car key*))
@@ -123,9 +123,9 @@
 
 (define (timeline-merge . timelines)
   ;; The timelines in this case are JSON objects, as above
-  (define types (make-hash))
+  (define types (make-hasheq))
   (for* ([tl (in-list timelines)] [event tl])
-    (define data (hash-ref! types (hash-ref event 'type) (make-hash)))
+    (define data (hash-ref! types (hash-ref event 'type) (make-hasheq)))
     (for ([(k v) (in-dict event)] #:when (hash-ref timeline-types k #f))
       (if (hash-has-key? data k)
           (hash-update! data k (λ (old) ((hash-ref timeline-types k) v old)))

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -68,7 +68,7 @@
 (define (make-merger . fields)
   (λ tables
     (define rows (apply append tables))
-    (define groups (make-hasheq))
+    (define groups (make-hash))
     (for ([row rows])
       (define-values (values key*) (partition cdr (map cons row fields)))
       (define key (map car key*))
@@ -123,9 +123,9 @@
 
 (define (timeline-merge . timelines)
   ;; The timelines in this case are JSON objects, as above
-  (define types (make-hasheq))
+  (define types (make-hash))
   (for* ([tl (in-list timelines)] [event tl])
-    (define data (hash-ref! types (hash-ref event 'type) (make-hasheq)))
+    (define data (hash-ref! types (hash-ref event 'type) (make-hash)))
     (for ([(k v) (in-dict event)] #:when (hash-ref timeline-types k #f))
       (if (hash-has-key? data k)
           (hash-update! data k (λ (old) ((hash-ref timeline-types k) v old)))

--- a/src/timeline.rkt
+++ b/src/timeline.rkt
@@ -15,8 +15,8 @@
 
 (define (timeline-event! type)
   (unless (*timeline-disabled*)
-    (define initial (hasheq 'type (~a type) 'time (current-inexact-milliseconds)))
-    (define b (make-hasheq (hash->list initial))) ; convert to mutable hash
+    (define b (make-hasheq (list (cons 'type (~a type))
+                                 (cons 'time (current-inexact-milliseconds)))))
     (set-box! *timeline* (cons b (unbox *timeline*)))))
 
 (define/contract (timeline-push! key . values)
@@ -25,7 +25,7 @@
     (define val (if (= (length values) 1) (car values) values))
     (hash-update! (car (unbox *timeline*)) key (curry cons val) '())))
 
-(define (timeline-adjust! type key . values)
+(define/contract (timeline-adjust! type key . values)
   (-> symbol? symbol? jsexpr? ... void?)
   (unless (*timeline-disabled*)
     (for/first ([cell (unbox *timeline*)] #:when (equal? (hash-ref cell 'type) (~a type)))


### PR DESCRIPTION
This PR resolves some long-standing issues with multi-threading.
- most shared mutable hash tables have either been changed to immutable tables or mutable hash tables using `eq?`-based key comparisons
- resetters make sure to initialize new hash tables rather than clear the old ones
- introduces a workaround for Racket CS <= 8.2 to resolve a [bug](https://github.com/racket/racket/commit/54d5b26b6e1be709a25e04d53eedda8077f60f52) involving `racket/place`