### PR TITLE
Fallback plugin / numerics rules on by default

### DIFF
--- a/src/binary32.rkt
+++ b/src/binary32.rkt
@@ -2,7 +2,10 @@
 
 ;; binary32 builtin plugin
 
-(require herbie/plugin math/flonum math/bigfloat herbie/errors)
+(require math/flonum math/bigfloat)
+(require (submod "syntax/syntax.rkt" internals)
+         (submod "interface.rkt" internals)
+         "errors.rkt")
 
 ; needed by src/syntax/test-rules.rkt
 ; cannot be exported with contracts since ffi/unsafe is required
@@ -270,10 +273,10 @@
   [itype 'binary32] [otype 'bool] ; Override number of arguments
   [fl (comparator >=)])
 
-(define-operator-impl (cast binary32->binary32 binary32) binary32
+(define-operator-impl (cast binary64->binary32 binary64) binary32
   [fl (curryr ->float32)])
 
-(define-operator-impl (cast binary32->binary32 binary32) binary32
+(define-operator-impl (cast binary32->binary64 binary32) binary64
   [fl identity])
 
 )

--- a/src/binary64.rkt
+++ b/src/binary64.rkt
@@ -2,15 +2,9 @@
 
 ;; binary64 builtin plugin
 
-(require math/base math/bigfloat math/flonum math/special-functions)
-(require (submod "syntax/syntax.rkt" internals)
-         (submod "interface.rkt" internals)
-         "syntax/syntax.rkt" "common.rkt"
-         "errors.rkt")
+(require herbie/plugin math/flonum math/bigfloat herbie/errors)
 
 ; (eprintf "Loading binary64 support...\n")
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (shift bits fn)
   (define shift-val (expt 2 bits))
@@ -19,6 +13,12 @@
 (define (unshift bits fn)
   (define shift-val (expt 2 bits))
   (λ (x) (+ (fn x) shift-val)))
+
+(define ((comparator test) . args)
+  (for/and ([left args] [right (cdr args)])
+    (test left right)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation (binary64 real flonum?)
   bigfloat->flonum
@@ -46,48 +46,32 @@
 
 (require ffi/unsafe)
 (define-syntax (define-libm-operator stx)
-  (syntax-case stx (real libm)
-    [(_ (op real ...) [libm id] [nonffi fn] [key value] ...)
+  (syntax-case stx (real)
+    [(_ (op real ...) [key value] ...)
      (let* ([num-args (length (cdr (syntax-e (cadr (syntax-e stx)))))]
             [sym2-append (λ (x y) (string->symbol (string-append (symbol->string x) (symbol->string y))))]
             [name (sym2-append (syntax-e (car (syntax-e (cadr (syntax-e stx))))) '.f64)])
        #`(begin
-           (define fl-proc (get-ffi-obj 'id #f (_fun #,@(build-list num-args (λ (_) #'_double)) -> _double)
-                                         (lambda ()
-                                          (*unknown-ops* (cons '#,name (*unknown-ops*)))
-                                          (warn 'fallback #:url "faq.html#native-ops"
-                                                "native `~a` not supported on your system, using fallback; ~a"
-                                                'op
-                                                "use --disable precision:fallback to disable fallbacks")
-                                          fn)))
+           (define fl-proc
+            (get-ffi-obj 'op #f (_fun #,@(build-list num-args (λ (_) #'_double)) -> _double)
+                         (λ () (λ _ (raise-herbie-error
+                                      #:url "faq.html#native-ops"
+                                      "native" 'op "not supported on your system"
+                                      "use the 'racket' precision instead")))))
            (define-operator-impl (op #,name #,@(build-list num-args (λ (_) #'binary64))) binary64
-             [fl fl-proc])))]))
+             [fl fl-proc] [key value] ...)))]))
 
-(define-syntax-rule (define-1ary-libm-operator op name fallback)
-  (define-libm-operator (op real) [libm name] [nonffi fallback]))
+(define-syntax-rule (define-1ary-libm-operator op)
+  (define-libm-operator (op real)))
 
-(define-syntax-rule (define-2ary-libm-operator op name fallback)
-  (define-libm-operator (op real real) [libm name] [nonffi fallback]))
+(define-syntax-rule (define-2ary-libm-operator op)
+  (define-libm-operator (op real real)))
 
-(define-syntax-rule (define-1ary-libm-operators [op name fallback] ...)
-  (begin (define-1ary-libm-operator op name fallback) ...))
+(define-syntax-rule (define-1ary-libm-operators op ...)
+  (begin (define-1ary-libm-operator op) ...))
 
-(define-syntax-rule (define-2ary-libm-operators [op name fallback] ...)
-  (begin (define-2ary-libm-operator op name fallback) ...))
-
-(define (no-complex fun)
-  (λ xs
-     (define res (apply fun xs))
-     (if (real? res) res +nan.0)))
-
-(define (from-bigfloat bff)
-  (λ args (bigfloat->flonum (apply bff (map bf args)))))
-
-(define (bffmod x mod)
-  (bf- x (bf* (bftruncate (bf/ x mod)) mod)))
-
-(define (bffma x y z)
-  (bf+ (bf* x y) z))
+(define-syntax-rule (define-2ary-libm-operators op ...)
+  (begin (define-2ary-libm-operator op) ...))
 
 
 (define-operator-impl (neg neg.f64 binary64) binary64 [fl -])
@@ -97,56 +81,55 @@
 (define-operator-impl (/ /.f64 binary64 binary64) binary64 [fl /])
 
 (define-1ary-libm-operators
- [acos acos (no-complex acos)]
- [acosh acosh (no-complex acosh)]
- [asin asin (no-complex asin)]
- [asinh asinh (no-complex asinh)]
- [atan atan (no-complex atan)]
- [atanh atanh (no-complex atanh)]
- [cbrt cbrt (no-complex (λ (x) (expt x 1/3)))]
- [ceil ceil ceiling]
- [cos cos cos]
- [cosh cosh cosh]
- [erf erf (no-complex erf)]
- [erfc erfc erfc]
- [exp exp exp]
- [exp2 exp2 (no-complex (λ (x) (expt 2 x)))]
- [expm1 expm1 (from-bigfloat bfexpm1)]
- [fabs fabs abs]
- [floor floor floor]
- [j0 j0 (from-bigfloat bfbesj0)]
- [j1 j1 (from-bigfloat bfbesj1)]
- [lgamma lgamma log-gamma]
- [log log (no-complex log)]
- [log10 log10 (no-complex (λ (x) (log x 10)))]
- [log1p log1p (from-bigfloat bflog1p)]
- [log2 log2 (from-bigfloat bflog2)]
- [logb logb (λ (x) (floor (bigfloat->flonum (bflog2 (bf (abs x))))))]
- [rint rint round]
- [round round round]
- [sin sin sin]
- [sinh sinh sinh]
- [sqrt sqrt (no-complex sqrt)]
- [tan tan tan]
- [tanh tanh tanh]
- [tgamma tgamma gamma]
- [trunc trunc truncate]
- [y0 y0 (from-bigfloat bfbesy0)]
- [y1 y1 (from-bigfloat bfbesy1)])
+ acos
+ acosh
+ asin
+ asinh
+ atan
+ atanh
+ cbrt
+ ceil
+ cos
+ cosh
+ erf
+ erfc
+ exp
+ exp2
+ expm1
+ fabs
+ floor
+ j0
+ j1
+ lgamma
+ log
+ log10
+ log1p
+ log2
+ logb
+ rint
+ round
+ sin
+ sinh
+ sqrt
+ tan
+ tanh
+ tgamma
+ trunc
+ y0
+ y1)
 
 (define-2ary-libm-operators
- [atan2 atan2 (no-complex atan)]
- [copysign copysign (λ (x y) (if (>= y 0) (abs x) (- (abs x))))]
- [fdim fdim (λ (x y) (max (- x y) 0))]
- [fmax fmax (λ (x y) (cond [(nan? x) y] [(nan? y) x] [else (max x y)]))]
- [fmin fmin (λ (x y) (cond [(nan? x) y] [(nan? y) x] [else (min x y)]))]
- [fmod fmod (from-bigfloat bffmod)]
- [hypot hypot (from-bigfloat bfhypot)]
- [pow pow (no-complex expt)]
- [remainder remainder remainder])
+ atan2
+ copysign
+ fdim
+ fmax
+ fmin
+ fmod
+ hypot
+ pow
+ remainder)
 
-(define-libm-operator (fma real real real)
- [libm fma] [nonffi (from-bigfloat bffma)])
+(define-libm-operator (fma real real real))
 
 (define-operator-impl (== ==.f64 binary64 binary64) bool
   [itype 'binary64] [otype 'bool] ; Override number of arguments

--- a/src/binary64.rkt
+++ b/src/binary64.rkt
@@ -2,7 +2,10 @@
 
 ;; binary64 builtin plugin
 
-(require herbie/plugin math/flonum math/bigfloat herbie/errors)
+(require math/flonum math/bigfloat)
+(require (submod "syntax/syntax.rkt" internals)
+         (submod "interface.rkt" internals)
+         "errors.rkt")
 
 ; (eprintf "Loading binary64 support...\n")
 

--- a/src/bool.rkt
+++ b/src/bool.rkt
@@ -2,9 +2,7 @@
 
 ;; bool builtin plugin
 
-(require (submod "syntax/syntax.rkt" internals)
-         (submod "syntax/rules.rkt" internals)
-         (submod "interface.rkt" internals))
+(require herbie/plugin)
 
 ; (eprintf "Loading bool support...\n")
 

--- a/src/bool.rkt
+++ b/src/bool.rkt
@@ -2,7 +2,9 @@
 
 ;; bool builtin plugin
 
-(require herbie/plugin)
+(require (submod "syntax/syntax.rkt" internals)
+         (submod "syntax/rules.rkt" internals)
+         (submod "interface.rkt" internals))
 
 ; (eprintf "Loading bool support...\n")
 

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -15,7 +15,7 @@
         [setup . (simplify search)]
         [generate . (rr taylor simplify)]
         [reduce . (regimes avg-error binary-search branch-expressions)]
-        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic special bools branches)]))
+        [rules . (arithmetic polynomials fractions exponents trigonometry hyperbolic numerics special bools branches)]))
 
 (define (check-flag-deprecated! category flag)
   (match* (category flag)

--- a/src/fallback.rkt
+++ b/src/fallback.rkt
@@ -2,7 +2,9 @@
 
 ;; fallback (Racket) builtin plugin
 
-(require herbie/plugin math/base math/bigfloat math/flonum math/special-functions)
+(require math/base math/bigfloat math/flonum math/special-functions)
+(require (submod "syntax/syntax.rkt" internals)
+         (submod "interface.rkt" internals))
 
 ; (eprintf "Loading fallback support...\n")
 

--- a/src/fallback.rkt
+++ b/src/fallback.rkt
@@ -1,0 +1,162 @@
+#lang racket
+
+;; fallback (Racket) builtin plugin
+
+(require herbie/plugin math/base math/bigfloat math/flonum math/special-functions)
+
+; (eprintf "Loading fallback support...\n")
+
+(define (shift bits fn)
+  (define shift-val (expt 2 bits))
+  (λ (x) (fn (- x shift-val))))
+
+(define (unshift bits fn)
+  (define shift-val (expt 2 bits))
+  (λ (x) (+ (fn x) shift-val)))
+
+(define ((comparator test) . args)
+  (for/and ([left args] [right (cdr args)])
+    (test left right)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-representation (racket real flonum?)
+  bigfloat->flonum
+  bf
+  (shift 63 ordinal->flonum)
+  (unshift 63 flonum->ordinal)
+  64
+  (disjoin nan? infinite?))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-constant-impl (PI PI.rkt) racket
+  [fl (const pi)])
+
+(define-constant-impl (E E.rkt) racket
+  [fl (const (exp 1.0))])
+
+(define-constant-impl (INFINITY INFINITY.rkt) racket
+  [fl (const +inf.0)])
+
+(define-constant-impl (NAN NAN.rkt) racket
+  [fl (const +nan.0)])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-syntax (define-fallback-operator stx)
+  (syntax-case stx (real fl)
+    [(_ (op real ...) [fl fn] [key value] ...)
+     (let* ([num-args (length (cdr (syntax-e (cadr (syntax-e stx)))))]
+            [sym2-append (λ (x y) (string->symbol (string-append (symbol->string x) (symbol->string y))))]
+            [name (sym2-append (syntax-e (car (syntax-e (cadr (syntax-e stx))))) '.rkt)])
+       #`(define-operator-impl (op #,name #,@(build-list num-args (λ (_) #'racket))) racket
+          [fl fn] [key value] ...))]))
+
+(define-syntax-rule (define-1ary-fallback-operator op fn)
+  (define-fallback-operator (op real) [fl fn]))
+
+(define-syntax-rule (define-2ary-fallback-operator op fn)
+  (define-fallback-operator (op real real) [fl fn]))
+
+(define-syntax-rule (define-1ary-fallback-operators [op fn] ...)
+  (begin (define-1ary-fallback-operator op fn) ...))
+
+(define-syntax-rule (define-2ary-fallback-operators [op fn] ...)
+  (begin (define-2ary-fallback-operator op fn) ...))
+
+(define (no-complex fun)
+  (λ xs
+     (define res (apply fun xs))
+     (if (real? res) res +nan.0)))
+
+(define (from-bigfloat bff)
+  (λ args (bigfloat->flonum (apply bff (map bf args)))))
+
+(define (bffmod x mod)
+  (bf- x (bf* (bftruncate (bf/ x mod)) mod)))
+
+(define (bffma x y z)
+  (bf+ (bf* x y) z))
+
+
+(define-1ary-fallback-operators
+ [neg -]
+ [acos (no-complex acos)]
+ [acosh (no-complex acosh)]
+ [asin (no-complex asin)]
+ [asinh (no-complex asinh)]
+ [atan (no-complex atan)]
+ [atanh (no-complex atanh)]
+ [cbrt (no-complex (λ (x) (expt x 1/3)))]
+ [ceil ceiling]
+ [cos cos]
+ [cosh cosh]
+ [erf (no-complex erf)]
+ [erfc erfc]
+ [exp exp]
+ [exp2 (no-complex (λ (x) (expt 2 x)))]
+ [expm1 (from-bigfloat bfexpm1)]
+ [fabs abs]
+ [floor floor]
+ [j0 (from-bigfloat bfbesj0)]
+ [j1 (from-bigfloat bfbesj1)]
+ [lgamma log-gamma]
+ [log (no-complex log)]
+ [log10 (no-complex (λ (x) (log x 10)))]
+ [log1p (from-bigfloat bflog1p)]
+ [log2 (from-bigfloat bflog2)]
+ [logb (λ (x) (floor (bigfloat->flonum (bflog2 (bf (abs x))))))]
+ [rint round]
+ [round round]
+ [sin sin]
+ [sinh sinh]
+ [sqrt (no-complex sqrt)]
+ [tan tan]
+ [tanh tanh]
+ [tgamma gamma]
+ [trunc truncate]
+ [y0 (from-bigfloat bfbesy0)]
+ [y1 (from-bigfloat bfbesy1)])
+
+(define-2ary-fallback-operators
+ [+ +]
+ [- -]
+ [* *]
+ [/ /]
+ [atan2 (no-complex atan)]
+ [copysign (λ (x y) (if (>= y 0) (abs x) (- (abs x))))]
+ [fdim (λ (x y) (max (- x y) 0))]
+ [fmax (λ (x y) (cond [(nan? x) y] [(nan? y) x] [else (max x y)]))]
+ [fmin (λ (x y) (cond [(nan? x) y] [(nan? y) x] [else (min x y)]))]
+ [fmod (from-bigfloat bffmod)]
+ [hypot (from-bigfloat bfhypot)]
+ [pow (no-complex expt)]
+ [remainder remainder])
+
+(define-fallback-operator (fma real real real)
+ [fl (from-bigfloat bffma)])
+
+(define-operator-impl (== ==.rkt racket racket) bool
+  [itype 'racket] [otype 'bool] ; Override number of arguments
+  [fl (comparator =)])
+
+(define-operator-impl (!= !=.rkt racket racket) bool
+  [itype 'racket] [otype 'bool] ; Override number of arguments
+  [fl (negate (comparator =))])
+
+(define-operator-impl (< <.rkt racket racket) bool
+  [itype 'racket] [otype 'bool] ; Override number of arguments
+  [fl (comparator <)])
+
+(define-operator-impl (> >.rkt racket racket) bool
+  [itype 'racket] [otype 'bool] ; Override number of arguments
+  [fl (comparator >)])
+
+(define-operator-impl (<= <=.rkt racket racket) bool
+  [itype 'racket] [otype 'bool] ; Override number of arguments
+  [fl (comparator <=)])
+
+(define-operator-impl (>= >=.rkt racket racket) bool
+  [itype 'racket] [otype 'bool] ; Override number of arguments
+  [fl (comparator >=)])

--- a/src/interface.rkt
+++ b/src/interface.rkt
@@ -102,6 +102,9 @@
    ['bool
     (dynamic-require 'herbie/bool #f)
     #t]
+   ['racket
+    (dynamic-require 'herbie/fallback #f)
+    #t]
    [_ #f]))
 
 (register-generator! generate-builtins)

--- a/src/plugin.rkt
+++ b/src/plugin.rkt
@@ -16,7 +16,8 @@
 (define (load-herbie-builtins)
   (dynamic-require 'herbie/bool #f)
   (dynamic-require 'herbie/binary64 #f)
-  (dynamic-require 'herbie/binary32 #f))
+  (dynamic-require 'herbie/binary32 #f)
+  (dynamic-require 'herbie/fallback #f))
 
 (define (load-herbie-plugins)
   (load-herbie-builtins)    ; automatically load default representations


### PR DESCRIPTION
This PR creates a new internal plugin called the fallback plugin (invoked by `:precision racket`). This plugin is essentially the same as `binary64` except it uses Racket's math library. The bad fallback code within the `binary64` and `binary32` plugins has been removed. If Herbie cannot find certain libm functions, it will produce an error if these functions are used. In addition, `numerics` rules have been enabled by default.