### PR TITLE
Fix a bug wherein demo results were being silently lost

### DIFF
--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -223,7 +223,7 @@
           (struct-copy report-info info [tests (cons data (report-info-tests info))]))
         (make-report-info (list data) #:seed seed #:note (if (*demo?*) "Web demo results" ""))))
   (write-datafile data-file info)
-  (call-with-output-file html-file #:exists 'replace (curryr make-report-page info)))
+  (call-with-output-file html-file #:exists 'replace (curryr make-report-page info #f)))
 
 (define (run-improve hash formula)
   (hash-set! *jobs* hash (open-output-string))

--- a/src/web/make-report.rkt
+++ b/src/web/make-report.rkt
@@ -40,6 +40,7 @@
 
   (define-values (pareto-start pareto-points pareto-max) (trs->pareto tests))
   (cond
+   [(not dir) (void)]
    [(> (length pareto-points) 1) ; generate the scatterplot if necessary
     (call-with-output-file (build-path dir "cost-accuracy.png")
       #:exists 'replace


### PR DESCRIPTION
The `make-report-page` takes an extra parameter now but no one told `demo.rkt`.