### PR TITLE
Fix multiple bugs

### DIFF
--- a/src/binary32.rkt
+++ b/src/binary32.rkt
@@ -158,7 +158,7 @@
        #`(begin
            (define fl-proc
             (get-ffi-obj '#,cname #f (_fun #,@(build-list num-args (λ (_) #'_float)) -> _float)
-                         (λ () (warn '#,cname #:url "faq.html#native-ops"
+                         (λ () (warn 'unsupported #:url "faq.html#native-ops"
                                      "native `~a` not supported on your system, disabling operator. ~a"
                                      '#,cname
                                      "Consider using :precision racket for Racket-only double-precision ops.")

--- a/src/binary32.rkt
+++ b/src/binary32.rkt
@@ -158,12 +158,14 @@
        #`(begin
            (define fl-proc
             (get-ffi-obj '#,cname #f (_fun #,@(build-list num-args (λ (_) #'_float)) -> _float)
-                         (λ () (λ _ (raise-herbie-error
-                                      #:url "faq.html#native-ops"
-                                      "native" 'op "not supported on your system"
-                                      "use the 'racket' precision instead")))))
-           (define-operator-impl (op #,name #,@(build-list num-args (λ (_) #'binary32))) binary32
-             [fl fl-proc] [key value] ...)))]))
+                         (λ () (warn '#,cname #:url "faq.html#native-ops"
+                                     "native `~a` not supported on your system, disabling operator. ~a"
+                                     '#,cname
+                                     "Consider using :precision racket for Racket-only double-precision ops.")
+                               #f)))
+           (when fl-proc
+            (define-operator-impl (op #,name #,@(build-list num-args (λ (_) #'binary32))) binary32
+              [fl fl-proc] [key value] ...))))]))
 
 (define-syntax-rule (define-1ary-libm-operator op)
   (define-libm-operator (op real)))

--- a/src/binary32.rkt
+++ b/src/binary32.rkt
@@ -161,7 +161,7 @@
                          (λ () (warn 'unsupported #:url "faq.html#native-ops"
                                      "native `~a` not supported on your system, disabling operator. ~a"
                                      '#,cname
-                                     "Consider using :precision racket for Racket-only double-precision ops.")
+                                     "Consider using :precision racket for Racket-only operators.")
                                #f)))
            (when fl-proc
             (define-operator-impl (op #,name #,@(build-list num-args (λ (_) #'binary32))) binary32

--- a/src/binary64.rkt
+++ b/src/binary64.rkt
@@ -57,12 +57,14 @@
        #`(begin
            (define fl-proc
             (get-ffi-obj 'op #f (_fun #,@(build-list num-args (λ (_) #'_double)) -> _double)
-                         (λ () (λ _ (raise-herbie-error
-                                      #:url "faq.html#native-ops"
-                                      "native" 'op "not supported on your system"
-                                      "use the 'racket' precision instead")))))
-           (define-operator-impl (op #,name #,@(build-list num-args (λ (_) #'binary64))) binary64
-             [fl fl-proc] [key value] ...)))]))
+                         (λ () (warn 'unsupported #:url "faq.html#native-ops"
+                                     "native `~a` not supported on your system, disabling operator. ~a"
+                                     'op
+                                     "Consider using :precision racket for Racket-only operators.")
+                               #f)))
+           (when fl-proc
+            (define-operator-impl (op #,name #,@(build-list num-args (λ (_) #'binary64))) binary64
+              [fl fl-proc] [key value] ...))))]))
 
 (define-syntax-rule (define-1ary-libm-operator op)
   (define-libm-operator (op real)))

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -80,7 +80,7 @@
   (unless (*warnings-disabled*)
     (define url* (and url (format "https://herbie.uwplse.org/doc/~a/~a" *herbie-version* url)))
     (define entry (list message args url* extra))
-    (hash-update! warnings type (λ (x) (cons entry x)) (list entry))
+    (hash-update! warnings type (curry cons entry) (list))
     (set! warning-log (cons (list type message args url* extra) warning-log))))
 
 (define (print-warnings)

--- a/src/errors.rkt
+++ b/src/errors.rkt
@@ -6,7 +6,8 @@
          (struct-out exn:fail:user:herbie)
          (struct-out exn:fail:user:herbie:syntax)
          (struct-out exn:fail:user:herbie:sampling)
-         warn warning-log *warnings-disabled*)
+         warn warning-log *warnings-disabled*
+         print-warnings)
 
 (struct exn:fail:user:herbie exn:fail:user (url)
         #:extra-constructor-name make-exn:fail:user:herbie)
@@ -66,20 +67,30 @@
     [else
      (old-error-display-handler message err)])))
 
-(define warnings-seen (mutable-set))
-(define warning-log '())
+
 (define *warnings-disabled* (make-parameter false))
+(define warnings (make-hash))
+(define warning-log '())
+
+(register-reset 
+  (λ () (set! warnings (make-hash))
+        (set! warning-log '())))
 
 (define (warn type message #:url [url #f] #:extra [extra '()] . args)
-  (unless (or (*warnings-disabled*) (set-member? warnings-seen type))
-    (set-add! warnings-seen type)
+  (unless (*warnings-disabled*)
     (define url* (and url (format "https://herbie.uwplse.org/doc/~a/~a" *herbie-version* url)))
-    (set! warning-log (cons (list type message args url* extra) warning-log))
-    (eprintf "Warning: ~a\n" (apply format message args))
-    (for ([line extra]) (eprintf "  ~a\n" line))
-    (when url (eprintf "See <~a> for more.\n" url*))))
+    (define entry (list message args url* extra))
+    (hash-update! warnings type (λ (x) (cons entry x)) (list entry))
+    (set! warning-log (cons (list type message args url* extra) warning-log))))
 
-(register-reset
- (λ ()
-   (set! warnings-seen (mutable-set))
-   (set! warning-log '())))
+(define (print-warnings)
+  (unless (*warnings-disabled*)
+    (for ([(type log) (in-hash warnings)])
+      (define url
+        (for/fold ([url #f]) ([entry (in-list (reverse log))])
+          (match-define (list message args url* extra) entry)
+          (eprintf "Warning: ~a\n" (apply format message args))
+          (for ([line extra]) (eprintf "  ~a\n" line))
+          (if url* url* url)))
+      (eprintf "See <~a> for more.\n" url))
+    (set! warnings (make-hash))))

--- a/src/herbie.rkt
+++ b/src/herbie.rkt
@@ -44,6 +44,9 @@
   (define seed (random 1 (expt 2 31)))
   (set-seed! seed)
 
+  ; handle plugin warnings
+  (print-warnings)
+
   (multi-command-line
    #:program "herbie"
    #:once-each

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -60,9 +60,9 @@
 ;; is stored as the value
 (define (cache-improvement! expr [improve #f])
   (when (*use-improve-cache*)
-    (if improve
-        (hash-update! improve-cache expr (curry cons improve) (list improve))
-        (hash-update! improve-cache expr identity (list)))))
+    (hash-update! improve-cache expr
+                  (if improve (curry cons improve) identity)
+                  (list))))
 
 (register-reset
   (λ () (set! improve-cache (make-hash))))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -609,7 +609,8 @@
     (^next-alt^ #f))
   (for ([iter (in-range iters)] #:break (atab-completed? (^table^)))
     (debug #:from 'progress #:depth 2 "iteration" (+ 1 iter) "/" iters)
-    (run-iter!))
+    (run-iter!)
+    (print-warnings))
   (debug #:from 'progress #:depth 1 "[Phase 3 of 3] Extracting.")
   (extract!))
 

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -70,7 +70,7 @@
                        #:precondition (test-precondition test)
                        #:preprocess (test-preprocess test)
                        #:specification (test-specification test)
-                       #:precision output-prec))
+                       #:precision output-prec))             
 
         (define context (*pcontext*))
         (when seed (set-seed! seed))
@@ -93,6 +93,7 @@
         (timeline-adjust! 'regimes 'baseline (errors-score baseline-errs))
         (timeline-adjust! 'regimes 'name (test-name test))
         (timeline-adjust! 'regimes 'link ".")
+        (print-warnings)
 
         (define-values (points exacts) (get-p&es context))
         (define-values (newpoints newexacts) (get-p&es newcontext))
@@ -119,6 +120,7 @@
   (define (on-exception start-time e)
     (parameterize ([*timeline-disabled* false])
       (timeline-event! 'end))
+    (print-warnings)
     (test-failure test (bf-precision)
                   (- (current-inexact-milliseconds) start-time) (timeline-extract output-repr)
                   warning-log e))
@@ -143,6 +145,7 @@
       (engine-result eng)
       (parameterize ([*timeline-disabled* false])
         (timeline-load! timeline)
+        (print-warnings)
         (test-timeout test (bf-precision) (*timeout*) (timeline-extract output-repr) '()))))
 
 (define (dummy-table-row result status link)

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -70,7 +70,7 @@
                        #:precondition (test-precondition test)
                        #:preprocess (test-preprocess test)
                        #:specification (test-specification test)
-                       #:precision output-prec))             
+                       #:precision output-prec))
 
         (define context (*pcontext*))
         (when seed (set-seed! seed))

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -39,12 +39,11 @@
          (constant-info x 'type)
          (constant-info (get-parametric-constant x type) 'type))]
     [#`,(? variable? x)
-     (define etype (type-name (representation-type (get-representation type))))
-     (define vtype (type-name (representation-type (get-representation (dict-ref env x)))))
+     (define vtype (dict-ref env x))
      (cond
       [(equal? vtype 'bool) 'bool]
-      [(equal? etype vtype) type]
-      [else (error! stx "Expected a variable of type ~a, but got ~a" etype vtype)])]
+      [(equal? type vtype) type]
+      [else (error! stx "Expected a variable of type ~a, but got ~a" type vtype)])]
     [#`(let ((,id #,expr) ...) #,body)
      (define env2
        (for/fold ([env2 env]) ([var id] [val expr])
@@ -95,6 +94,8 @@
      (define t #f)
      (for ([arg exprs] [i (in-naturals)])
        (define actual-type (expression->type arg env type error!))
+       (when (equal? actual-type 'bool)
+          (error! stx "~a does not take boolean arguments" op))
        (if (= i 0) (set! t actual-type) #f)
        (unless (equal? t actual-type)
          (error! stx "~a expects argument ~a of type ~a (not ~a)" op (+ i 1) t actual-type)))

--- a/src/web/demo.rkt
+++ b/src/web/demo.rkt
@@ -242,6 +242,8 @@
      (define formula
        (with-handlers ([exn:fail? (λ (e) #f)])
          (read-syntax 'web (open-input-string formula-str))))
+     (unless formula
+      (raise-herbie-error "bad input: did you include special characters like `#`?"))
      (with-handlers
          ([exn:fail:user:herbie?
            (λ (e)
@@ -250,7 +252,6 @@
               `(p "Invalid formula " (code ,formula-str) ". "
                   "Formula must be a valid program using only the supported functions. "
                   "Please " (a ([href ,go-back]) "go back") " and try again.")))])
-
        (when (eof-object? formula)
          (raise-herbie-error "no formula specified"))
        (assert-program! formula)


### PR DESCRIPTION
This PR fixes multiple bugs found in recent demo crashes as well as issue #396. These fixes include
 - raise error with malformed FPCore without crashing
 - early exit in demo on failed input
 - disable operators that can't be loaded through ffi
 - add missing type check
 - load representations for unit tests to work
 
 In addition, warnings are now aggregated and must be manually printed through `print-warnings`.  This allows warnings to be grouped.