### PR TITLE
Make make-index read and write from cache, not files

### DIFF
--- a/infra/make-index.rkt
+++ b/infra/make-index.rkt
@@ -1,26 +1,16 @@
 #lang racket
 
-(require racket/runtime-path)
+(require racket/runtime-path racket/hash)
 (require (only-in xml write-xexpr) json)
 (require racket/date "../src/common.rkt" "../src/datafile.rkt")
-(provide directory-jsons name->timestamp)
-
-(define-runtime-path report-json-path "../previous/")
-
-(define (name->timestamp path)
-  (define rpath (find-relative-path (simple-form-path report-json-path) path))
-  (define folder (path-element->string (first (explode-path rpath))))
-  (string->number
-   (if (string-contains? folder ":")
-       (first (string-split folder ":"))
-       folder)))
+(provide directory-jsons)
 
 (define (directory-jsons dir)
   (reap [sow]
     (let loop ([dir dir])
       (cond
        [(file-exists? (build-path dir "results.json"))
-        (sow (find-relative-path (simple-form-path report-json-path) (simple-form-path dir)))]
+        (sow dir)]
        [(directory-exists? dir)
         (for-each loop (directory-list dir #:build? true))]))))
 
@@ -62,7 +52,7 @@
 (define/contract (compute-row folder)
   (-> path? cache-row?)
   (eprintf "Reading ~a\n" folder)
-  (define info (read-datafile (build-path report-json-path folder "results.json")))
+  (define info (read-datafile (build-path folder "results.json")))
   (match-define (report-info date commit branch hostname seed flags points iterations note tests) info)
 
   (define-values (total-start total-end)
@@ -103,9 +93,6 @@
         'bits-improved (- total-start total-end)
         'bits-available total-start))
 
-(define (read-row folder)
-  (dict-ref! (*cache*) (string->symbol (path->string folder)) (λ () (compute-row folder))))
-
 (define (round* x)
   (cond
    [(>= (abs x) (expt 10 6)) "?"]
@@ -139,28 +126,21 @@
            (td ([title ,(format "At ~a\nOn ~a\nFlags ~a" (field 'date-full) (field 'hostname) (string-join (field 'options) " "))])
                (a ([href ,(format "./~a/results.html" (field 'folder))]) "»")))))))
 
-(define (make-index-page out)
-  (when (file-exists? (build-path report-json-path "index.cache"))
-    (define cached-info (hash-copy (call-with-input-file (build-path report-json-path "index.cache") read-json)))
-    (if (for/and ([(k v) (in-hash cached-info)]) (cache-row? v))
-        (*cache* cached-info)
-        (eprintf "Ignoring cache; contains invalid values")))
+(define (make-index-page folders out)
+  (define branch-infos
+     (group-by (curryr dict-ref 'branch)
+               (sort
+                (filter (compose (curry < (- (current-seconds) (* 60 60 24 30)))
+                                 (curryr dict-ref 'date-unix))
+                        folders)
+               > #:key (curryr dict-ref 'date-unix))))
 
-  (define dirs (directory-jsons report-json-path))
-  (define folders
-     (map read-row (sort (filter name->timestamp dirs) > #:key name->timestamp)))
-  (define recent-folders
-    (filter (λ (x) (< (- (current-seconds) (dict-ref x 'date-unix)) (* 60 60 24 30)))
-            folders))
-
-  (define branch-infos*
-    (sort
-     (group-by (curryr dict-ref 'branch) recent-folders)
-     > #:key (λ (x) (dict-ref (first x) 'date-unix))))
+  (when (null? branch-infos)
+    (raise-user-error 'make-index "No recent nightly runs"))
 
   (define-values (mainline-infos other-infos)
     (partition (λ (x) (set-member? '("master" "develop") (dict-ref (first x) 'branch)))
-               branch-infos*))
+               branch-infos))
 
   (when (null? mainline-infos)
     (set! mainline-infos
@@ -196,9 +176,9 @@
      (body
       (div
        ((id "large"))
-       (div "Reports: " (span ((class "number")) ,(~a (length recent-folders))))
+       (div "Reports: " (span ((class "number")) ,(~a (apply + (map length branch-infos)))))
        (div "Mainline: " (span ((class "number")) ,(~a (length (apply append mainline-infos)))))
-       (div "Branches: " (span ((class "number")) ,(~a (length branch-infos*))))
+       (div "Branches: " (span ((class "number")) ,(~a (length branch-infos))))
        (div "Crash-free: " (span ((class "number")) ,(if since-last-crash
                                                          (format "~ad" (inexact->exact (round since-last-crash)))
                                                          "∞"))))
@@ -220,10 +200,25 @@
             (print-rows rows #:name (dict-ref (first rows) 'branch)))))))
    out))
 
+(define (get-reports file)
+  (cond
+   [(directory-exists? file)
+    (for/hash ([dir (directory-jsons file)])
+      (values dir (compute-row dir)))]
+   [(file-exists? file)
+    (define cached-info (hash-copy (call-with-input-file file read-json)))
+    (for ([(k v) (in-hash cached-info)] #:unless (cache-row? v))
+      (raise-user-error 'make-index "Invalid cache row for file ~a" k))
+    (make-immutable-hash (hash->list cached-info))]))
+
 (module+ main
-  (call-with-output-file "index.html"
-    #:exists 'replace
-    make-index-page)
-  (call-with-output-file (build-path report-json-path "index.cache")
-    #:exists 'replace
-    (curry write-json (*cache*))))
+  (command-line
+   #:args files
+   (define reports (foldl hash-union (hash) (map get-reports files)))
+   (printf "Loaded data on ~a reports.\n" (hash-count reports))
+   (call-with-output-file "index.html"
+     #:exists 'replace
+     (curry make-index-page (hash-values reports)))
+   (call-with-output-file "index.cache"
+     #:exists 'replace
+     (curry write-json reports))))

--- a/infra/publish.sh
+++ b/infra/publish.sh
@@ -27,7 +27,7 @@ index () {
           "index.html" "infra/index.css" "infra/regression-chart.js" "src/web/report.js" \
           "$RHOST:$RHOSTDIR/"
     ssh "$RHOST" chgrp uwplse "$RHOSTDIR/{index.html,index.css,report.js,regression-chart.js}"
-    rm index.html
+    rm index.cache index.html
 }
 
 reindex () {
@@ -35,14 +35,14 @@ reindex () {
     rsync --recursive --checksum --inplace --ignore-existing \
           --include 'results.json' --include 'results.json.gz' --include '*/' --exclude '*' \
           "$RHOST:$RHOSTDIR" "$DIR"
-    find "$DIR" -name "results.json.gz" -exec gunzip {} \;
+    find "$DIR" -name "results.json.gz" -exec gunzip -f {} \;
     racket infra/make-index.rkt "$DIR"
     rsync index.cache "$RHOST:$RHOSTDIR/index.cache"
     rsync --recursive \
           "index.html" "infra/index.css" "infra/regression-chart.js" "src/web/report.js" \
           "$RHOST:$RHOSTDIR/"
     ssh "$RHOST" chgrp uwplse "$RHOSTDIR/{index.html,index.css,report.js,regression-chart.js}"
-    rm index.html
+    rm index.cache index.html
 }
 
 upload_reports () {

--- a/infra/publish.sh
+++ b/infra/publish.sh
@@ -36,7 +36,7 @@ reindex () {
           --include 'results.json' --include 'results.json.gz' --include '*/' --exclude '*' \
           "$RHOST:$RHOSTDIR" "$DIR"
     find "$DIR" -name "results.json.gz" -exec gunzip {} \;
-    racket infra/make-index.rkt index.cache
+    racket infra/make-index.rkt "$DIR"
     rsync index.cache "$RHOST:$RHOSTDIR/index.cache"
     rsync --recursive \
           "index.html" "infra/index.css" "infra/regression-chart.js" "src/web/report.js" \

--- a/infra/publish.sh
+++ b/infra/publish.sh
@@ -5,7 +5,7 @@ RHOST="uwplse.org"
 RHOSTDIR="/var/www/herbie/reports"
 
 upload () {
-    DIR=$1
+    DIR="$1"
     B=$(git rev-parse --abbrev-ref HEAD)
     C=$(git rev-parse HEAD | sed 's/\(..........\).*/\1/')
     RDIR="$(date +%s):$(hostname):$B:$C"
@@ -19,7 +19,10 @@ upload () {
 }
 
 index () {
-    racket infra/make-index.rkt
+    DIR="$1"
+    rsync "$RHOST:$RHOSTDIR/index.cache" index.cache
+    racket infra/make-index.rkt index.cache "$DIR"
+    rsync index.cache "$RHOST:$RHOSTDIR/index.cache"
     rsync --recursive \
           "index.html" "infra/index.css" "infra/regression-chart.js" "src/web/report.js" \
           "$RHOST:$RHOSTDIR/"
@@ -27,26 +30,35 @@ index () {
     rm index.html
 }
 
-download_reports () {
+reindex () {
+    DIR="$1"
     rsync --recursive --checksum --inplace --ignore-existing \
           --include 'results.json' --include 'results.json.gz' --include '*/' --exclude '*' \
-          uwplse.org:/var/www/herbie/reports/ previous/
-    find previous/ -name "results.json.gz" -exec gunzip {} \;
+          "$RHOST:$RHOSTDIR" "$DIR"
+    find "$DIR" -name "results.json.gz" -exec gunzip {} \;
+    racket infra/make-index.rkt index.cache
+    rsync index.cache "$RHOST:$RHOSTDIR/index.cache"
+    rsync --recursive \
+          "index.html" "infra/index.css" "infra/regression-chart.js" "src/web/report.js" \
+          "$RHOST:$RHOSTDIR/"
+    ssh "$RHOST" chgrp uwplse "$RHOSTDIR/{index.html,index.css,report.js,regression-chart.js}"
+    rm index.html
 }
 
 upload_reports () {
-    rsync --recursive previous/ uwplse.org:/var/www/herbie/reports/
+    DIR="$1"
+    rsync --recursive "$DIR"/ "$RHOST:$RHOSTDIR"
 }
 
 help () {
     printf "USAGE: publish.sh upload <dir>\t\t\tUpload the directory <dir>\n"
-    printf "       publish.sh index\t\t\t\tRegenerate the report index\n"
+    printf "       publish.sh index <dir>\t\t\t\tAdd the directory <dir> to the index page\n"
 }
 
 CMD="$1"
+DIR="$2"
 
-if [[ $CMD = "upload" ]]; then
-    DIR="$2"
+check_dir () {
     if [[ -z $DIR ]]; then
         echo "Please pass a directory to upload"
         echo
@@ -56,14 +68,20 @@ if [[ $CMD = "upload" ]]; then
         echo "Directory $DIR does not exist"
         exit 2
     else
-        upload "$DIR"
+        return 0
     fi
+}
+
+if [[ $CMD = "upload" ]]; then
+    check_dir
+    upload "$DIR"
 elif [[ $CMD = "index" ]]; then
-    download_reports
-    index
+    index "$DIR"
+elif [[ $CMD = "update-index" ]]; then
+    reindex "$DIR"
 elif [[ $CMD = "update-reports" ]]; then
-    upload_reports
-    index
+    upload_reports "$DIR"
+    reindex "$DIR"
 else
     help
 fi


### PR DESCRIPTION
Right now, `make-index.rkt` requires the `report.json` file from all reports ever run to be present on the computer where it is run. Frankly, this is insanity—that data is being constantly sent to and from `uwplse.org`, it is bulky, it is slow. So in this new system, only cache files are sent back and forth, and the only files you need locally are the ones not currently in the cache file.

Overall, this PR makes `make-index` run quickly, require much less data storage, and in general use a sane instead of an insane architecture.