### PR TITLE
Remove "tables" entirely from syntax.rkt

### DIFF
--- a/src/common.rkt
+++ b/src/common.rkt
@@ -6,7 +6,7 @@
 
 (provide reap ->float32
          call-with-output-files
-         take-up-to flip-lists find-duplicates
+         flip-lists find-duplicates
          argmins argmaxs index-of set-disjoint?
          get-seed set-seed!
          quasisyntax dict sym-append comparator
@@ -38,14 +38,6 @@
       (real->single-flonum x)))
 
 ;; Utility list functions
-
-(define (take-up-to l k)
-  (for/list ([x l] [i (in-range k)])
-    x))
-
-(module+ test
-  (check-equal? (take-up-to '(a b c d e f) 3) '(a b c))
-  (check-equal? (take-up-to '(a b) 3) '(a b)))
 
 (define (argmins f lst)
   (let loop ([lst lst] [best-score #f] [best-elts '()])

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -11,7 +11,8 @@
          get-seed set-seed!
          quasisyntax dict sym-append comparator
          format-time format-bits web-resource
-         (all-from-out "config.rkt") (all-from-out "debug.rkt"))
+         debug ; from debug.rkt
+         (all-from-out "config.rkt"))
 
 ;; Various syntactic forms of convenience used in Herbie
 

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -223,7 +223,8 @@
   ; low-error locations
   (^lowlocs^
     (if (*pareto-mode*) ; Pareto mode uses low-error locations
-        (for/list ([(err loc) (in-dict (take-up-to (reverse locs-errs) (*localize-expressions-limit*)))])
+        (for/list ([(err loc) (in-dict (reverse locs-errs))]
+                   [_ (in-range (*localize-expressions-limit*))])
           (let ([expr (location-get loc (alt-program (^next-alt^)))])
             (timeline-push! 'locations (~a expr) (errors-score err) #t)
             (cons loc (alt `(λ ,vars ,expr) (list 'mainloop loc) (list (^next-alt^))))))

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -64,7 +64,7 @@
     (for/list ([arg args] [arg-name arg-names])
       (cons arg-name
             (if (and (list? arg) (set-member? args ':precision))
-                (get-representation (list-ref args (add1 (index-of args ':precision))))
+                (get-representation (cadr (member ':precision args)))
                 default-repr))))
 
   ;; Named fpcores need to be added to function table

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -26,7 +26,7 @@
 ;; Implementations inherit attributes
 
 (struct constant (bf ival))
-(define constants (make-hash))
+(define constants (make-hasheq))
 
 (define (register-constant! name attrib-dict)
   (hash-set! constants name (apply constant (map (curry dict-ref attrib-dict) '(bf ival)))))
@@ -61,7 +61,7 @@
 ;; Constant implementations
 
 (struct constant-impl (type bf fl ival))
-(define constant-impls (make-hash))
+(define constant-impls (make-hasheq))
 
 (define parametric-constants (hash))
 (define parametric-constants-reverse (hash))
@@ -117,7 +117,7 @@
 ;; Implementations inherit attributes
 
 (struct operator (itype otype bf ival))
-(define operators (make-hash))
+(define operators (make-hasheq))
 
 (define (register-operator! name itypes otype attrib-dict)
   (define itypes* (dict-ref attrib-dict 'itype itypes))
@@ -228,7 +228,7 @@
 ;; Operator implementations
 
 (struct operator-impl (itype otype bf fl ival))
-(define operator-impls (make-hash))
+(define operator-impls (make-hasheq))
 
 (define parametric-operators (hash))
 (define parametric-operators-reverse (hash))


### PR DESCRIPTION
This PR replaces each "table" with a simple struct definition and a hasheq table from symbols to that struct. This removes a bunch of code which frankly was kind of dumb. Negative diff PR!!!