### PR TITLE
Move patch table code to separate file

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -74,9 +74,6 @@
 
 ;; In localization, the maximum number of locations returned
 (define *localize-expressions-limit* (make-parameter 4))
-
-;; In localization, limit is for new locations
-;; (only if *use-improve-cache* is on)
 (define *localize-limit-for-new* (make-parameter #f))
 
 ;; How accurate to make the binary search

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -224,16 +224,10 @@
                [alt->done? (hash-remove* alt->done? altns)]
                [alt->cost (hash-remove* alt->cost altns)]))
 
-(define (is-nan? expr)
-  (and (hash-has-key? parametric-constants-reverse expr)
-       (equal? (hash-ref parametric-constants-reverse expr) 'NAN)))
-
 (define (atab-add-altns atab altns repr)
-  (define altns* (filter-not (compose (curryr expr-contains? is-nan?) alt-program)
-                             (remove-duplicates altns alt-equal?)))
-  (define progs (map alt-program altns*))
+  (define progs (map alt-program altns))
   (define errss (apply vector-map list (batch-errors progs (alt-table-context atab) repr)))
-  (for/fold ([atab atab]) ([altn (in-list altns*)] [errs (in-vector errss)])
+  (for/fold ([atab atab]) ([altn (in-list altns)] [errs (in-vector errss)])
     (atab-add-altn atab altn errs repr)))
 
 (define (worse-than? point->alts altn cost tied-pnts tied-errs)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -67,13 +67,11 @@
   (let loop ([expr expr] [loc '()])
     (match expr
      [(list op args ...)
-      (define below
-        (for/fold ([below '()] #:result (reverse below))
-                  ([arg (in-list args)] [i (in-naturals 1)])
-          (append (loop arg (cons i loc)) below)))
       (if (equal? expr subexpr)
-          (cons (reverse loc) below)
-          below)]
+          (list (reverse loc))
+          (for/fold ([below '()] #:result (reverse below))
+                    ([arg (in-list args)] [i (in-naturals 1)])
+            (append (loop arg (cons i loc)) below)))]
      [_
       (if (equal? expr subexpr)
           (list (reverse loc))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -66,16 +66,15 @@
 (define (get-locations expr subexpr)
   (let loop ([expr expr] [loc '()])
     (match expr
-     [(list op args ...)
-      (if (equal? expr subexpr)
-          (list (reverse loc))
-          (for/fold ([below '()] #:result (reverse below))
-                    ([arg (in-list args)] [i (in-naturals 1)])
-            (append (loop arg (cons i loc)) below)))]
-     [_
-      (if (equal? expr subexpr)
-          (list (reverse loc))
-          (list))])))
+      [(== subexpr)
+       (list (reverse loc))]
+      [(list op args ...)
+       (apply
+        append
+        (for/list ([arg (in-list args)] [i (in-naturals 1)])
+          (loop arg (cons i loc))))]
+      [_
+       (list)])))
 
 ;; Returns a list of locations and errors sorted
 ;; by error scores in descending order

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -374,7 +374,6 @@
     (timeline-push! 'alts (~a (program-body (alt-program alt)))
                     (if (set-member? ndone-alts alt) "fresh" "done")
                     (score-alt alt)))
-
   (define joined-alts
     (cond
      [(and (flag-set? 'reduce 'regimes) (> (length all-alts) 1)
@@ -400,8 +399,4 @@
               'final-simplify (list altn)))
       alt-equal?))
   (timeline-event! 'end)
-
-  (define best (argmin score-alt cleaned-alts))
-  (*herbie-preprocess* (remove-unecessary-preprocessing best (*herbie-preprocess*)))
-  (define rest (filter-not (curry alt-equal? best) cleaned-alts))
-  (cons best (sort rest > #:key alt-cost)))
+  (remove-duplicates cleaned-alts alt-equal?))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -1,12 +1,10 @@
 #lang racket
 
 (require "syntax/rules.rkt" "syntax/sugar.rkt" "syntax/types.rkt"
-         "core/alt-table.rkt" "core/localize.rkt" "core/regimes.rkt"
+         "core/alt-table.rkt" "core/localize.rkt" "core/regimes.rkt" "core/simplify.rkt"
          "alternative.rkt" "common.rkt" "conversions.rkt" "errors.rkt"
          "interface.rkt" "patch.rkt" "points.rkt" "preprocess.rkt"
-         "programs.rkt" "sampling.rkt" "timeline.rkt" "symmetry.rkt")
-
-(require "core/taylor.rkt" "core/simplify.rkt")
+         "programs.rkt" "sampling.rkt" "symmetry.rkt" "timeline.rkt")
 
 (provide (all-defined-out))
 

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -118,9 +118,6 @@
         (sow altn)]))))
 
 (define (gen-series!)
-  (when (null? (^queued^))
-    (raise-user-error 'gen-series! "No expressions queued in patch table. Run `patch-table-add!`"))
-
   (when (flag-set? 'generate 'taylor)
     (timeline-event! 'series)
     (define series-expansions
@@ -276,7 +273,9 @@
 
 (define (patch-table-add! expr vars down?)
   (when (patch-table-has-expr? expr)
-    (raise-user-error 'patch-table-add! "Attempting to add previously patched expression!"))
+    (raise-user-error 'patch-table-add!
+      "attempting to add previously patched expression: ~a"
+      expr))
   (define altn* (alt `(λ ,vars ,expr) `(patch) '()))
   (if down?
       (^queuedlow^ (cons altn* (^queuedlow^)))
@@ -291,7 +290,9 @@
 
 (define (patch-table-run)
   (debug #:from 'progress #:depth 3 "generating series expansions")
-  (gen-series!)
+  (if (null? (^queued^))
+      (^series^ '())
+      (gen-series!))
   (debug #:from 'progress #:depth 3 "generating rewritten candidates")
   (gen-rewrites!)
   (debug #:from 'progress #:depth 3 "simplifying candidates")

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -48,15 +48,14 @@
   (patchtable-final *patch-table*))
 
 ; Adds an improvement to the patch table
-; If `improve` is not provided, the patch table either
-;  (a) leaves the existing list of improvements empty
-;  (b) sets the improvements to be an empty list 
+; If `improve` is not provided, a key is added
+; with no improvements
 (define (add-patch! expr [improve #f])
   (cond
    [(not (*use-improve-cache*)) (void)]
    [improve
     (hash-update! (patchtable-table *patch-table*) expr
-                  (curry cons improve) (list improve))]
+                  (curry cons improve) (list))]
    [else
     (hash-update! (patchtable-table *patch-table*) expr
                   identity (list))]))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -1,27 +1,29 @@
 #lang racket
 
-(require "alternative.rkt" "common.rkt" "interface.rkt" "programs.rkt"
-         "core/matcher.rkt" "core/taylor.rkt" "core/simplify.rkt"
-         "timeline.rkt" "syntax/rules.rkt")
+(require "core/matcher.rkt" "core/taylor.rkt" "core/simplify.rkt"
+         "alternative.rkt" "common.rkt" "interface.rkt" "programs.rkt"
+         "timeline.rkt" "syntax/rules.rkt" "syntax/sugar.rkt")
 
 (provide
   (contract-out
    [patch-table-add! (-> alt? (listof natural?) boolean? void?)]
    [patch-table-get (-> expr? (listof expr?))]
-   [patch-table-has-expr? (-> expr? boolean?)])
-  patch-table-run!)
+   [patch-table-has-expr? (-> expr? boolean?)]
+   [patch-table-runnable? (-> boolean?)]
+   [patch-table-run (-> (listof alt?))]
+   [patch-table-run-simplify (-> (listof alt?) (listof alt?))]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Patch table ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(struct patchtable (table queued queuedlow rewrites series) #:mutable)
+(struct patchtable (table queued queuedlow rewrites series final) #:mutable)
 
 ; The "patch table"
 ; Stores a mapping from expression to improvements (expr -> (listof exprs))
-(define *patch-table* (patchtable (make-hash) '() '() '() '()))
+(define *patch-table* (patchtable (make-hash) '() '() #f #f #f))
 
 ; patch table may be invalidated between runs
 (register-reset
-  (λ () (set! *patch-table* (patchtable (make-hash) '() '() '() '()))))
+  (λ () (set! *patch-table* (patchtable (make-hash) '() '() #f #f #f))))
 
 ; setters / getters
 
@@ -40,7 +42,10 @@
 (define (^series^ [val #f])
   (when val (set-patchtable-series! *patch-table* val))
   (patchtable-series *patch-table*))
-  
+
+(define (^final^ [val #f])
+  (when val (set-patchtable-final! *patch-table* val))
+  (patchtable-final *patch-table*))
 
 ; Adds an improvement to the patch table
 ; If `improve` is not provided, the patch table either
@@ -55,8 +60,83 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Internals ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define transforms-to-try
+  (let ([invert-x (λ (x) `(/ 1 ,x))] [exp-x (λ (x) `(exp ,x))] [log-x (λ (x) `(log ,x))]
+	[ninvert-x (λ (x) `(/ 1 (neg ,x)))])
+    `((0 ,identity ,identity)
+      (inf ,invert-x ,invert-x)
+      (-inf ,ninvert-x ,ninvert-x)
+      #;(exp ,exp-x ,log-x)
+      #;(log ,log-x ,exp-x))))
+
+;; Taylor is problematic since it doesn't know what reprs are
+;; There are two types of errors that occur due to this inconsistency
+;;  - reduce:
+;;      the internal simplifier will try to desugar an subexpression
+;;      with an operator/precision mismatch
+;;  - external:
+;;      Taylor is successful in generating an expression but
+;;      external desugaring fails because of an unsupported/mismatched
+;;      operator
+(define (taylor-fail-desugaring expr)
+  (λ _
+    (debug #:from 'progress #:depth 5 "Series expansion (desugaring failure)")
+    (debug #:from 'progress #:depth 5 "Problematic expression: " expr)
+    #f))
+
+; taylor uses older format, resugaring and desugaring needed
+; not all taylor transforms are valid in a given repr, return false on failure
+(define (taylor-expr expr repr var f finv)
+  (define expr* (resugar-program expr repr #:full #f))
+  (with-handlers ([exn:fail? (const #f)])       ; in case taylor fails internally
+    (define genexpr (approximate expr* var #:transform (cons f finv)))
+    (λ (x) (desugar-program (genexpr) repr (*var-reprs*) #:full #f))))
+
+(define (taylor-alt altn)
+  (define expr (program-body (alt-program altn)))
+  (define repr (repr-of expr (*output-repr*) (*var-reprs*)))
+  (define vars (free-variables expr))
+  (reap [sow]
+    (for* ([var vars] [transform-type transforms-to-try])
+      (match-define (list name f finv) transform-type)
+      (define genexpr (taylor-expr expr repr var f finv))
+      (cond
+       [genexpr  ; taylor successful
+        #;(define pts (for/list ([(p e) (in-pcontext (*pcontext*))]) p))
+        (for ([i (in-range 4)])
+          (define expr* 
+            (with-handlers ([exn:fail? (taylor-fail-desugaring expr)]) ; failed on desugaring
+              (location-do '(2) (alt-program altn) genexpr)))
+          (when expr*
+            (sow (alt expr* (list 'taylor name '(2)) (list altn)))))]
+       [else  ; taylor failed
+        (debug #:from 'progress #:depth 5 "Series expansion (internal failure)")
+        (debug #:from 'progress #:depth 5 "Problematic expression: " expr)
+        (sow altn)]))))
+
+(define (gen-series!)
+  (when (null? (^queued^))
+    (raise-user-error 'gen-series! "No expressions queued in patch table. Run `patch-table-add!`"))
+
+  (when (flag-set? 'generate 'taylor)
+    (timeline-event! 'series)
+    (define series-expansions
+      (apply append
+        (for/list ([(location altn) (in-dict (^queued^))] [n (in-naturals 1)])
+          (debug #:from 'progress #:depth 4 "[" n "/" (length (^queued^)) "] generating series at" location)
+          (define expr (program-body (alt-program altn)))
+          (define tnow (current-inexact-milliseconds))
+          (begin0 (filter-not (curry alt-equal? altn) (taylor-alt altn))
+            (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))))
+
+    (timeline-push! 'count (length (^queued^)) (length series-expansions))
+    ; TODO: accuracy stats for timeline
+    (^series^ series-expansions))
+  (void))
+
+
 (define (gen-rewrites!)
-  (unless (^queued^)
+  (when (and (null? (^queued^)) (null? (^queuedlow^)))
     (raise-user-error 'gen-rewrites! "No expressions queued in patch table. Run `patch-table-add!`"))
 
   (timeline-event! 'rewrite)
@@ -112,10 +192,79 @@
         rewritten))
         
   (timeline-push! 'count (length (^queued^)) (length rewritten*))
+  ; TODO: accuracy stats for timeline
   (^rewrites^ rewritten*)
-  ; TODO: accuracy concerns for timeline
   (void))
 
+(define (get-starting-expr altn)
+  (match (alt-event altn)
+   [(list 'patch loc) (location-get loc (alt-program (first (alt-prevs altn))))]
+   [else (get-starting-expr (first (alt-prevs altn)))]))
+
+(define (simplify!)
+  (unless (or (^series^) (^rewrites^))
+    (raise-user-error 'simplify! "No candidates generated. Run (gen-series!) or (gen-rewrites!)"))
+
+  (when (flag-set? 'generate 'simplify)
+    (timeline-event! 'simplify)
+    (define children (append (or (^series^) empty) (or (^rewrites^) empty)))
+
+    ;; We want to avoid simplifying if possible, so we only
+    ;; simplify things produced by function calls in the rule
+    ;; pattern. This means no simplification if the rule output as
+    ;; a whole is not a function call pattern, and no simplifying
+    ;; subexpressions that don't correspond to function call
+    ;; patterns.
+    (define locs-list
+      (for/list ([child (in-list children)] [n (in-naturals 1)])
+        (match (alt-event child)
+          [(list 'taylor _ loc) (list loc)]
+          [(list 'change cng)
+           (match-define (change rule loc _) cng)
+           (define pattern (rule-output rule))
+           (cond
+            [(not (list? pattern)) '()]
+            [else
+             (for/list ([pos (in-naturals 1)]
+                        [arg-pattern (cdr pattern)] #:when (list? arg-pattern))
+               (append loc (list pos)))])]
+          [_ (list '(2))])))
+
+    (define to-simplify
+      (for/list ([child (in-list children)] [locs locs-list]
+                 #:when true [loc locs])
+        (location-get loc (alt-program child))))
+
+    (define simplification-options
+      (simplify-batch to-simplify #:rules (*simplify-rules*) #:precompute true))
+
+    (define simplify-hash
+      (make-immutable-hash (map cons to-simplify simplification-options)))
+
+    (define simplified
+      (apply append
+             (for/list ([child (in-list children)] [locs locs-list])
+              (make-simplification-combinations child locs simplify-hash))))
+
+    ; dedup for cache
+    (define simplified* (remove-duplicates simplified alt-equal?))
+    (unless (and (null? (^queued^)) (null? (^queuedlow^)))  ; don't run for simplify-only
+      (define cachable (map cdr (^queued^)))
+      (for ([altn (in-list simplified*)])
+        (let ([expr0 (get-starting-expr altn)])
+          (when (set-member? cachable expr0)
+            (add-patch! (get-starting-expr altn) altn)))))
+    
+    (timeline-push! 'count (length locs-list) (length simplified*))
+    (^final^ simplified*))
+  (void))
+
+(define (patch-table-clear!)
+  (^queued^ '())
+  (^queuedlow^ '())
+  (^rewrites^ #f)
+  (^series^ #f)
+  (^final^ #f))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Public API ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -134,11 +283,24 @@
   (void))
 
 (define (patch-table-get expr)
-  (void))
+  (hash-ref (patchtable-table *patch-table*) expr))
 
-(define (patch-table-run!)
+(define (patch-table-runnable?)
+  (or (not (null? (^queued^))) (not (null? (^queuedlow^)))))
+
+(define (patch-table-run)
   (debug #:from 'progress #:depth 3 "generating series expansions")
+  (gen-series!)
   (debug #:from 'progress #:depth 3 "generating rewritten candidates")
-  (debug #:from 'progress #:depth 3 "simplifying candidates")
   (gen-rewrites!)
-  (void))
+  (debug #:from 'progress #:depth 3 "simplifying candidates")
+  (simplify!)
+  (begin0 (^final^)
+    (patch-table-clear!)))
+
+(define (patch-table-run-simplify altns)
+  (^rewrites^ (append altns (if (^rewrites^) (^rewrites^) '())))
+  (simplify!)
+  (begin0 (^final^)
+    (patch-table-clear!)))
+          

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -1,0 +1,144 @@
+#lang racket
+
+(require "alternative.rkt" "common.rkt" "interface.rkt" "programs.rkt"
+         "core/matcher.rkt" "core/taylor.rkt" "core/simplify.rkt"
+         "timeline.rkt" "syntax/rules.rkt")
+
+(provide
+  (contract-out
+   [patch-table-add! (-> alt? (listof natural?) boolean? void?)]
+   [patch-table-get (-> expr? (listof expr?))]
+   [patch-table-has-expr? (-> expr? boolean?)])
+  patch-table-run!)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; Patch table ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(struct patchtable (table queued queuedlow rewrites series) #:mutable)
+
+; The "patch table"
+; Stores a mapping from expression to improvements (expr -> (listof exprs))
+(define *patch-table* (patchtable (make-hash) '() '() '() '()))
+
+; patch table may be invalidated between runs
+(register-reset
+  (λ () (set! *patch-table* (patchtable (make-hash) '() '() '() '()))))
+
+; setters / getters
+
+(define (^queued^ [val #f])
+  (when val (set-patchtable-queued! *patch-table* val))
+  (patchtable-queued *patch-table*))
+
+(define (^queuedlow^ [val #f])
+  (when val (set-patchtable-queuedlow! *patch-table* val))
+  (patchtable-queuedlow *patch-table*))
+
+(define (^rewrites^ [val #f])
+  (when val (set-patchtable-rewrites! *patch-table* val))
+  (patchtable-rewrites *patch-table*))
+
+(define (^series^ [val #f])
+  (when val (set-patchtable-series! *patch-table* val))
+  (patchtable-series *patch-table*))
+  
+
+; Adds an improvement to the patch table
+; If `improve` is not provided, the patch table either
+;  (a) leaves the existing list of improvements empty
+;  (b) sets the improvements to be an empty list 
+(define (add-patch! expr [improve #f])
+  (if improve
+      (hash-update! (patchtable-table *patch-table*) expr
+                    (curry cons improve) (list improve))
+      (hash-update! (patchtable-table *patch-table*) expr
+                    identity (list))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; Internals ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (gen-rewrites!)
+  (unless (^queued^)
+    (raise-user-error 'gen-rewrites! "No expressions queued in patch table. Run `patch-table-add!`"))
+
+  (timeline-event! 'rewrite)
+  (define rewrite (if (flag-set? 'generate 'rr) rewrite-expression-head rewrite-expression))
+  (timeline-push! 'method (~a (object-name rewrite)))
+
+  (define changelists
+    (for/list ([(location altn) (in-dict (^queued^))] [n (in-naturals 1)])
+      (debug #:from 'progress #:depth 4 "[" n "/" (length (^queued^)) "] rewriting at" location)
+      (define expr (program-body (alt-program altn)))
+      (define tnow (current-inexact-milliseconds))
+      (begin0 (rewrite expr (*output-repr*) #:rules (*rules*) #:root '(2))
+        (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow)))))
+
+  (define reprchange-rules
+    (if (*pareto-mode*)
+        (filter (λ (r) (expr-contains? (rule-output r) rewrite-repr-op?)) (*rules*))
+        (list)))
+
+  ; Empty in normal mode
+  (define changelists-low-locs
+    (for/list ([(location altn) (in-dict (^queuedlow^))] [n (in-naturals 1)])
+      (debug #:from 'progress #:depth 4 "[" n "/" (length (^queuedlow^)) "] rewriting at" location)
+      (define expr (program-body (alt-program altn)))
+      (define tnow (current-inexact-milliseconds))
+      (begin0 (rewrite expr (*output-repr*) #:rules reprchange-rules #:root '(2))
+        (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow)))))
+
+  (define comb-changelists (append changelists changelists-low-locs))
+  (define altns (map cdr (append (^queued^) (^queuedlow^))))
+
+  (define rules-used
+    (append-map (curry map change-rule) (apply append comb-changelists)))
+  (define rule-counts
+    (for ([rgroup (group-by identity rules-used)])
+      (timeline-push! 'rules (~a (rule-name (first rgroup))) (length rgroup))))
+
+  (define (repr-change altn)
+    (alt (apply-repr-change (alt-program altn)) (alt-event altn) (alt-prevs altn)))
+
+  (define rewritten
+    (filter (compose program-body alt-program)  ; false body means failure
+      (for/list ([cls comb-changelists] [altn altns]
+                #:when true [cl cls])
+        (for/fold ([altn altn] #:result (repr-change altn)) ([cng cl])
+            (alt (change-apply cng (alt-program altn))
+                 (list 'change cng)
+                 (list altn))))))
+
+  (define rewritten*
+    (if (and (*pareto-mode*) (> (length rewritten) 1000))
+        (take rewritten 1000)
+        rewritten))
+        
+  (timeline-push! 'count (length (^queued^)) (length rewritten*))
+  (^rewrites^ rewritten*)
+  ; TODO: accuracy concerns for timeline
+  (void))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; Public API ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (patch-table-has-expr? expr)
+  (hash-has-key? (patchtable-table *patch-table*) expr))
+
+(define (patch-table-add! altn loc down?)
+  (define expr (location-get loc (alt-program altn)))
+  (when (patch-table-has-expr? expr)
+    (raise-user-error 'patch-table-add! "Attempting to add previously patched expression!"))
+  (define vars (program-variables (alt-program altn)))
+  (define altn* (alt `(λ ,vars ,expr) (list 'patch loc) (list altn)))
+  (if down?
+      (^queuedlow^ (cons (cons loc altn*) (^queuedlow^)))
+      (^queued^ (cons (cons loc altn*) (^queued^))))
+  (void))
+
+(define (patch-table-get expr)
+  (void))
+
+(define (patch-table-run!)
+  (debug #:from 'progress #:depth 3 "generating series expansions")
+  (debug #:from 'progress #:depth 3 "generating rewritten candidates")
+  (debug #:from 'progress #:depth 3 "simplifying candidates")
+  (gen-rewrites!)
+  (void))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -128,9 +128,18 @@
           (begin0 (filter-not (curry alt-equal? altn) (taylor-alt altn))
             (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))))
 
+    (define (is-nan? expr)
+      (and (hash-has-key? parametric-constants-reverse expr)
+          (equal? (hash-ref parametric-constants-reverse expr) 'NAN)))
+
+    ; maybe necessary for CI to pass (this changes often)
+    (define series-expansions*
+      (filter-not (λ (x) (expr-contains? (program-body (alt-program x)) is-nan?))
+                  series-expansions))
+
     ; TODO: accuracy stats for timeline
-    (timeline-push! 'count (length (^queued^)) (length series-expansions))
-    (^series^ series-expansions))
+    (timeline-push! 'count (length (^queued^)) (length series-expansions*))
+    (^series^ series-expansions*))
   (void))
 
 

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -88,14 +88,14 @@
         (define oracle-errs (oracle-error fns newcontext output-repr))
 
         ; find the best, sort the rest by cost
-        (define-values (best rest end-score)
+        (define-values (best end-score rest)
           (for/fold ([best #f] [score #f] [rest #f])
                     ([altn (in-list unsorted-alts)] [errs (in-list end-errss)])
             (let ([new-score (errors-score errs)])
               (cond
-               [(not best) (values altn '() new-score)]
-               [(< new-score score) (values altn (cons best rest) new-score)] ; kick out current best
-               [else (values best (cons altn rest) score)]))))
+               [(not best) (values altn new-score '())]
+               [(< new-score score) (values altn new-score (cons best rest))] ; kick out current best
+               [else (values best score (cons altn rest))]))))
         (*herbie-preprocess* (remove-unecessary-preprocessing best (*herbie-preprocess*)))
         (define alts (cons best (sort rest > #:key alt-cost)))
 


### PR DESCRIPTION
This PR moves all patch table code to a separate file and provides an API for the mainloop to enqueue expressions, run improvements, and extract patches.