### PR TITLE
Make constants zero-ary operators

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: make install
-      - run: raco test src/ infra/
+      - run: raco test src/ infra/ egg-herbie/
 
   hamming:
     name: "Integration tests (Hamming)"

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -189,7 +189,7 @@
           (cons '(- z (+ (+ y 2) x)) "(- real h2 (+ real (+ real h0 2) h1))")
           (cons '(*.f64 x y) "(* f64 h1 h0)")
           (cons '(+.f32 (*.f32 x y) 2) "(+ f32 (* f32 h1 h0) 2)")
-          (cons '(cos.f64 PI.f64) "(cos f64 (PI f64))")
+          (cons '(cos.f64 (PI.f64)) "(cos f64 (PI f64))")
           (cons '(if TRUE x y) "(if real (TRUE real) h1 h0)")))
 
   (define nil

--- a/egg-herbie/to-egg-pattern.rkt
+++ b/egg-herbie/to-egg-pattern.rkt
@@ -50,5 +50,5 @@
 (module+ test
   (check-equal? (to-egg-pattern `(+ a b)) "(+ real ?a ?b)")
   (check-equal? (to-egg-pattern `(/ c (- 2 a))) "(/ real ?c (- real 2 ?a))")
-  (check-equal? (to-egg-pattern `(cos.f64 PI.f64)) "(cos f64 (PI f64))")
+  (check-equal? (to-egg-pattern `(cos.f64 (PI.f64))) "(cos f64 (PI f64))")
   (check-equal? (to-egg-pattern `(if TRUE x y)) "(if real (TRUE real) ?x ?y)"))

--- a/src/alternative.rkt
+++ b/src/alternative.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "programs.rkt")
+(require "cost.rkt")
 (provide (struct-out change) (struct-out alt) make-alt alt?
          alt-program alt-add-event *start-prog* *all-alts*
          alt-cost alt-equal?)

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -225,8 +225,8 @@
                [alt->cost (hash-remove* alt->cost altns)]))
 
 (define (is-nan? expr)
-  (and (hash-has-key? parametric-constants-reverse expr)
-       (equal? (hash-ref parametric-constants-reverse expr) 'NAN)))
+  (and (hash-has-key? parametric-operators-reverse expr)
+       (equal? (hash-ref parametric-operators-reverse expr) 'NAN)))
 
 (define (atab-add-altns atab altns repr)
   (define altns* (filter-not (compose (curryr expr-contains? is-nan?) alt-program)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -29,6 +29,12 @@
 				       (apply (eval-prog `(λ ,(map car vars) ,c) 'bf repr) p))])
                      (cons (for/list ([c exact-cond] [t exact-ift] [f exact-iff]) (if c t f))
                            (repeat 1)))]
+                  [`(,f)
+                   (define repr (get-representation (operator-info f 'otype)))
+                   (define <-bf (representation-bf->repr repr))
+                   (define exact ((operator-info f 'bf)))
+                   (define approx ((operator-info f 'fl)))
+                   (cons (repeat exact) (repeat (ulp-difference (<-bf exact) approx repr)))]
                   [`(,f ,args ...)
                    (define repr (get-representation (operator-info f 'otype)))
                    (define argreprs

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -5,12 +5,17 @@
 
 (provide localize-error)
 
+(define *analyze-cache* (make-hash))
+(define *analyze-context* (make-parameter #f))
+
+(register-reset
+ (λ ()
+  (*analyze-context* (*pcontext*))
+  (set! *analyze-cache* (make-hash))))
+
 (define (repeat c)
   (for/list ([(p e) (in-pcontext (*pcontext*))])
     c))
-
-(define *analyze-cache* (make-hash))
-(define *analyze-context* (make-parameter #f))
 
 (define (localize-on-expression expr vars cache repr)
   (hash-ref! cache expr
@@ -59,11 +64,6 @@
                    (define approx (map (curry apply (operator-info f 'fl)) argapprox))
                    (cons exact (map (λ (ex ap) (ulp-difference (<-bf ex) ap repr))
                                     exact approx))]))))
-
-(register-reset
- (λ ()
-  (*analyze-context* (*pcontext*))
-  (set! *analyze-cache* (make-hash))))
 
 ;; Returns a list of locations and errors sorted
 ;; by error scores in descending order

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -18,9 +18,6 @@
                 (match expr
                   [(? number?)
                    (cons (repeat (bf expr)) (repeat 1))]
-                  [(? constant?)
-                   (define val ((constant-info expr 'bf)))
-                   (cons (repeat val) (repeat 1))]
                   [(? variable?)
                    (cons (map (curryr representation-repr->bf (dict-ref (*var-reprs*) expr))
                               (dict-ref vars expr))
@@ -80,7 +77,6 @@
         (define err (cdr (hash-ref cache expr)))
         (match expr                               ; descend first
           [(? number?) (void)]
-          [(? constant?) (void)]
           [(? variable?) (void)]
           [(list 'if cond ift iff)
            (loop ift (cons 2 loc))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -83,11 +83,11 @@
           [(? constant?) (void)]
           [(? variable?) (void)]
           [(list 'if cond ift iff)
-          (loop ift (cons 2 loc))
-          (loop iff (cons 3 loc))]
+           (loop ift (cons 2 loc))
+           (loop iff (cons 3 loc))]
           [(list op args ...)
-          (for ([idx (in-naturals 1)] [arg args])
-            (loop arg (cons idx loc)))])
+           (for ([idx (in-naturals 1)] [arg args])
+             (loop arg (cons idx loc)))])
         (unless (andmap (curry = 1) err)     ; then add to locations
           (sow (cons err (reverse loc))))))
     > #:key (compose errors-score car)))

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -32,8 +32,6 @@
   (match pattern
    [(? number?)
     (and (equal? pattern expr) '())]
-   [(? constant?)
-    (and (equal? pattern expr) '())]
    [(? variable?)
     (list (cons pattern expr))]
    [(list phead _ ...)
@@ -48,7 +46,6 @@
   ; pattern binding -> expr
   (match pattern
    [(? number?) pattern]
-   [(? constant?) pattern]
    [(? variable?)
     (dict-ref bindings pattern)]
    [(list phead pargs ...)
@@ -117,9 +114,6 @@
         [(? variable?)
          (sow (cons '() (list (cons pattern expr))))]
         [(? number?)
-         (when (equal? expr pattern)
-           (sow (cons '() '())))]
-        [(? constant?)
          (when (equal? expr pattern)
            (sow (cons '() '())))]
         [(list phead _ ...)

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -6,7 +6,7 @@
 (provide
  pattern-match pattern-substitute
  rewrite-expression-head rewrite-expression
- change-apply)
+ change-apply rule-apply)
 
 ;;; Our own pattern matcher.
 ;;

--- a/src/core/matcher.rkt
+++ b/src/core/matcher.rkt
@@ -6,7 +6,7 @@
 (provide
  pattern-match pattern-substitute
  rewrite-expression-head rewrite-expression
- change-apply rule-rewrite)
+ change-apply)
 
 ;;; Our own pattern matcher.
 ;;
@@ -61,13 +61,6 @@
     (if bindings
         (cons (pattern-substitute (rule-output rule) bindings) bindings)
         #f)))
-
-(define (rule-rewrite rule prog [loc '()])
-  (let/ec return
-    (location-do loc prog
-                 (λ (x) (match (rule-apply rule x)
-                          [(cons out bindings) out]
-                          [#f (return #f)])))))
 
 (define (change-apply cng prog)
   (match-define (change rule location bindings) cng)

--- a/src/core/periodicity.rkt
+++ b/src/core/periodicity.rkt
@@ -92,8 +92,8 @@
        `(λ ,vars ,(loop body (cons 2 loc)))]
       [(? real? x)
        (annotation x (reverse loc) 'constant x)]
-      [(? constant? c)
-       (define val ((constant-info c 'fl)))
+      [(list c)
+       (define val ((operator-info c 'fl)))
        (annotation val (reverse loc) 'constant val)]
       [(? variable? x)
        (annotation x (reverse loc) 'linear `((,x . 1)))]

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -20,7 +20,6 @@
   (define expr ((get-evaluator) expr*))
   (match expr
     [(? number?) expr]
-    [(? constant?) expr]
     [(? variable?) expr]
     [`(λ ,vars ,body)
      `(λ ,vars ,(simplify body))]
@@ -40,7 +39,6 @@
 (define (simplify-node expr)
   (match expr
     [(? number?) expr]
-    [(? constant?) expr]
     [(? variable?) expr]
     [(or `(+ ,_ ...) `(- ,_ ...) `(neg ,_))
      (make-addition-node (combine-aterms (gather-additive-terms expr)))]
@@ -67,7 +65,6 @@
   (let ([label (or label expr)])
     (match expr
       [(? number?) `((,expr 1))]
-      [(? constant?) `((1 ,expr))]
       [(? variable?) `((1 ,expr))]
       [`(+ ,args ...) (append-map recurse args)]
       [`(neg ,arg) (map negate-term (recurse arg))]

--- a/src/core/reduce.rkt
+++ b/src/core/reduce.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "../common.rkt" "../programs.rkt" "matcher.rkt" "../interface.rkt"
-         "../function-definitions.rkt" "../syntax/rules.rkt" "../syntax/syntax.rkt"
+         "../syntax/rules.rkt" "../syntax/syntax.rkt"
          "../syntax/sugar.rkt" "../syntax/types.rkt")
 
 (provide simplify)
@@ -16,11 +16,10 @@
       (λ (r) (resugar-program (rule-input r) (get-representation (rule-otype r)) #:full #f))
       (filter (λ (r) (variable? (rule-output r))) (*rules*)))))
 
-(define (simplify expr*)
-  (define expr ((get-evaluator) expr*))
+(define (simplify expr)
   (match expr
     [(? number?) expr]
-    [(? variable?) expr]
+    [(? symbol?) expr]
     [`(λ ,vars ,body)
      `(λ ,vars ,(simplify body))]
     [`(lambda ,vars ,body)

--- a/src/core/simplify.rkt
+++ b/src/core/simplify.rkt
@@ -219,7 +219,7 @@
           [(-.f64 (*.f64 (sqrt.f64 (+.f64 x 1)) (sqrt.f64 (+.f64 x 1)))
               (*.f64 (sqrt.f64 x) (sqrt.f64 x))) . 1]
           [(+.f64 1/5 3/10) . 1/2]
-          [(cos.f64 PI.f64) . -1]
+          [(cos.f64 (PI.f64)) . -1]
           ;; this test is problematic and runs out of nodes currently
           ;[(/ 1 (- (/ (+ 1 (sqrt 5)) 2) (/ (- 1 (sqrt 5)) 2))) . (/ 1 (sqrt 5))]
           ))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -106,9 +106,9 @@
      (taylor-exact 0 1)]
     [(? number?)
      (taylor-exact expr)]
-    [(? constant?)
-     (taylor-exact expr)]
     [(? variable?)
+     (taylor-exact expr)]
+    [`(,const)
      (taylor-exact expr)]
     [`(+ ,args ...)
      (apply taylor-add (map (curry taylor var) args))]

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -7,6 +7,7 @@
 (provide approximate)
 
 (define (approximate expr var #:transform [tform (cons identity identity)] #:iters [iters 5])
+  (load-rule-hacks)
   (define expr* (simplify (replace-expression expr var ((car tform) var))))
   (match-define (cons offset coeffs) (taylor var expr*))
 

--- a/src/cost.rkt
+++ b/src/cost.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "interface.rkt" "syntax/syntax.rkt" "syntax/sugar.rkt")
-(provide expr-cost)
+(provide program-cost expr-cost)
 
 (define (operator-cost op bits)
   (* bits
@@ -39,3 +39,7 @@
       (apply + (operator-cost op (representation-total-bits repr))
                (map loop args ireprs))]
      [_ (representation-total-bits repr)])))
+
+(define (program-cost prog)
+  (match-define (list (or 'lambda 'λ 'FPCore) (list vars ...) body) prog)
+  (expr-cost body))

--- a/src/function-definitions.rkt
+++ b/src/function-definitions.rkt
@@ -14,8 +14,8 @@
 (define (all-ops expr good?)
   (match expr
     [(? number?) #t]
-    [(? constant?) #t]
     [(? variable?) #t]
+    [(list f) #t]
     [(list f args ...)
      (and (good? f) (andmap (curryr all-ops good?) args))]))
 

--- a/src/function-definitions.rkt
+++ b/src/function-definitions.rkt
@@ -62,6 +62,11 @@
       (let ([expr* (simplify expr)])
         (if expr* (loop expr*) expr)))))
 
+(define (rule-rewrite rule prog)
+  (match (rule-apply rule prog)
+    [(cons out bindings) out]
+    [#f #f]))
+
 (define (make-evaluator)
   (define evaluation-rules
     (for/hash ([rule (*rules*)] #:when (evaluation-rule? rule))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -303,7 +303,7 @@
             (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))))
 
     (define (is-nan? x)
-      (and (constant? x) (equal? (hash-ref parametric-constants-reverse x) 'NAN)))
+      (and (operator? x) (equal? (hash-ref parametric-operators-reverse x) 'NAN)))
 
     ; Probably unnecessary, at least CI passes!
     (define series-expansions*

--- a/src/plugin.rkt
+++ b/src/plugin.rkt
@@ -3,7 +3,7 @@
 (require (submod "syntax/types.rkt" internals) (submod "interface.rkt" internals)
          (submod "syntax/rules.rkt" internals) (submod "syntax/syntax.rkt" internals)
          "errors.rkt")
-(provide define-type define-representation define-constant-impl define-operator-impl
-         define-constant define-operator define-ruleset define-ruleset*
-         register-ruleset! register-constant-impl! register-operator-impl! register-representation! 
-         register-generator! register-constant! register-operator! warn)
+(provide define-type define-representation define-operator-impl
+         define-operator define-ruleset define-ruleset*
+         register-ruleset! register-operator-impl! register-representation! 
+         register-generator! register-operator! warn)

--- a/src/points.rkt
+++ b/src/points.rkt
@@ -239,17 +239,6 @@
     (values pt processed ex)))
 
 
-(define (extract-sampled-points allvars precondition)
-  (match precondition
-    [`(or (and (== ,(? variable? varss) ,(? constant? valss)) ...) ...)
-     (define pts
-       (for/list ([vars varss] [vals valss])
-         (if (set=? vars allvars)
-             (map (curry dict-ref (map cons vars vals)) allvars)
-             #f)))
-     (and (andmap identity pts) pts)]
-    [_ #f]))
-
 ;; This is the obsolete version for the "halfpoint" method
 ;; TODO: It currently ignores preprocessing, just using the unprocessed version of the point
 (define (prepare-points-halfpoints prog precondition repr sampler preprocess-structs)

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -2,13 +2,12 @@
 
 (require math/bigfloat rival)
 (require "syntax/types.rkt" "syntax/syntax.rkt" "float.rkt" "interface.rkt"
-         "timeline.rkt" "cost.rkt")
+         "timeline.rkt")
 (module+ test (require rackunit "load-plugin.rkt"))
 
 (provide (all-from-out "syntax/syntax.rkt")
          program-body program-variables
          expr? expr-supports? expr-contains?
-         program-cost
          type-of repr-of
          location-do location-get
          batch-eval-progs eval-prog eval-application
@@ -28,10 +27,6 @@
   (-> expr? (listof symbol?))
   (match-define (list (or 'lambda 'λ 'FPCore) (list vars ...) body) prog)
   vars)
-
-(define (program-cost prog)
-  (match-define (list (or 'lambda 'λ 'FPCore) (list vars ...) body) prog)
-  (expr-cost body))
 
 ;; Returns type name
 ;; Fast version does not recurse into functions applications

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -114,15 +114,12 @@
   (define f (batch-eval-progs (list prog) mode repr))
   (λ args (vector-ref (apply f args) 0)))
 
-(define (real->bf x repr)
-  ((type-exact->inexact (representation-type repr)) x))
-
 (define (batch-eval-progs progs mode repr)
   (define real->precision
     (match mode
      ['fl (λ (x repr) (real->repr x repr))]
-     ['bf (λ (x repr) (real->bf x repr))]
-     ['ival (λ (x repr) (mk-ival (real->bf x repr)))]))
+     ['bf (λ (x repr) (bf x))]
+     ['ival (λ (x repr) (mk-ival (bf x)))]))
 
   (define arg->precision
     (match mode

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -292,7 +292,6 @@
     '(/ 1 cos))
    '(/ (cos (* 2 x)) (* (pow (/ 1 cos) 2) (* (fabs (* sin x)) (fabs (* sin x)))))))
 
-
 ; Updates the repr of an expression if needed
 (define (apply-repr-change-expr expr)
   (let loop ([expr expr] [prec #f])
@@ -379,7 +378,7 @@
                 (let ([conv (get-repr-conv (constant-info expr 'type) prec*)])
                   (and conv (list conv expr))))))] ; if constant does not exist in repr, add conversion
      [_ expr])))
-      
+
 (define (apply-repr-change prog)
   (match prog
    [(list 'FPCore (list vars ...) body) `(FPCore ,vars ,(apply-repr-change-expr body))]

--- a/src/reprs/binary32.rkt
+++ b/src/reprs/binary32.rkt
@@ -127,16 +127,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-constant-impl (PI PI.f32) binary32
+(define-operator-impl (PI PI.f32) binary32
   [fl (const (->float32 pi))])
 
-(define-constant-impl (E E.f32) binary32
+(define-operator-impl (E E.f32) binary32
   [fl (const (->float32 (exp 1.0)))])
 
-(define-constant-impl (INFINITY INFINITY.f32) binary32
+(define-operator-impl (INFINITY INFINITY.f32) binary32
   [fl (const (->float32 +inf.0))])
 
-(define-constant-impl (NAN NAN.f32) binary32
+(define-operator-impl (NAN NAN.f32) binary32
   [fl (const (->float32 +nan.0))])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/reprs/binary32.rkt
+++ b/src/reprs/binary32.rkt
@@ -244,28 +244,22 @@
 
 (define-libm-operator (fma real real real))
 
-(define-operator-impl (== ==.f32 binary32 binary32) bool
-  [itype 'binary32] [otype 'bool] ; Override number of arguments
+(define-operator-impl (== ==.f32 . binary32) bool
   [fl (comparator =)])
 
-(define-operator-impl (!= !=.f32 binary32 binary32) bool
-  [itype 'binary32] [otype 'bool] ; Override number of arguments
+(define-operator-impl (!= !=.f32 . binary32) bool
   [fl (negate (comparator =))])
 
-(define-operator-impl (< <.f32 binary32 binary32) bool
-  [itype 'binary32] [otype 'bool] ; Override number of arguments
+(define-operator-impl (< <.f32 . binary32) bool
   [fl (comparator <)])
 
-(define-operator-impl (> >.f32 binary32 binary32) bool
-  [itype 'binary32] [otype 'bool] ; Override number of arguments
+(define-operator-impl (> >.f32 . binary32) bool
   [fl (comparator >)])
 
-(define-operator-impl (<= <=.f32 binary32 binary32) bool
-  [itype 'binary32] [otype 'bool] ; Override number of arguments
+(define-operator-impl (<= <=.f32 . binary32) bool
   [fl (comparator <=)])
 
-(define-operator-impl (>= >=.f32 binary32 binary32) bool
-  [itype 'binary32] [otype 'bool] ; Override number of arguments
+(define-operator-impl (>= >=.f32 . binary32) bool
   [fl (comparator >=)])
 
 (define-operator-impl (cast binary64->binary32 binary64) binary32

--- a/src/reprs/binary64.rkt
+++ b/src/reprs/binary64.rkt
@@ -132,26 +132,20 @@
 
 (define-libm-operator (fma real real real))
 
-(define-operator-impl (== ==.f64 binary64 binary64) bool
-  [itype 'binary64] [otype 'bool] ; Override number of arguments
+(define-operator-impl (== ==.f64 . binary64) bool
   [fl (comparator =)])
 
-(define-operator-impl (!= !=.f64 binary64 binary64) bool
-  [itype 'binary64] [otype 'bool] ; Override number of arguments
+(define-operator-impl (!= !=.f64 . binary64) bool
   [fl (negate (comparator =))])
 
-(define-operator-impl (< <.f64 binary64 binary64) bool
-  [itype 'binary64] [otype 'bool] ; Override number of arguments
+(define-operator-impl (< <.f64 . binary64) bool
   [fl (comparator <)])
 
-(define-operator-impl (> >.f64 binary64 binary64) bool
-  [itype 'binary64] [otype 'bool] ; Override number of arguments
+(define-operator-impl (> >.f64 . binary64) bool
   [fl (comparator >)])
 
-(define-operator-impl (<= <=.f64 binary64 binary64) bool
-  [itype 'binary64] [otype 'bool] ; Override number of arguments
+(define-operator-impl (<= <=.f64 . binary64) bool
   [fl (comparator <=)])
 
-(define-operator-impl (>= >=.f64 binary64 binary64) bool
-  [itype 'binary64] [otype 'bool] ; Override number of arguments
+(define-operator-impl (>= >=.f64 . binary64) bool
   [fl (comparator >=)])

--- a/src/reprs/binary64.rkt
+++ b/src/reprs/binary64.rkt
@@ -29,16 +29,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-constant-impl (PI PI.f64) binary64
+(define-operator-impl (PI PI.f64) binary64
   [fl (const pi)])
 
-(define-constant-impl (E E.f64) binary64
+(define-operator-impl (E E.f64) binary64
   [fl (const (exp 1.0))])
 
-(define-constant-impl (INFINITY INFINITY.f64) binary64
+(define-operator-impl (INFINITY INFINITY.f64) binary64
   [fl (const +inf.0)])
 
-(define-constant-impl (NAN NAN.f64) binary64
+(define-operator-impl (NAN NAN.f64) binary64
   [fl (const +nan.0)])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/reprs/bool.rkt
+++ b/src/reprs/bool.rkt
@@ -40,18 +40,18 @@
 
 (define-ruleset bool-reduce (bools simplify fp-safe)
   #:type ([a bool] [b bool])
-  [not-true     (not TRUE)       FALSE]
-  [not-false    (not FALSE)      TRUE]
+  [not-true     (not (TRUE))     (FALSE)]
+  [not-false    (not (FALSE))    (TRUE)]
   [not-not      (not (not a))    a]
   [not-and      (not (and a b))  (or  (not a) (not b))]
   [not-or       (not (or  a b))  (and (not a) (not b))]
-  [and-true-l   (and TRUE a)     a]
-  [and-true-r   (and a TRUE)     a]
-  [and-false-l  (and FALSE a)    FALSE]
-  [and-false-r  (and a FALSE)    FALSE]
+  [and-true-l   (and (TRUE) a)   a]
+  [and-true-r   (and a (TRUE))   a]
+  [and-false-l  (and (FALSE) a)  (FALSE)]
+  [and-false-r  (and a (FALSE))  (FALSE)]
   [and-same     (and a a)        a]
-  [or-true-l    (or TRUE a)      TRUE]
-  [or-true-r    (or a TRUE)      TRUE]
-  [or-false-l   (or FALSE a)     a]
+  [or-true-l    (or (TRUE) a)    (TRUE)]
+  [or-true-r    (or a (TRUE))      (TRUE)]
+  [or-false-l   (or (FALSE) a)   a]
   [or-false-r   (or a FALSE)     a]
   [or-same      (or a a)         a])

--- a/src/reprs/bool.rkt
+++ b/src/reprs/bool.rkt
@@ -30,12 +30,10 @@
 (define-operator-impl (not not bool) bool
   [fl not])
 
-(define-operator-impl (and and bool bool) bool
-  [itype 'bool] [otype 'bool] ; Override number of arguments
+(define-operator-impl (and and . bool) bool
   [fl and-fn])
 
-(define-operator-impl (or or bool bool) bool
-  [itype 'bool] [otype 'bool] ; Override number of arguments
+(define-operator-impl (or or . bool) bool
   [fl or-fn])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; rules ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/reprs/bool.rkt
+++ b/src/reprs/bool.rkt
@@ -16,10 +16,10 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-constant-impl (TRUE TRUE) bool
+(define-operator-impl (TRUE TRUE) bool
   [fl (const true)])
 
-(define-constant-impl (FALSE FALSE) bool
+(define-operator-impl (FALSE FALSE) bool
   [fl (const false)])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/reprs/bool.rkt
+++ b/src/reprs/bool.rkt
@@ -51,7 +51,7 @@
   [and-false-r  (and a (FALSE))  (FALSE)]
   [and-same     (and a a)        a]
   [or-true-l    (or (TRUE) a)    (TRUE)]
-  [or-true-r    (or a (TRUE))      (TRUE)]
+  [or-true-r    (or a (TRUE))    (TRUE)]
   [or-false-l   (or (FALSE) a)   a]
-  [or-false-r   (or a FALSE)     a]
+  [or-false-r   (or a (FALSE))   a]
   [or-same      (or a a)         a])

--- a/src/reprs/fallback.rkt
+++ b/src/reprs/fallback.rkt
@@ -136,26 +136,20 @@
 (define-fallback-operator (fma real real real)
  [fl (from-bigfloat bffma)])
 
-(define-operator-impl (== ==.rkt racket racket) bool
-  [itype 'racket] [otype 'bool] ; Override number of arguments
+(define-operator-impl (== ==.rkt . racket) bool
   [fl (comparator =)])
 
-(define-operator-impl (!= !=.rkt racket racket) bool
-  [itype 'racket] [otype 'bool] ; Override number of arguments
+(define-operator-impl (!= !=.rkt . racket) bool
   [fl (negate (comparator =))])
 
-(define-operator-impl (< <.rkt racket racket) bool
-  [itype 'racket] [otype 'bool] ; Override number of arguments
+(define-operator-impl (< <.rkt . racket) bool
   [fl (comparator <)])
 
-(define-operator-impl (> >.rkt racket racket) bool
-  [itype 'racket] [otype 'bool] ; Override number of arguments
+(define-operator-impl (> >.rkt . racket) bool
   [fl (comparator >)])
 
-(define-operator-impl (<= <=.rkt racket racket) bool
-  [itype 'racket] [otype 'bool] ; Override number of arguments
+(define-operator-impl (<= <=.rkt . racket) bool
   [fl (comparator <=)])
 
-(define-operator-impl (>= >=.rkt racket racket) bool
-  [itype 'racket] [otype 'bool] ; Override number of arguments
+(define-operator-impl (>= >=.rkt . racket) bool
   [fl (comparator >=)])

--- a/src/reprs/fallback.rkt
+++ b/src/reprs/fallback.rkt
@@ -29,16 +29,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-constant-impl (PI PI.rkt) racket
+(define-operator-impl (PI PI.rkt) racket
   [fl (const pi)])
 
-(define-constant-impl (E E.rkt) racket
+(define-operator-impl (E E.rkt) racket
   [fl (const (exp 1.0))])
 
-(define-constant-impl (INFINITY INFINITY.rkt) racket
+(define-operator-impl (INFINITY INFINITY.rkt) racket
   [fl (const +inf.0)])
 
-(define-constant-impl (NAN NAN.rkt) racket
+(define-operator-impl (NAN NAN.rkt) racket
   [fl (const +nan.0)])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; operators ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/sandbox.rkt
+++ b/src/sandbox.rkt
@@ -4,7 +4,7 @@
          "mainloop.rkt" "alternative.rkt" "timeline.rkt" (submod "timeline.rkt" debug)
          "interface.rkt" "datafile.rkt" "syntax/read.rkt" "syntax/rules.rkt" "profile.rkt"
          (submod "syntax/rules.rkt" internals) "syntax/syntax.rkt" "conversions.rkt"
-         "syntax/sugar.rkt" "preprocess.rkt")
+         "syntax/sugar.rkt" "preprocess.rkt" "cost.rkt")
 
 (provide get-test-result *reeval-pts* *timeout*
          (struct-out test-result) (struct-out test-success)

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -115,7 +115,7 @@
           (string-join (map ~a unused) ", "))))
 
 (define (check-weird-variables vars)
-  (for* ([var vars] [const (in-hash-keys parametric-constants)])
+  (for* ([var vars] [const (all-constants)])
     (when (string-ci=? (symbol->string var) (symbol->string const))
       (warn 'strange-variable
             "unusual variable ~a; did you mean ~a?" var const))))

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -131,7 +131,8 @@
       [(list? body*) `(cast (! :precision ,iprec ,body*))]
       [else body*])] ; constants and variables should not have casts and precision changes
     [(list op)
-     (hash-ref parametric-operators-reverse op op)]
+     (define op* (hash-ref parametric-operators-reverse op op))
+     (if full? op* (list op*))]
     [(list op args ...)
      (define op* (hash-ref parametric-operators-reverse op op))
      (define atypes

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -1,14 +1,8 @@
 #lang racket
 
 (require "types.rkt" "syntax.rkt" "../interface.rkt")
-(provide desugar-program resugar-program register-function! *functions*)
+(provide desugar-program resugar-program)
 (module+ test (require rackunit))
-
-;; name -> (vars repr body)
-(define *functions* (make-parameter (make-hasheq)))
-
-(define (register-function! name args repr body)
-  (hash-set! (*functions*) name (list args repr body)))
 
 ;; preprocessing
 (define (expand expr)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -79,7 +79,7 @@
          (define-values (re* re-type) (loop re 'binary64))
          (define-values (im* im-type) (loop im 'binary64))
          (values (list 'complex re* im*) 'complex)]
-        [(list x) ; constant
+        [(or (? constant-operator? x) (list x)) ; constant
          (let/ec k
            (for/list ([sig (hash-ref parametric-operators x)])
              (match-define (list* name rtype atypes) sig)

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require syntax/id-set)
-(require "../common.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt" "sugar.rkt")
+(require "../common.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt")
 (provide assert-program!)
 (module+ test (require rackunit "../load-plugin.rkt"))
 

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -8,7 +8,7 @@
 (define (check-expression* stx vars error!)
   (match stx
     [#`,(? number?) (void)]
-    [#`,(? constant?) (void)]
+    [#`,(? constant-operator?) (void)]
     [#`,(? variable? var)
      (unless (set-member? vars stx)
        (error! stx "Unknown variable ~a" var))]

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -127,9 +127,14 @@
 
   (hash-set! operators name (apply operator (map (curry hash-ref fields) '(itype otype bf ival)))))
 
-(define-syntax-rule (define-operator (name itypes ...) otype [key value] ...)
-  (register-operator! 'name '(itypes ...) 'otype
-                      (list (cons 'key value) ...)))
+(define-syntax define-operator
+  (syntax-rules ()
+    [(define-operator (name itypes ...) otype [key value] ...)
+     (register-operator! 'name '(itypes ...) 'otype
+                         (list (cons 'key value) ...))]
+    [(define-operator (name . itype) otype [key value] ...)
+     (register-operator! 'name 'itype 'otype
+                         (list (cons 'key value) ...))]))
 
 (define-syntax-rule (define-1ary-real-operator name bf-impl ival-impl)
   (define-operator (name real) real
@@ -291,8 +296,12 @@
     (hash-set parametric-operators-reverse name operator)))
   
 
-(define-syntax-rule (define-operator-impl (operator name atypes ...) rtype [key value] ...)
-  (register-operator-impl! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...)))
+(define-syntax define-operator-impl
+  (syntax-rules ()
+    [(define-operator-impl (operator name atypes ...) rtype [key value] ...)
+     (register-operator-impl! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...))]
+    [(define-operator-impl (operator name . atype) rtype [key value] ...)
+     (register-operator-impl! 'operator 'name 'atype 'rtype (list (cons 'key value) ...))]))
 
 (define (get-parametric-operator name #:fail-fast? [fail-fast? #t] . actual-types)
   (or
@@ -322,23 +331,23 @@
      (for-each operator-remove! (*unknown-ops*)))))
 
 ;; real operators
-(define-operator (==) real
-  [itype 'real] [bf (comparator bf=)] [ival ival-==])
+(define-operator (== . real) real
+  [bf (comparator bf=)] [ival ival-==])
 
-(define-operator (!=) real
-  [itype 'real] [bf (negate (comparator bf=))] [ival ival-!=])
+(define-operator (!= . real) real
+  [bf (negate (comparator bf=))] [ival ival-!=])
 
-(define-operator (<) real
-  [itype 'real] [bf (comparator bf<)] [ival ival-<])
+(define-operator (< . real) real
+  [bf (comparator bf<)] [ival ival-<])
 
-(define-operator (>) real
-  [itype 'real] [bf (comparator bf>)] [ival ival->])
+(define-operator (> . real) real
+  [bf (comparator bf>)] [ival ival->])
 
-(define-operator (<=) real
-  [itype 'real] [bf (comparator bf<=)] [ival ival-<=])
+(define-operator (<= . real) real
+  [bf (comparator bf<=)] [ival ival-<=])
 
-(define-operator (>=) real
-  [itype 'real] [bf (comparator bf>=)] [ival ival->=])
+(define-operator (>= . real) real
+  [bf (comparator bf>=)] [ival ival->=])
 
 ;; logical operators ;;
 
@@ -348,12 +357,10 @@
 (define-operator (not bool) bool
   [bf not] [ival ival-not])
 
-(define-operator (and bool bool) bool
-  [itype 'bool] ; override number of arguments
+(define-operator (and . bool) bool
   [bf and-fn] [ival ival-and])
 
-(define-operator (or bool bool) bool
-  [itype 'bool] ; override number of arguments
+(define-operator (or . bool) bool
   [bf or-fn] [ival ival-or])
 
 ;; Miscellaneous operators ;;

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -6,6 +6,7 @@
 (provide (rename-out [constant-or-impl? constant?]
                      [operator-or-impl? operator?])
          variable? operator-info operator-exists?
+         *functions* register-function!
          constant-info get-operator-arity
          get-parametric-operator parametric-operators parametric-operators-reverse
          get-parametric-constant parametric-constants parametric-constants-reverse
@@ -390,3 +391,9 @@
 
 (define (variable? var)
   (and (symbol? var) (not (constant-or-impl? var))))
+
+;; name -> (vars repr body)
+(define *functions* (make-parameter (make-hasheq)))
+
+(define (register-function! name args repr body)
+  (hash-set! (*functions*) name (list args repr body)))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -339,7 +339,7 @@
     (error 'constant-info "Unknown constant ~a" constant))
   (define accessor
     (match field
-      ['type constant-impl-otype]
+      ['type constant-impl-type]
       ['bf constant-impl-bf]
       ['fl constant-impl-fl]
       ['ival constant-impl-ival]))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -384,10 +384,10 @@
 
 (define (operator-or-impl? op)
   (and (symbol? op) (not (equal? op 'if))
-       (or (and (hash-has-key? parametric-operators var) 
-                (not (null? (operator-itype (hash-ref operators var)))))
-           (and (hash-has-key? operator-impls var)
-                (not (null? (operator-itype (hash-ref operator-impls var))))))))
+       (or (and (hash-has-key? parametric-operators op) 
+                (not (null? (operator-itype (hash-ref operators op)))))
+           (and (hash-has-key? operator-impls op)
+                (not (null? (operator-itype (hash-ref operator-impls op))))))))
 
 (define (constant-or-impl? var)
   (and (symbol? var)

--- a/src/syntax/test-rules.rkt
+++ b/src/syntax/test-rules.rkt
@@ -42,7 +42,7 @@
   (define make-point
     (make-sampler
      repr
-     `(λ ,fv ,(desugar-program (dict-ref *conditions* name 'TRUE) repr (*var-reprs*)))
+     `(λ ,fv ,(desugar-program (dict-ref *conditions* name '(TRUE)) repr (*var-reprs*)))
      `((λ ,fv ,p1)
        (λ ,fv ,p2))
      empty))
@@ -113,21 +113,12 @@
                         (get-representation 'bool)))
   (define _ (*simplify-rules*))  ; force an update
   (for* ([test-ruleset (*rulesets*)] [test-rule (first test-ruleset)])
-
-    (define ground-truth
-      (cond
-       [(and (expr-supports? (rule-input test-rule) 'ival)
-             (expr-supports? (rule-output test-rule) 'ival))
-        ival-ground-truth]
-       [else
-        (unless (set-member? (second test-ruleset) 'complex)
-          (fail-check "Real or boolean rule not supported by intervals"))
-        (when (dict-has-key? *conditions* (rule-name test-rule))
-          (fail-check "Using bigfloat sampling on a rule with a condition"))
-        bf-ground-truth]))
+    (unless (and (expr-supports? (rule-input test-rule) 'ival)
+                 (expr-supports? (rule-output test-rule) 'ival))
+      (fail-check "Rule does not support ival sampling"))
 
     (test-case (~a (rule-name test-rule))
-      (check-rule-correct test-rule ground-truth)))
+      (check-rule-correct test-rule ival-ground-truth)))
 
   (for* ([test-ruleset (*rulesets*)]
          [test-rule (first test-ruleset)]

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -1,7 +1,6 @@
 #lang racket
 
-(require "../common.rkt" "../errors.rkt" "../interface.rkt"
-         "syntax.rkt" "sugar.rkt" "types.rkt")
+(require "../common.rkt" "../errors.rkt" "../interface.rkt" "syntax.rkt" "types.rkt")
 (provide assert-program-typed!)
 
 (define (assert-program-typed! stx)

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -43,7 +43,7 @@
      (let/ec k
        (for/list ([sig (hash-ref parametric-operators x)])
          (match-define (list* name rtype atypes) sig)
-         (when (equal? rtype type)
+         (when (or (equal? rtype type) (equal? rtype 'bool))
            (k (operator-info name 'otype))))
        (error! stx "Could not find implementation of ~a for ~a" x type))]
     [#`,(? variable? x)

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -5,12 +5,12 @@
 (provide (struct-out type) get-type type-name?)
 (module+ internals (provide define-type))
 
-(struct type (name exact? inexact? exact->inexact inexact->exact))
+(struct type (name))
 
 (define type-dict (make-hasheq))
 
 (define-syntax-rule (define-type name (exact? inexact?) e->i i->e)
-  (hash-set! type-dict 'name (type 'name exact? inexact? e->i i->e)))
+  (hash-set! type-dict 'name (type 'name)))
 
 (define (type-name? x) (hash-has-key? type-dict x))
 (define (get-type x) (hash-ref type-dict x))

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -2,7 +2,7 @@
 
 (require math/bigfloat)
 
-(provide (struct-out type) get-type type-name? bigvalue? value-of bigvalue-of)
+(provide (struct-out type) get-type type-name?)
 (module+ internals (provide define-type))
 
 (struct type (name exact? inexact? exact->inexact inexact->exact))
@@ -20,11 +20,3 @@
 
 (define-type bool (boolean? boolean?)
   identity identity)
-
-(define (value-of type) (type-exact? (hash-ref type-dict type))) ; used once (eval-application in src/programs.rkt)
-(define (bigvalue-of type) (type-inexact? (hash-ref type-dict type))) ; not used
-
-; used 3 times (src/float.rkt and src/syntax/syntax.rkt)
-; counterpart value? is in src/interface.rkt since the definition of what is a value is
-; now repr specific
-(define (bigvalue? x) (for/or ([(type rec) (in-hash type-dict)]) ((type-inexact? rec) x)))


### PR DESCRIPTION
This PR mostly removes the notion of a constant from Herbie; instead, constants are now zero-ary operators. So in Herbie's internals (but *not* the user-accessible syntax) you now write `(cos (PI))` instead of `(cos PI)`. This required surgery in more of Herbie than expected but in my tests it is currently getting superior results.

There are some regressions from this (constants no longer get auto-cast, for example) but they seem rare or niche.