### PR TITLE
Remove all variary operators

### DIFF
--- a/infra/regression-chart.js
+++ b/infra/regression-chart.js
@@ -171,7 +171,7 @@ function make_speed_graph(node, data) {
 function select_data(data, options, tag) {
     return data = DATA.filter(function(x) {
         var out = true;
-        for (var flag in OPTIONS) {
+        for (var flag in options) {
             out = out && (x.flags.indexOf(flag) !== -1) == OPTIONS[flag];
         }
         return out && x.tag == tag;
@@ -195,7 +195,7 @@ function render(node1, node2, data, options, tag) {
 
 function draw_results(node1, node2) {
     DATA = get_data(document.getElementById("reports"));
-    OPTIONS = {"rules:numerics": false};
+    OPTIONS = {"rules:numerics": true};
     TAG = null;
     NODE1 = node1;
     NODE2 = node2;

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -42,12 +42,7 @@
                    (cons (repeat exact) (repeat (ulp-difference (<-bf exact) approx repr)))]
                   [`(,f ,args ...)
                    (define repr (get-representation (operator-info f 'otype)))
-                   (define argreprs
-                     (match (operator-info f 'itype)
-                       [(? representation-name? type)
-                        (map (const (get-representation type)) args)]
-                       [(list arg-types ...)
-                        (map get-representation arg-types)]))
+                   (define argreprs (map get-representation (operator-info f 'itype)))
                    (define <-bf (representation-bf->repr repr))
                    (define arg<-bfs (map representation-bf->repr argreprs))
 

--- a/src/cost.rkt
+++ b/src/cost.rkt
@@ -32,10 +32,7 @@
      [(list 'if cond ift iff)
       (+ 1 (loop cond repr) (max (loop ift repr) (loop iff repr)))]
      [(list op args ...)
-      (define ireprs
-        (match (operator-info op 'itype)
-         [(? representation-name? a) (map (const (get-representation a)) args)]
-         [(? list? as) (map get-representation as)]))
+      (define ireprs (map get-representation (operator-info op 'itype)))
       (apply + (operator-cost op (representation-total-bits repr))
                (map loop args ireprs))]
      [_ (representation-total-bits repr)])))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -303,7 +303,7 @@
             (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))))
 
     (define (is-nan? x)
-      (and (operator? x) (equal? (hash-ref parametric-operators-reverse x) 'NAN)))
+      (and (operator? x) (equal? (hash-ref parametric-operators-reverse x #f) 'NAN)))
 
     ; Probably unnecessary, at least CI passes!
     (define series-expansions*

--- a/src/reprs/binary32.rkt
+++ b/src/reprs/binary32.rkt
@@ -111,10 +111,6 @@
   (define shift-val (expt 2 bits))
   (λ (x) (+ (fn x) shift-val)))
 
-(define ((comparator test) . args)
-  (for/and ([left args] [right (cdr args)])
-    (test left right)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation (binary32 real float32?)
@@ -244,23 +240,23 @@
 
 (define-libm-operator (fma real real real))
 
-(define-operator-impl (== ==.f32 . binary32) bool
-  [fl (comparator =)])
+(define-operator-impl (== ==.f32 binary32 binary32) bool
+  [fl =])
 
-(define-operator-impl (!= !=.f32 . binary32) bool
-  [fl (negate (comparator =))])
+(define-operator-impl (!= !=.f32 binary32 binary32) bool
+  [fl (negate =)])
 
-(define-operator-impl (< <.f32 . binary32) bool
-  [fl (comparator <)])
+(define-operator-impl (< <.f32 binary32 binary32) bool
+  [fl <])
 
-(define-operator-impl (> >.f32 . binary32) bool
-  [fl (comparator >)])
+(define-operator-impl (> >.f32 binary32 binary32) bool
+  [fl >])
 
-(define-operator-impl (<= <=.f32 . binary32) bool
-  [fl (comparator <=)])
+(define-operator-impl (<= <=.f32 binary32 binary32) bool
+  [fl <=])
 
-(define-operator-impl (>= >=.f32 . binary32) bool
-  [fl (comparator >=)])
+(define-operator-impl (>= >=.f32 binary32 binary32) bool
+  [fl >=])
 
 (define-operator-impl (cast binary64->binary32 binary64) binary32
   [fl (curryr ->float32)])

--- a/src/reprs/binary64.rkt
+++ b/src/reprs/binary64.rkt
@@ -13,10 +13,6 @@
   (define shift-val (expt 2 bits))
   (λ (x) (+ (fn x) shift-val)))
 
-(define ((comparator test) . args)
-  (for/and ([left args] [right (cdr args)])
-    (test left right)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation (binary64 real flonum?)
@@ -132,20 +128,20 @@
 
 (define-libm-operator (fma real real real))
 
-(define-operator-impl (== ==.f64 . binary64) bool
-  [fl (comparator =)])
+(define-operator-impl (== ==.f64 binary64 binary64) bool
+  [fl =])
 
-(define-operator-impl (!= !=.f64 . binary64) bool
-  [fl (negate (comparator =))])
+(define-operator-impl (!= !=.f64 binary64 binary64) bool
+  [fl (negate =)])
 
-(define-operator-impl (< <.f64 . binary64) bool
-  [fl (comparator <)])
+(define-operator-impl (< <.f64 binary64 binary64) bool
+  [fl <])
 
-(define-operator-impl (> >.f64 . binary64) bool
-  [fl (comparator >)])
+(define-operator-impl (> >.f64 binary64 binary64) bool
+  [fl >])
 
-(define-operator-impl (<= <=.f64 . binary64) bool
-  [fl (comparator <=)])
+(define-operator-impl (<= <=.f64 binary64 binary64) bool
+  [fl <=])
 
-(define-operator-impl (>= >=.f64 . binary64) bool
-  [fl (comparator >=)])
+(define-operator-impl (>= >=.f64 binary64 binary64) bool
+  [fl >=])

--- a/src/reprs/bool.rkt
+++ b/src/reprs/bool.rkt
@@ -30,10 +30,10 @@
 (define-operator-impl (not not bool) bool
   [fl not])
 
-(define-operator-impl (and and . bool) bool
+(define-operator-impl (and and bool bool) bool
   [fl and-fn])
 
-(define-operator-impl (or or . bool) bool
+(define-operator-impl (or or bool bool) bool
   [fl or-fn])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; rules ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/reprs/fallback.rkt
+++ b/src/reprs/fallback.rkt
@@ -13,10 +13,6 @@
   (define shift-val (expt 2 bits))
   (λ (x) (+ (fn x) shift-val)))
 
-(define ((comparator test) . args)
-  (for/and ([left args] [right (cdr args)])
-    (test left right)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; representation ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define-representation (racket real flonum?)
@@ -136,20 +132,20 @@
 (define-fallback-operator (fma real real real)
  [fl (from-bigfloat bffma)])
 
-(define-operator-impl (== ==.rkt . racket) bool
-  [fl (comparator =)])
+(define-operator-impl (== ==.rkt racket racket) bool
+  [fl =])
 
-(define-operator-impl (!= !=.rkt . racket) bool
-  [fl (negate (comparator =))])
+(define-operator-impl (!= !=.rkt racket racket) bool
+  [fl (negate =)])
 
-(define-operator-impl (< <.rkt . racket) bool
-  [fl (comparator <)])
+(define-operator-impl (< <.rkt racket racket) bool
+  [fl <])
 
-(define-operator-impl (> >.rkt . racket) bool
-  [fl (comparator >)])
+(define-operator-impl (> >.rkt racket racket) bool
+  [fl >])
 
-(define-operator-impl (<= <=.rkt . racket) bool
-  [fl (comparator <=)])
+(define-operator-impl (<= <=.rkt racket racket) bool
+  [fl <=])
 
-(define-operator-impl (>= >=.rkt . racket) bool
-  [fl (comparator >=)])
+(define-operator-impl (>= >=.rkt racket racket) bool
+  [fl >=])

--- a/src/sampling.rkt
+++ b/src/sampling.rkt
@@ -193,5 +193,7 @@
     (when (> search-result 0)
       (check-true (<= (vector-ref arr (- search-result 1)) search-for))))
 
-  (check-equal? (precondition->hyperrects '(λ (a b) (and (<=.f64 0 a 1) (<=.f64 0 b 1))) (list repr repr) repr)
+  (check-equal? (precondition->hyperrects
+                 '(λ (a b) (and (and (<=.f64 0 a) (<=.f64 a 1))
+                                (and (<=.f64 0 b) (<=.f64 b 1)))) (list repr repr) repr)
                 (list (list (ival (bf 0.0) (bf 1.0)) (ival (bf 0.0) (bf 1.0))))))

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -80,9 +80,7 @@
       [(list 'if cond ift iff)
         (append (loop cond) (loop ift) (loop iff))]
       [(list op args ...)
-        (define itypes (operator-info op 'itype))
-        (append (if (list? itypes) itypes (list itypes))
-                (append-map loop args))]
+        (append (operator-info op 'itype) (append-map loop args))]
       [_ '()]))))
 
 (define (type-of-rule input output ctx)

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -50,7 +50,7 @@
      (define f (syntax->datum f-syntax))
      (cond
       [(operator-exists? f)
-        (define arity (length (operator-info f 'itype))) ;; variary is #f
+        (define arity (length (real-operator-info f 'itype)))
         (unless (= arity (length args))
           (error! stx "Operator ~a given ~a arguments (expects ~a)"
                   f (length args) arity))]

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -43,7 +43,7 @@
     [#`(! #,props ... #,body)
      (check-properties* props '() body)
      (check-expression* body vars error!)]
-    [#`(,(? (curry set-member? '(+ - * /))) #,args ...)
+    [#`(,(? (curry set-member? '(+ - * / and or = != < > <= >=))) #,args ...)
      ;; These expand associativity so we don't check the number of arguments
      (for ([arg args]) (check-expression* arg vars error!))]
     [#`(#,f-syntax #,args ...)

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -44,14 +44,14 @@
      (check-properties* props '() body)
      (check-expression* body vars error!)]
     [#`(,(? (curry set-member? '(+ - * / and or = != < > <= >=))) #,args ...)
-     ;; These expand associativity so we don't check the number of arguments
+     ;; These expand by associativity so we don't check the number of arguments
      (for ([arg args]) (check-expression* arg vars error!))]
     [#`(#,f-syntax #,args ...)
      (define f (syntax->datum f-syntax))
      (cond
       [(operator-exists? f)
-        (define arity (get-operator-arity f)) ;; variary is #f
-        (unless (or (not arity) (= arity (length args)))
+        (define arity (length (operator-info f 'itype))) ;; variary is #f
+        (unless (= arity (length args))
           (error! stx "Operator ~a given ~a arguments (expects ~a)"
                   f (length args) arity))]
       [(hash-has-key? (*functions*) f)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -4,7 +4,7 @@
 (require "../common.rkt" "../interface.rkt" "../errors.rkt" "types.rkt")
 
 (provide (rename-out [operator-or-impl? operator?])
-         variable? operator-info operator-exists? constant-operator?
+         variable? operator-info real-operator-info operator-exists? constant-operator?
          *functions* register-function!
          get-parametric-operator parametric-operators parametric-operators-reverse
          *unknown-ops* *loaded-ops*
@@ -135,6 +135,18 @@
 
 (define parametric-operators (hash))
 (define parametric-operators-reverse (hash))
+
+(define/contract (real-operator-info operator field)
+  (-> symbol? (or/c 'itype 'otype 'bf 'fl 'ival) any/c)
+  (unless (hash-has-key? operators operator)
+    (error 'real-operator-info "Unknown operator ~a" operator))
+  (define accessor
+    (match field
+      ['itype operator-itype]
+      ['otype operator-otype]
+      ['bf operator-bf]
+      ['ival operator-ival]))
+  (accessor (hash-ref operators operator)))
 
 (define/contract (operator-info operator field)
   (-> symbol? (or/c 'itype 'otype 'bf 'fl 'ival) any/c)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -35,9 +35,6 @@
   (syntax-rules ()
     [(define-operator (name itypes ...) otype [key value] ...)
      (register-operator! 'name '(itypes ...) 'otype
-                         (list (cons 'key value) ...))]
-    [(define-operator (name . itype) otype [key value] ...)
-     (register-operator! 'name 'itype 'otype
                          (list (cons 'key value) ...))]))
 
 (define-syntax-rule (define-1ary-real-operator name bf-impl ival-impl)
@@ -203,9 +200,7 @@
 (define-syntax define-operator-impl
   (syntax-rules ()
     [(define-operator-impl (operator name atypes ...) rtype [key value] ...)
-     (register-operator-impl! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...))]
-    [(define-operator-impl (operator name . atype) rtype [key value] ...)
-     (register-operator-impl! 'operator 'name 'atype 'rtype (list (cons 'key value) ...))]))
+     (register-operator-impl! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...))]))
 
 (define (get-parametric-operator name #:fail-fast? [fail-fast? #t] . actual-types)
   (or
@@ -235,22 +230,22 @@
      (for-each operator-remove! (*unknown-ops*)))))
 
 ;; real operators
-(define-operator (== . real) real
+(define-operator (== real real) real
   [bf (comparator bf=)] [ival ival-==])
 
-(define-operator (!= . real) real
+(define-operator (!= real real) real
   [bf (negate (comparator bf=))] [ival ival-!=])
 
-(define-operator (< . real) real
+(define-operator (< real real) real
   [bf (comparator bf<)] [ival ival-<])
 
-(define-operator (> . real) real
+(define-operator (> real real) real
   [bf (comparator bf>)] [ival ival->])
 
-(define-operator (<= . real) real
+(define-operator (<= real real) real
   [bf (comparator bf<=)] [ival ival-<=])
 
-(define-operator (>= . real) real
+(define-operator (>= real real) real
   [bf (comparator bf>=)] [ival ival->=])
 
 ;; logical operators ;;
@@ -261,10 +256,10 @@
 (define-operator (not bool) bool
   [bf not] [ival ival-not])
 
-(define-operator (and . bool) bool
+(define-operator (and bool bool) bool
   [bf and-fn] [ival ival-and])
 
-(define-operator (or . bool) bool
+(define-operator (or bool bool) bool
   [bf or-fn] [ival ival-or])
 
 ;; Miscellaneous operators ;;

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -193,7 +193,7 @@
     (hash-set parametric-operators-reverse name operator)))
   
 
-(define-syntax (define-operator-impl (operator name atypes ...) rtype [key value] ...)
+(define-syntax-rule (define-operator-impl (operator name atypes ...) rtype [key value] ...)
   (register-operator-impl! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...)))
 
 (define (get-parametric-operator name #:fail-fast? [fail-fast? #t] . actual-types)

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -6,7 +6,6 @@
 (provide (rename-out [operator-or-impl? operator?])
          variable? operator-info operator-exists? constant-operator?
          *functions* register-function!
-         get-operator-arity
          get-parametric-operator parametric-operators parametric-operators-reverse
          *unknown-ops* *loaded-ops*
          repr-conv? rewrite-repr-op? get-repr-conv
@@ -31,11 +30,8 @@
 
   (hash-set! operators name (apply operator (map (curry hash-ref fields) '(itype otype bf ival)))))
 
-(define-syntax define-operator
-  (syntax-rules ()
-    [(define-operator (name itypes ...) otype [key value] ...)
-     (register-operator! 'name '(itypes ...) 'otype
-                         (list (cons 'key value) ...))]))
+(define-syntax-rule (define-operator (name itypes ...) otype [key value] ...)
+  (register-operator! 'name '(itypes ...) 'otype (list (cons 'key value) ...)))
 
 (define-syntax-rule (define-1ary-real-operator name bf-impl ival-impl)
   (define-operator (name real) real
@@ -197,10 +193,8 @@
     (hash-set parametric-operators-reverse name operator)))
   
 
-(define-syntax define-operator-impl
-  (syntax-rules ()
-    [(define-operator-impl (operator name atypes ...) rtype [key value] ...)
-     (register-operator-impl! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...))]))
+(define-syntax (define-operator-impl (operator name atypes ...) rtype [key value] ...)
+  (register-operator-impl! 'operator 'name '(atypes ...) 'rtype (list (cons 'key value) ...)))
 
 (define (get-parametric-operator name #:fail-fast? [fail-fast? #t] . actual-types)
   (or
@@ -214,13 +208,6 @@
          (error 'get-parametric-operator
                 "parametric operator with op ~a and input types ~a not found"
                 name actual-types))))
-
-;; mainly useful for getting arg count of an unparameterized operator
-;; will break if operator impls have different aritys
-;; returns #f for variary operators
-(define (get-operator-arity op)
-  (let ([itypes (operator-itype (hash-ref operators op))])
-    (if (type-name? itypes) #f (length itypes))))
 
 (define *unknown-ops* (make-parameter '()))
 

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -109,6 +109,22 @@
        (unless (equal? t actual-type)
          (error! stx "~a expects argument ~a of type ~a (not ~a)" op (+ i 1) t actual-type)))
      t]
+    [#`(,(and (or '< '> '<= '>= '= '!=) op) #,exprs ...)
+     (define t #f)
+     (for ([arg exprs] [i (in-naturals)])
+       (define actual-type (expression->type arg env type error!))
+       (when (equal? actual-type 'bool)
+          (error! stx "~a does not take boolean arguments" op))
+       (if (= i 0) (set! t actual-type) #f)
+       (unless (equal? t actual-type)
+         (error! stx "~a expects argument ~a of type ~a (not ~a)" op (+ i 1) t actual-type)))
+     'bool]
+    [#`(,(and (or 'and 'or) op) #,exprs ...)
+     (for ([arg exprs] [i (in-naturals)])
+       (define actual-type (expression->type arg env type error!))
+       (unless (equal? actual-type 'bool)
+          (error! stx "~a only takes boolean arguments" op)))
+     'bool]
     [#`(,(and (or 're 'im) op) #,arg)
      ; TODO: this special case can be removed when complex-herbie is moved to a composite type
      ; re, im : complex -> binary64


### PR DESCRIPTION
This fairly simple commit replaces the variary and/or/comparison operators with a simple expander. The expander is generally smart, in that it is linear except in the case of `!=` where it does generate quadratically-many comparisons. I do not expect that variary `!=` is used enough for this to matter.