### PR TITLE
Remove the parametric-operators hash tables

### DIFF
--- a/src/conversions.rkt
+++ b/src/conversions.rkt
@@ -33,12 +33,12 @@
   (define conv1 (sym-append prec1* '-> prec2*))
   (define conv2 (sym-append prec2* '-> prec1*))
 
-  (unless (hash-has-key? parametric-operators-reverse conv1)
+  (unless (impl-exists? conv1)
     (define impl (compose (representation-bf->repr repr2) (representation-repr->bf repr1)))
     (register-operator-impl! 'cast conv1 (list prec1) prec2  ; fallback implementation
       (list (cons 'fl impl))))
   
-  (unless (hash-has-key? parametric-operators-reverse conv2)
+  (unless (impl-exists? conv2)
     (define impl (compose (representation-bf->repr repr1) (representation-repr->bf repr2)))
     (register-operator-impl! 'cast conv2 (list prec2) prec1  ; fallback implementation
       (list (cons 'fl impl))))
@@ -47,13 +47,13 @@
   (define repr-rewrite1 (sym-append '<- prec1*))
   (define repr-rewrite2 (sym-append '<- prec2*))
 
-  (unless (hash-has-key? parametric-operators repr-rewrite1)
+  (unless (operator-exists? repr-rewrite1)
     (register-operator! repr-rewrite1 (list 'real) 'real
       (list (cons 'bf identity) (cons 'ival identity)))
     (register-operator-impl! repr-rewrite1 repr-rewrite1 (list prec1) prec1
       (list (cons 'fl identity))))
 
-  (unless (hash-has-key? parametric-operators repr-rewrite2)
+  (unless (operator-exists? repr-rewrite2)
     (register-operator! repr-rewrite2 (list 'real) 'real
       (list (cons 'bf identity) (cons 'ival identity)))
     (register-operator-impl! repr-rewrite2 repr-rewrite2 (list prec2) prec2
@@ -75,10 +75,10 @@
   (define repr-rewrite2 (sym-append '<- prec2*))
 
   ;; if missing, try generating them
-  (unless (and (hash-has-key? parametric-operators-reverse conv1)
-               (hash-has-key? parametric-operators-reverse conv2)
-               (hash-has-key? parametric-operators repr-rewrite1)
-               (hash-has-key? parametric-operators repr-rewrite2))
+  (unless (and (impl-exists? conv1)
+               (impl-exists? conv2)
+               (operator-exists? repr-rewrite1)
+               (operator-exists? repr-rewrite2))
     (generate-conversion-ops prec1 prec2))
 
   ;; Repr rewrite/conversion rules

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -225,8 +225,7 @@
                [alt->cost (hash-remove* alt->cost altns)]))
 
 (define (is-nan? expr)
-  (and (hash-has-key? parametric-operators-reverse expr)
-       (equal? (hash-ref parametric-operators-reverse expr) 'NAN)))
+  (and (impl-exists? expr) (equal? (impl->operator expr) 'NAN)))
 
 (define (atab-add-altns atab altns repr)
   (define altns* (filter-not (compose (curryr expr-contains? is-nan?) alt-program)

--- a/src/cost.rkt
+++ b/src/cost.rkt
@@ -5,7 +5,7 @@
 
 (define (operator-cost op bits)
   (* bits
-    (match (hash-ref parametric-operators-reverse op)
+    (match (impl->operator op)
      ['+     1]
      ['-     1]
      ['neg   1]

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -303,7 +303,7 @@
             (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))))
 
     (define (is-nan? x)
-      (and (operator? x) (equal? (impl->operator x) 'NAN)))
+      (and (impl-exists? x) (equal? (impl->operator x) 'NAN)))
 
     ; Probably unnecessary, at least CI passes!
     (define series-expansions*

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -303,7 +303,7 @@
             (timeline-push! 'times (~a expr) (- (current-inexact-milliseconds) tnow))))))
 
     (define (is-nan? x)
-      (and (operator? x) (equal? (hash-ref parametric-operators-reverse x #f) 'NAN)))
+      (and (operator? x) (equal? (impl->operator x) 'NAN)))
 
     ; Probably unnecessary, at least CI passes!
     (define series-expansions*

--- a/src/programs.rkt
+++ b/src/programs.rkt
@@ -331,7 +331,7 @@
           (let ([args* (map loop args (operator-info op 'itype))])
             (and (andmap identity args*) (cons op args*)))
           (let ([op* (apply get-parametric-operator 
-                            (hash-ref parametric-operators-reverse op)
+                            (impl->operator op)
                             (make-list (length args) prec*)
                             #:fail-fast? #f)]
                 [args* (map (curryr loop prec*) args)])

--- a/src/syntax/rules.rkt
+++ b/src/syntax/rules.rkt
@@ -50,11 +50,11 @@
 (define (rule-ops-supported? rule)
   (define (ops-in-expr expr)
     (cond
-      [(list? expr) (if (set-member? (*loaded-ops*) (car expr))
-                        (for/and ([subexpr (cdr expr)])
-                          (ops-in-expr subexpr))
-                        #f)]
-      [else #t]))
+      [(list? expr)
+       (and (impl-exists? (car expr))
+            (for/and ([subexpr (cdr expr)])
+              (ops-in-expr subexpr)))]
+      [else true]))
   (ops-in-expr (rule-output rule)))
 
 (register-reset

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -4,12 +4,12 @@
 (require "../common.rkt" "../interface.rkt" "../errors.rkt" "types.rkt")
 
 (provide (rename-out [operator-or-impl? operator?])
-         variable? operator-info real-operator-info operator-exists? constant-operator?
+         variable? constant-operator? operator-exists? impl-exists?
+         real-operator-info operator-info 
+         impl->operator all-constants operator-all-impls
          *functions* register-function!
-         get-parametric-operator parametric-operators parametric-operators-reverse
-         *unknown-ops* *loaded-ops*
-         repr-conv? rewrite-repr-op? get-repr-conv
-         all-constants)
+         get-parametric-operator
+         repr-conv? rewrite-repr-op? get-repr-conv)
 
 (module+ internals 
   (provide define-operator-impl
@@ -20,7 +20,7 @@
 ;; Abstract operator table
 ;; Implementations inherit attributes
 
-(struct operator (itype otype bf ival))
+(struct operator (name itype otype bf ival))
 (define operators (make-hasheq))
 
 (define (register-operator! name itypes otype attrib-dict)
@@ -28,7 +28,7 @@
   (define otype* (dict-ref attrib-dict 'otype otype))
   (define fields (make-hasheq (append (list (cons 'itype itypes*) (cons 'otype otype*)) attrib-dict)))
 
-  (hash-set! operators name (apply operator (map (curry hash-ref fields) '(itype otype bf ival)))))
+  (hash-set! operators name (apply operator name (map (curry hash-ref fields) '(itype otype bf ival)))))
 
 (define-syntax-rule (define-operator (name itypes ...) otype [key value] ...)
   (register-operator! 'name '(itypes ...) 'otype (list (cons 'key value) ...)))
@@ -130,11 +130,10 @@
 
 ;; Operator implementations
 
-(struct operator-impl (itype otype bf fl ival))
+(struct operator-impl (name op itype otype bf fl ival))
 (define operator-impls (make-hasheq))
 
-(define parametric-operators (hash))
-(define parametric-operators-reverse (hash))
+(define operators-to-impls (make-hasheq))
 
 (define/contract (real-operator-info operator field)
   (-> symbol? (or/c 'itype 'otype 'bf 'fl 'ival) any/c)
@@ -165,9 +164,6 @@
   (-> symbol? any/c)
   (hash-remove! operator-impls operator))
 
-(define (*loaded-ops*)
-  (hash-keys parametric-operators-reverse))
-
 (define (check-operator-types! inherited itypes otype)
   (define itypes* (dict-ref inherited 'itype))
   (define otype* (dict-ref inherited 'otype))
@@ -196,13 +192,8 @@
   (define fields (make-hasheq attrib-dict*))
   (hash-set! fields 'itype itypes)
   (hash-set! fields 'otype otype)
-  (hash-set! operator-impls name (apply operator-impl (map (curry hash-ref fields) '(itype otype bf fl ival))))
-  (set! parametric-operators
-    (hash-update parametric-operators operator
-                 (curry cons (list* name otype (operator-info name 'itype)))
-                 '()))
-  (set! parametric-operators-reverse
-    (hash-set parametric-operators-reverse name operator)))
+  (hash-set! operator-impls name (apply operator-impl name op (map (curry hash-ref fields) '(itype otype bf fl ival))))
+  (hash-update! operators-to-impls operator (curry cons name) '()))
   
 
 (define-syntax-rule (define-operator-impl (operator name atypes ...) rtype [key value] ...)
@@ -210,23 +201,19 @@
 
 (define (get-parametric-operator name #:fail-fast? [fail-fast? #t] . actual-types)
   (or
-    (for/or ([sig (hash-ref parametric-operators name)])
-      (match-define (list* true-name rtype atypes) sig)
-        (and (if (representation-name? atypes)
-                 (andmap (curry equal? atypes) actual-types)
-                 (equal? atypes actual-types))
-             true-name))
+    (for/or ([impl (operator-all-impls name)])
+      (define atypes (operator-info impl 'itype))
+      (and (equal? atypes actual-types) impl))
     (and fail-fast?
          (error 'get-parametric-operator
                 "parametric operator with op ~a and input types ~a not found"
                 name actual-types))))
 
-(define *unknown-ops* (make-parameter '()))
+(define (impl->operator name)
+  (operator-name (operator-impl-op (hash-ref operator-impls name))))
 
-(register-reset
- (λ ()
-   (unless (flag-set? 'precision 'fallback)
-     (for-each operator-remove! (*unknown-ops*)))))
+(define (operator-all-impls name)
+  (hash-ref operators-to-impls name))
 
 ;; real operators
 (define-operator (== real real) real
@@ -270,12 +257,11 @@
   (and (symbol? expr) (regexp-match? #px"^(<-)[\\S]+$" (symbol->string expr))))
 
 (define (get-repr-conv iprec oprec)
-  (for/or ([sig (hash-ref parametric-operators 'cast)])
-    (match-define (list* true-name rtype atypes) sig)
-      (and (repr-conv? true-name)
-           (equal? rtype oprec)
-           (equal? (car atypes) iprec)
-           true-name)))
+  (for/or ([name (operator-all-impls 'cast)])
+    (and (repr-conv? name)
+         (equal? (operator-info name 'otype) oprec)
+         (equal? (car (operator-info name 'itype)) iprec)
+         name)))
 
 (define-operator (PI) real
   [bf (λ () pi.bf)] 
@@ -312,21 +298,24 @@
 
 ;; Expression predicates ;;
 
+(define (impl-exists? op)
+  (hash-has-key? operator-impls op))
+
 (define (operator-or-impl? op)
   (and (symbol? op) (not (equal? op 'if))
-       (or (hash-has-key? parametric-operators op)
+       (or (hash-has-key? operators op)
            (hash-has-key? operator-impls op))))
 
 (define (constant-operator? op)
   (and (symbol? op)
-       (or (and (hash-has-key? parametric-operators op) 
+       (or (and (hash-has-key? operators op) 
                 (null? (operator-itype (hash-ref operators op))))
            (and (hash-has-key? operator-impls op)
                 (null? (operator-itype (hash-ref operator-impls op)))))))
 
 (define (variable? var)
   (and (symbol? var)
-       (or (not (hash-has-key? parametric-operators var))
+       (or (not (hash-has-key? operators var))
            (not (null? (operator-itype (hash-ref operators var)))))
        (or (not (hash-has-key? operator-impls var))
            (not (null? (operator-impl-itype (hash-ref operator-impls var)))))))
@@ -338,6 +327,6 @@
   (hash-set! (*functions*) name (list args repr body)))
 
 (define (all-constants)
-  (for/list ([(name rec) (in-hash parametric-operators)]
-             #:when (= (length rec) 2))
+  (for/list ([(name rec) (in-hash operators)]
+             #:when (= (length (operator-itype rec)) 0))
     name))

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -147,7 +147,7 @@
           (error! stx "Invalid arguments to ~a; expects ~a but got (~a ~a)" op
                   (string-join
                     (for/list ([sig (operator-all-impls op)])
-                      (define atypes (operator-info sig 'itypes))
+                      (define atypes (operator-info sig 'itype))
                       (format "(~a ~a)" op (string-join (map (curry format "<~a>") atypes) " ")))
                     " or ")
                   op (string-join (map (curry format "<~a>") actual-types) " "))
@@ -173,7 +173,7 @@
   (define (fail stx msg . args)
     (error (apply format msg args) stx))
 
-  (define (check-type env-type rtype expr #:env [env #hash()])
+  (define (check-types env-type rtype expr #:env [env #hash()])
     (load-representations! env-type env) ; load ops (unit tests)
     (check-equal? (expression->type expr env env-type fail) rtype))
 
@@ -185,13 +185,13 @@
        v)
      #t))
 
-  (check-type 'binary64 'binary64 #'4)
-  (check-type 'binary64'binary64 #'x #:env #hash((x . binary64)))
-  (check-type 'binary64 'binary64 #'(acos x) #:env #hash((x . binary64)))
+  (check-types 'binary64 'binary64 #'4)
+  (check-types 'binary64 'binary64 #'x #:env #hash((x . binary64)))
+  (check-types 'binary64 'binary64 #'(acos x) #:env #hash((x . binary64)))
   (check-fails 'binary64 #'(acos x) #:env #hash((x . bool)))
-  (check-type 'binary64 'bool #'(and a b c) #:env #hash((a . bool) (b . bool) (c . bool)))
-  (check-type 'binary64 'binary64 #'(if (== a 1) 1 0) #:env #hash((a . binary64)))
+  (check-types 'binary64 'bool #'(and a b c) #:env #hash((a . bool) (b . bool) (c . bool)))
+  (check-types 'binary64 'binary64 #'(if (== a 1) 1 0) #:env #hash((a . binary64)))
   (check-fails 'binary64 #'(if (== a 1) 1 0) #:env #hash((a . bool)))
-  (check-type 'binary64 'bool #'(let ([a 1]) TRUE))
+  (check-types 'binary64 'bool #'(let ([a 1]) TRUE))
   (check-fails 'binary64 #'(if (== a 1) 1 TRUE) #:env #hash((a . binary64)))
-  (check-type 'binary64 'binary64 #'(let ([a 1]) a) #:env #hash((a . bool))))
+  (check-types 'binary64 'binary64 #'(let ([a 1]) a) #:env #hash((a . bool))))

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -41,10 +41,10 @@
     [#`,(? number?) type]
     [#`,(? constant-operator? x)
      (let/ec k
-       (for/list ([sig (hash-ref parametric-operators x)])
-         (match-define (list* name rtype atypes) sig)
+       (for/list ([name (operator-all-impls x)])
+         (define rtype (operator-info name 'otype))
          (when (or (equal? rtype type) (equal? rtype 'bool))
-           (k (operator-info name 'otype))))
+           (k rtype)))
        (error! stx "Could not find implementation of ~a for ~a" x type))]
     [#`,(? variable? x)
      (define vtype (dict-ref env x))
@@ -91,11 +91,9 @@
          (begin
           (error! stx "Invalid arguments to -; expects ~a but got (- <~a>)"
                   (string-join
-                   (for/list ([sig (hash-ref parametric-operators 'neg)])
-                     (match-define (list* _ _ atypes) sig)
-                     (if (list? atypes)
-                         (format "(- ~a)" (string-join (map (curry format "<~a>") atypes) " "))
-                         (format "(- <~a> ...)" atypes)))
+                   (for/list ([sig (operator-all-impls 'neg)])
+                     (define atypes (operator-info sig 'itype))
+                     (format "(- ~a)" (string-join (map (curry format "<~a>") atypes) " ")))
                    " or ")
                   actual-type)
           #f))]    
@@ -148,11 +146,9 @@
          (begin
           (error! stx "Invalid arguments to ~a; expects ~a but got (~a ~a)" op
                   (string-join
-                    (for/list ([sig (hash-ref parametric-operators op)])
-                     (match-define (list* _ _ atypes) sig)
-                     (if (list? atypes)
-                         (format "(~a ~a)" op (string-join (map (curry format "<~a>") atypes) " "))
-                         (format "(~a <~a> ...)" op atypes)))
+                    (for/list ([sig (operator-all-impls op)])
+                      (define atypes (operator-info sig 'itypes))
+                      (format "(~a ~a)" op (string-join (map (curry format "<~a>") atypes) " ")))
                     " or ")
                   op (string-join (map (curry format "<~a>") actual-types) " "))
           #f))]


### PR DESCRIPTION
This PR removes the `parametric-operators` and `parametric-operators-reverse` hash tables. In its place are new methods like `operator-all-impls`, `impl->operator`, and a few others.

In doing this refactor, I also removed a number of code blocks that deal with variary operators, and also removed some obsolete data like `*unknown-ops*`.