### PR TITLE
Cleanup mainloop / patch table split

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -74,7 +74,6 @@
 
 ;; In localization, the maximum number of locations returned
 (define *localize-expressions-limit* (make-parameter 4))
-(define *localize-limit-for-new* (make-parameter #f))
 
 ;; How accurate to make the binary search
 (define *binary-search-test-points* (make-parameter 16))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -53,6 +53,7 @@
           (sow (option-on-expr sound-alts bexpr repr))))))
   (define best (argmin (compose errors-score option-errors) options))
   (debug "Found split indices:" best #:from 'regime #:depth 3)
+  (timeline-push! 'count (length alts) (length (option-split-indices best)))
   best)
 
 (define (exprs-to-branch-on alts repr)
@@ -385,12 +386,10 @@
     (debug "Computing regimes starting at alt" (+ idx 1) "of"
             (length sorted) #:from 'regime #:depth 2)
     (cond
-      [(null? alts) '()]
-      [(= (length alts) 1) (list (car alts))]
-      [else
-      (timeline-event! 'regimes)
+     [(null? alts) '()]
+     [(= (length alts) 1) (list (car alts))]
+     [else
       (define opt (infer-splitpoints alts repr))
-      (timeline-event! 'bsearch)
       (define branched-alt (combine-alts opt repr sampler))
       (define high (si-cidx (argmax (λ (x) (si-cidx x)) (option-split-indices opt))))
       (cons branched-alt (loop (take alts high) (+ idx (- (length alts) high))))])))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -164,23 +164,21 @@
 
   (define orig-prog (alt-program (^next-alt^)))
   (define vars (program-variables orig-prog))
-  (define err&exprs (localize-error (alt-program (^next-alt^)) (*output-repr*)))
+  (define loc-errs (localize-error (alt-program (^next-alt^)) (*output-repr*)))
 
   ; high-error locations
   (^locs^
-    (for/list ([e&e err&exprs] [i (in-range 4)])
-      (match-define (cons err expr) e&e)
-      (begin0 (cons vars expr)
-        (timeline-push! 'locations (~a expr) (errors-score err)
-                        (not (patch-table-has-expr? expr))))))
+    (for/list ([(err expr) (in-dict loc-errs)] [i (in-range 4)])
+      (timeline-push! 'locations (~a expr) (errors-score err)
+                      (not (patch-table-has-expr? expr)))
+      (cons vars expr)))
 
   ; low-error locations
   (^lowlocs^
     (if (*pareto-mode*)
-        (for/list ([e&e (reverse err&exprs)] [i (in-range 4)])
-          (match-define (cons err expr) e&e)
-          (begin0 (cons vars expr)
-            (timeline-push! 'locations (~a expr) (errors-score err) #f)))
+        (for/list ([(err expr) (in-dict (reverse loc-errs))] [i (in-range 4)])
+          (timeline-push! 'locations (~a expr) (errors-score err) #f)
+          (cons vars expr)) 
         '()))
 
   (void))

--- a/src/mainloop.rkt
+++ b/src/mainloop.rkt
@@ -168,7 +168,7 @@
 
   ; high-error locations
   (^locs^
-    (for/list ([(err expr) (in-dict loc-errs)] [i (in-range 4)])
+    (for/list ([(err expr) (in-dict loc-errs)] [i (in-range (*localize-expressions-limit*))])
       (timeline-push! 'locations (~a expr) (errors-score err)
                       (not (patch-table-has-expr? expr)))
       (cons vars expr)))
@@ -176,7 +176,7 @@
   ; low-error locations
   (^lowlocs^
     (if (*pareto-mode*)
-        (for/list ([(err expr) (in-dict (reverse loc-errs))] [i (in-range 4)])
+        (for/list ([(err expr) (in-dict (reverse loc-errs))] [i (in-range (*localize-expressions-limit*))])
           (timeline-push! 'locations (~a expr) (errors-score err) #f)
           (cons vars expr)) 
         '()))

--- a/src/patch.rkt
+++ b/src/patch.rkt
@@ -50,14 +50,9 @@
 ; If `improve` is not provided, a key is added
 ; with no improvements
 (define (add-patch! expr [improve #f])
-  (cond
-   [(not (*use-improve-cache*)) (void)]
-   [improve
+  (when (*use-improve-cache*)
     (hash-update! (patchtable-table *patch-table*) expr
-                  (curry cons improve) (list))]
-   [else
-    (hash-update! (patchtable-table *patch-table*) expr
-                  identity (list))]))
+                  (if improve (curry cons improve) identity) (list))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Internals ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
This PR cleans up some messy code from #407 and adds alt count info to the timeline.