### PR TITLE
Fix paths in nightlies

### DIFF
--- a/infra/publish.sh
+++ b/infra/publish.sh
@@ -10,11 +10,11 @@ upload () {
     B=$(git rev-parse --abbrev-ref HEAD)
     C=$(git rev-parse HEAD | sed 's/\(..........\).*/\1/')
     RDIR="$(date +%s):$(hostname):$B:$C"
-    racket infra/make-index.rkt index.cache "$DIR"
+    racket infra/make-index.rkt --relpath "$RDIR" index.cache "$DIR"
     rsync index.cache "$RHOST:$RHOSTDIR/index.cache"
     find "$DIR" -name "*.txt" -exec gzip -f {} \;
     find "$DIR" -name "*.json" -exec gzip -f {} \;
-    rsync --recursive "$DIR" "$RHOST:$RHOSTDIR/$RDIR"
+    rsync --recursive "$DIR/" "$RHOST:$RHOSTDIR/$RDIR/"
     rsync --recursive \
           "index.html" "infra/index.css" "infra/regression-chart.js" "src/web/report.js" \
           "$RHOST:$RHOSTDIR/"
@@ -42,19 +42,19 @@ reindex () {
     DIR="$1"
     rsync --recursive --checksum --inplace --ignore-existing \
           --include 'results.json' --include 'results.json.gz' --include '*/' --exclude '*' \
-          "$RHOST:$RHOSTDIR" "$DIR"
+          "$RHOST:$RHOSTDIR/" "$DIR/"
     find "$DIR" -name "results.json.gz" -exec gunzip -f {} \;
     racket infra/make-index.rkt "$DIR"
     rsync index.cache "$RHOST:$RHOSTDIR/index.cache"
     rsync "index.html" "infra/index.css" "infra/regression-chart.js" "src/web/report.js" \
           "$RHOST:$RHOSTDIR/"
     ssh "$RHOST" chgrp uwplse "$RHOSTDIR/{index.html,index.css,report.js,regression-chart.js}"
-    rm index.cache index.html
+    rm index.html
 }
 
 upload_reports () {
     DIR="$1"
-    rsync --recursive "$DIR"/ "$RHOST:$RHOSTDIR"
+    rsync --recursive "$DIR/" "$RHOST:$RHOSTDIR/"
 }
 
 help () {


### PR DESCRIPTION
When I rewrote the nightly code to use digests, I forgot to fix my handling of paths, which are used to derive the links that are placed in the web page. This PR fixes that issue, by using relative paths and allowing renaming.