### PR TITLE
Read decimals exactly

### DIFF
--- a/src/shell.rkt
+++ b/src/shell.rkt
@@ -10,7 +10,9 @@
         (λ (e)
           ((error-display-handler) (exn-message e) e)
           (get-input))])
-    (define input (read-syntax "stdin" (current-input-port)))
+    (define input 
+      (parameterize ([read-decimal-as-inexact false])
+        (read-syntax "stdin" (current-input-port))))
     (if (eof-object? input)
         (begin (printf "\n") eof)
         (parse-test input))))

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -121,15 +121,19 @@
       (warn 'strange-variable
             "unusual variable ~a; did you mean ~a?" var const))))
 
+(define (our-read-syntax port name)
+  (parameterize ([read-decimal-as-inexact false])
+    (read-syntax port name)))
+
 (define (load-stdin)
-  (for/list ([test (in-port (curry read-syntax "stdin") (current-input-port))])
+  (for/list ([test (in-port (curry our-read-syntax "stdin") (current-input-port))])
     (parse-test test)))
 
 (define (load-file file)
   (call-with-input-file file
     (λ (port)
       (port-count-lines! port)
-      (for/list ([test (in-port (curry read-syntax file) port)])
+      (for/list ([test (in-port (curry our-read-syntax file) port)])
         (parse-test test)))))
 
 (define (load-directory dir)


### PR DESCRIPTION
Right now, if you write a number in decimal format in Herbie's input, like `3.1415`, Herbie interprets that as an inexact floating-point value, which hinders optimization because Herbie avoids computing with it. This changes Herbie's reader to treat that input as the fraction 31415/100000, an exact real value, which Herbie can then compute on and optimize.