### PR TITLE
Add an `AGENT.md` for LLM coders

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,21 @@
+
+# Testing
+
+- Before presenting any code run `make fmt` to format the code. This
+  is mandatory and PRs that don't follow the coding style are
+  rejected.
+- As a quick test to make sure everything is working, you can run
+  `racket src/main.rkt report bench/tutorial.rkt tmp`; this should
+  take about 5-10 seconds and all of the tests should pass, getting
+  basically perfect accuracy.
+- You can also run the unit tests with `raco test src/`, but these
+  aren't very complete; focus more on the full run from the previous
+  bullet point.
+
+# PRs
+
+- PR descriptions should be in full sentences one to a few paragraphs
+  paragraphs in length. For all but the most trivial fixes, describe
+  the current behavior and why you changed it.
+- Be explicit about the expected impact: "should be faster", "should
+  be more accurate", "pure refactor, not changes", and so on.


### PR DESCRIPTION
Yeah. It's here. What can we do?

More seriously, I've been using it and it's produced some PRs—look in the PR tab for the "codex" tag. I'm told that explaining testing and similar disciplines helps it out.