### PR TITLE
Don't crash if the timeline is empty and there's an active key

### DIFF
--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -30,7 +30,7 @@
 (define always-compact '(mixsample outcomes))
 
 (define (timeline-event! type)
-  (when *timeline-active-key*
+  (when (and *timeline-active-key* (pair? (unbox (*timeline*))))
     (hash-update! (car (unbox (*timeline*)))
                   *timeline-active-key*
                   (curry append *timeline-active-value*)


### PR DESCRIPTION
I found this while testing #1265 and it was crashing in an exception handler on my machine. Don't know why but this does fix it.