### PR TITLE
Use shared format-percent

### DIFF
--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -172,15 +172,6 @@
                                               [count counts])
                                      `(tr (td ,(~r count #:group-sep " ") "×") (td ,(~a reason))))))))
 
-(define (format-percent num den)
-  (string-append (if (zero? den)
-                     (cond
-                       [(positive? num) "+∞"]
-                       [(zero? num) "0"]
-                       [(negative? num) "-∞"])
-                     (~r (* (/ num den) 100) #:precision 1))
-                 "%"))
-
 (define (average . values)
   (/ (apply + values) (length values)))
 


### PR DESCRIPTION
There's a `format-percent` helper in both `reports/timeline.rkt` and `reports/common.rkt`, this deletes the duplicate.

https://chatgpt.com/codex/tasks/task_e_684b019d81508331a8749bf4a8353da0