### PR TITLE
Hide the metrics link for the online demo (by seed)

### DIFF
--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -158,7 +158,7 @@ function toTitleCase(str) {
 
 function buildHeader(title) {
     // The online demo always runs with seed 1; hide the Metrics link there
-    const showMetricsLink = resultsJsonData?.seed !== 1
+    const showMetricsLink = resultsJsonData?.seed != 1
     return Element("header", {}, [
         Element("h1", {}, title),
         Element("img", { src: "logo-car.png" }, []),


### PR DESCRIPTION
This PR fixes #1267 by hiding the "Metrics" link on the index page, only for the online demo. Or, more precisely, for seed 1, which presumably only the online demo has. We can change to a more obscure seed if it's a problem but I bet it's not.