### PR TITLE
Fix `fmt` on `main`

### DIFF
--- a/infra/convert-demo.rkt
+++ b/infra/convert-demo.rkt
@@ -14,8 +14,7 @@
 
 (define (format-expr is-version-10 expr)
   (match expr
-    [(? string?)
-     (or (string->number expr) (raise (error "string that is not a num")))]
+    [(? string?) (or (string->number expr) (raise (error "string that is not a num")))]
     [(list op args ...) (format-op (cons op (map (curry format-expr is-version-10) args)))]
     [(? symbol?)
      (if is-version-10


### PR DESCRIPTION
Looks like Resyntax broke it (@jackfirth)