### PR TITLE
Remove unused utils imports from syntax

### DIFF
--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -5,8 +5,7 @@
          ffi/unsafe)
 
 (require "../core/rival.rkt"
-         "types.rkt"
-         "../utils/common.rkt")
+         "types.rkt")
 
 (provide from-rival
          from-libm

--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -3,8 +3,6 @@
 (require math/bigfloat
          math/base
          math/flonum)
-(require "../utils/common.rkt"
-         "../utils/errors.rkt")
 
 (provide (struct-out representation)
          repr->prop


### PR DESCRIPTION
## Summary
- Remove unused `../utils/common.rkt` require from `syntax/generators.rkt`
- Drop unused `../utils/common.rkt` and `../utils/errors.rkt` requires from `syntax/types.rkt`

## Testing
- `raco make src/syntax/generators.rkt`
- `raco make src/syntax/types.rkt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp`


------
https://chatgpt.com/codex/tasks/task_e_689553f900548331b8800c5f7ba494b1