### PR TITLE
Generalize libm generator to accept an FFI library

### DIFF
--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -9,6 +9,7 @@
          "../utils/common.rkt")
 
 (provide from-rival
+         from-ffi
          from-libm
          from-bigfloat
          define-generator
@@ -33,15 +34,15 @@
         (first exs)
         fail)))
 
-; ----------------------- LIBM GENERATOR ----------------------------
+; ----------------------- FFI GENERATOR -----------------------------
 
 ;; Looks up a function `name` with type signature `itype -> ... -> otype`
-;; in the system libm and returns the FFI function or `#f` if
-;; the procedure cannot be found.
+;; in the given FFI library and returns the function or `#f` if it
+;; cannot be found.
 ;; ```
-;; (make-libm (<name> <itype> ... <otype))
+;; (make-ffi <lib> (<name> <itype> ... <otype>))
 ;; ```
-(define (make-libm name itypes otype)
+(define (make-ffi lib name itypes otype)
   ; Repr matching
   (define (repr->ffi repr)
     (match (representation-name repr)
@@ -49,15 +50,19 @@
       ['binary32 _float]
       ['integer _int]
       [else (raise-syntax-error 'repr->type "unknown type" repr)]))
-  (get-ffi-obj name #f (_cprocedure (map repr->ffi itypes) (repr->ffi otype)) (const #f)))
+  (get-ffi-obj name lib (_cprocedure (map repr->ffi itypes) (repr->ffi otype)) (const #f)))
 
-(define-generator ((from-libm name) spec ctx)
+(define-generator ((from-ffi lib name) spec ctx)
   (let ([itypes (context-var-reprs ctx)]
         [otype (context-repr ctx)])
-    (define fl (make-libm name itypes otype))
+    (define fl (make-ffi lib name itypes otype))
     (unless fl
-      (error 'libm-generator "Could not find libm implementation of `~a ~a ~a`" otype name itypes))
+      (error 'ffi-generator "Could not find FFI implementation of `~a ~a ~a`" otype name itypes))
     fl))
+
+(define libm-lib (ffi-lib #f))
+(define (from-libm name)
+  (from-ffi libm-lib name))
 
 ; ----------------------- BIGFLOAT GENERATOR ------------------------
 

--- a/www/doc/2.3/platforms.html
+++ b/www/doc/2.3/platforms.html
@@ -214,12 +214,22 @@
   <pre>(define-operation (fabs.f32 [x &lt;binary32&gt;]) &lt;binary32&gt;
   #:spec (fabs x) #:impl (from-libm 'fabsf) #:cost 0.125)</pre>
 
-  <p>The <code>from-libm</code> uses dynamic linking to
-  load <code>libm</code>, extracts the symbol passed
-  to <code>from-libm</code>, and then uses the operation's signature
-  to call into the dynamically-linked library from Racket. Must make
-  sure to pass the correct symbol name; for single-precision
-  functions, make sure to add the "<code>f</code>" suffix.</p>
+  <p>The <code>from-libm</code> helper uses dynamic linking to load
+  <code>libm</code>, extracts the symbol passed to
+  <code>from-libm</code>, and then uses the operation's signature to
+  call into the dynamically-linked library from Racket. Be sure to
+  pass the correct symbol name; for single-precision functions, add the
+  "<code>f</code>" suffix.</p>
+
+  <p>For other libraries, open them with
+  <code>ffi-lib</code> and use <code>from-ffi</code>, which
+  generalizes <code>from-libm</code>. For example, to load functions
+  from the GNU Scientific Library:</p>
+
+  <pre>(require ffi/unsafe)
+(define libgsl (ffi-lib "gsl"))
+(define-operation (cos.gsl [x &lt;binary64&gt;]) &lt;binary64&gt;
+  #:spec (cos x) #:impl (from-ffi libgsl 'gsl_sf_cos) #:cost 0.125)</pre>
 
   <h3>Numeric Variations</h3>
 

--- a/www/doc/2.3/plugins.html
+++ b/www/doc/2.3/plugins.html
@@ -114,9 +114,9 @@
   <h2>Defining Generators</h2>
 
   <p><dfn>Generators</dfn> are helper functions for generating
-  implementations in <code>define-operation</code>. For
-  example, <a href="platforms.html"><code>from-libm</code>
-  and <code>from-rival</code></a> are generators.</p>
+  implementations in <code>define-operation</code>. For example,
+  <a href="platforms.html"><code>from-ffi</code></a> is a
+  generator.</p>
 
   <p>To define a generator, use <code>define-generator</code>:</p>
 
@@ -128,7 +128,8 @@
   <p>Here, <code>from-<var>foo</var></code> is the name of your
   generator, and <var>args</var> are any additional arguments the
   generator takes. For example, <code>from-libm</code> takes one
-  argument, the symbol name.</p>
+  argument, the symbol name, while <code>from-ffi</code> takes an open
+  library and a symbol name.</p>
 
   <p>Then, inside the <var>body</var>, you can use those arguments as
   well as <code>spec</code> and <code>ctx</code>, to construct an


### PR DESCRIPTION
## Summary
Herbie now exposes a flexible `from-ffi` generator for resolving operations from an already-opened foreign library while retaining the existing `from-libm` helper as a thin wrapper. Built-in C and Herbie platforms continue to call `from-libm`, preserving current behavior while enabling custom platforms to load operations from arbitrary shared libraries. Documentation has been revised to show `from-ffi` used with the GNU Scientific Library and to clarify how generators are defined.

## Testing
- `make fmt`
- `racket src/main.rkt report bench/tutorial.fpcore tmp`


------
https://chatgpt.com/codex/tasks/task_e_68958eba04348331afa231df41c42119