### PR TITLE
Move validate-platform into platform-language

### DIFF
--- a/src/syntax/platform-language.rkt
+++ b/src/syntax/platform-language.rkt
@@ -244,6 +244,16 @@
   ; Update table
   (hash-set! impls (operator-impl-name impl) impl))
 
+(define (validate-platform! platform)
+  (when (empty? (platform-implementations platform))
+    (raise-herbie-error "Platform contains no operations"))
+  (for ([(name impl) (in-hash (platform-implementations platform))])
+    (define ctx (operator-impl-ctx impl))
+    (for ([repr (in-list (cons (context-repr ctx) (context-var-reprs ctx)))])
+      (unless (equal? (hash-ref (platform-representations platform) (representation-name repr) #f)
+                      repr)
+        (raise-herbie-error "Representation ~a not defined" (representation-name repr))))))
+
 (define-syntax (platform-register-implementations! stx)
   (syntax-case stx ()
     [(_ platform ([name ([var : repr] ...) otype spec fl fpcore cost] ...))

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -32,7 +32,6 @@
          platform-lifting-rules
          platform-lowering-rules
          platform-copy
-         validate-platform!
          repr-exists?
          get-representation
          impl-exists?
@@ -67,16 +66,6 @@
   (define repr-costs (make-hash))
   (define impls (make-hash))
   (create-platform reprs impls repr-costs))
-
-(define (validate-platform! platform)
-  (when (empty? (platform-implementations platform))
-    (raise-herbie-error "Platform contains no operations"))
-  (for ([(name impl) (in-hash (platform-implementations platform))])
-    (define ctx (operator-impl-ctx impl))
-    (for ([repr (in-list (cons (context-repr ctx) (context-var-reprs ctx)))])
-      (unless (equal? (hash-ref (platform-representations platform) (representation-name repr) #f)
-                      repr)
-        (raise-herbie-error "Representation ~a not defined" (representation-name repr))))))
 
 ;; Returns the representation associated with `name`
 ;; attempts to generate the repr if not initially found


### PR DESCRIPTION
Herbie's platform DSL used to validate platform definitions in `platform.rkt`, exporting a helper called `validate-platform!`. This change relocates that helper into `platform-language.rkt`, keeping validation alongside the DSL where platforms are defined. Because no external module needs it, the helper is no longer exported.

This is a small refactor that simplifies the public API without changing behavior or performance.

## Testing
- `make fmt`
- `racket -y src/main.rkt report bench/tutorial.fpcore tmp`


------
https://chatgpt.com/codex/tasks/task_e_689903c406788331b6e1185d3aad694b