### PR TITLE
Kalman filter benchmarks

### DIFF
--- a/bench/physics/kalman.fpcore
+++ b/bench/physics/kalman.fpcore
@@ -1,6 +1,6 @@
 (FPCore (dt r)
         :name "Kalman filter per K"
-        :pre (and (< 0 dt) (< r 0))
+        :pre (and (> dt 0) (> r 0))
         ; initializing matrices
         (let ([p00 25.0]
               [p01 0.0]
@@ -69,7 +69,7 @@
                       
 (FPCore (x0 x1 x2 dt r sensor)
         :name "Kalman filter per x"
-        :pre (and (< 0 dt) (< r 0) (< 0 sensor))
+        :pre (and (> dt 0) (> r 0) (> sensor 0))
         ; initializing matrices
         (let ([p00 25.0]
               [p01 0.0]
@@ -147,7 +147,7 @@
                         
 (FPCore (dt r)
         :name "Kalman filter per P"
-        :pre (and (< 0 dt) (< r 0))
+        :pre (and (> dt 0) (> r 0))
         ; initializing matrices
         (let ([p00 25.0]
               [p01 0.0]


### PR DESCRIPTION
This PR adds new benchmarks.
These benchmarks represent Kalman filter implementation that is taken from: [Elaeina](https://github.com/sandialabs/elaenia/blob/main/examples/05_kalman/05_gps/gps.c) repository.

Kalman filter benchmarks are parsed per each output variable.
Despite that the benchmarks share a large part of executions - they differ in an output variable.