### PR TITLE
label dump-egglog outputs

### DIFF
--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -93,7 +93,7 @@
   (egglog-runner batch brfs reprs schedule ctx))
 
 ;; Runs egglog using an egglog runner by extracting multiple variants
-(define (run-egglog-multi-extractor runner output-batch) ; multi expression extraction
+(define (run-egglog-multi-extractor runner output-batch [label #f]) ; multi expression extraction
   (define insert-batch (egglog-runner-batch runner))
   (define insert-brfs (egglog-runner-brfs runner))
   (define curr-program (make-egglog-program))
@@ -107,8 +107,9 @@
          (make-directory dump-dir))
        (define name
          (for/first ([i (in-naturals)]
-                     #:unless (file-exists? (build-path dump-dir (format "~a.egg" i))))
-           (build-path dump-dir (format "~a.egg" i))))
+                     #:unless
+                     (file-exists? (build-path dump-dir (format "~a~a.egg" (if label label "") i))))
+           (build-path dump-dir (format "~a~a.egg" (if label label "") i))))
 
        (open-output-file name #:exists 'replace)]
 

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -103,7 +103,7 @@
 
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
-        (run-egglog-multi-extractor runner global-batch)
+        (run-egglog-multi-extractor runner global-batch 'taylor)
         (egraph-best runner global-batch)))
 
   ; apply changelists
@@ -175,7 +175,7 @@
 
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
-        (run-egglog-multi-extractor runner global-batch)
+        (run-egglog-multi-extractor runner global-batch 'rewrite)
         (egraph-variations runner global-batch)))
 
   ; apply changelists


### PR DESCRIPTION
Label the egglog outputs for test files when `--enable dump:egglog` is set to show whether they are for taylor expansion or rewriting.