### PR TITLE
Remove the iter-limit for lift/lower passes

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1217,9 +1217,7 @@
 
 ;; Runs rules over the egraph with the given egg parameters.
 ;; Invariant: the returned egraph is never unsound
-(define (egraph-run-rules egg-graph0
-                          egg-rules
-                          #:node-limit [node-limit #f])
+(define (egraph-run-rules egg-graph0 egg-rules #:node-limit [node-limit #f])
   (define ffi-rules (map cdr egg-rules))
 
   ;; run the rules


### PR DESCRIPTION
The logic is that lifting and lowering never need more than one iteration, so we should just run them until saturation. I also turn off stop reason logging for these passes (since they always saturate). Unrelatedly, I also make unsoundness louder (always log) basically because I'm hoping to discover we are never unsound and, if so, remove the whole unsoundness handling code.