### PR TITLE
WIP: Only run Taylor on the last iteration

### DIFF
--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -62,7 +62,7 @@
 
     (for ([iteration (in-range (*num-iterations*))]
           #:break (atab-completed? (^table^)))
-      (run-iteration! global-spec-batch spec-reducer))
+      (run-iteration! global-spec-batch spec-reducer iteration))
     (define alternatives (extract!))
     (timeline-event! 'preprocess)
     (for/list ([altn alternatives])
@@ -234,14 +234,14 @@
   (^patched^ #f)
   (void))
 
-(define (run-iteration! global-spec-batch spec-reducer)
+(define (run-iteration! global-spec-batch spec-reducer iteration)
   (unless (^next-alts^)
     (choose-alts!))
 
   (define brfs (map alt-expr (^next-alts^)))
   (define brfs* (batch-reachable (*global-batch*) brfs #:condition node-is-impl?))
 
-  (reconstruct! (generate-candidates (*global-batch*) brfs* global-spec-batch spec-reducer))
+  (reconstruct! (generate-candidates (*global-batch*) brfs* global-spec-batch spec-reducer iteration))
   (finalize-iter!)
   (void))
 

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -200,7 +200,7 @@
     [(list) (alt-expr altn)]
     [(list prev) (get-starting-expr prev)]))
 
-(define (generate-candidates batch brfs spec-batch reducer)
+(define (generate-candidates batch brfs spec-batch reducer iteration)
   ; Starting alternatives
   (define start-altns
     (for/list ([brf brfs])
@@ -213,7 +213,8 @@
 
   ; Series expand
   (define approximations
-    (if (flag-set? 'generate 'taylor)
+    (if (and (flag-set? 'generate 'taylor)
+             (>= iteration (- (*num-iterations*) 1)))
         (run-taylor start-altns batch spec-batch reducer)
         '()))
 


### PR DESCRIPTION
This PR changes Taylor to only run on the last iteration. The code is ugly because I don't really expect it to work.

The basic thesis here is that Taylor is usually only needed once (multiple iterations might approximate away multiple variable but that doesn't seem common?) and that if you do it too early (iteration 1) it might gate off multi-iteration rewrites due to greediness. Frankly we've tried this before and it didn't work, but there have been recent bug fixes in rewrites that make me think that maybe it will work this time.