### PR TITLE
Update CI versions & references

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v1.11
+        uses: Bogdanp/setup-racket@v1.14
         with:
             version: "8.18"
             architecture: ${{ matrix.arch }}
@@ -49,7 +49,7 @@ jobs:
         with:
             toolchain: stable
             components: rustfmt, clippy
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - name: "Install dependencies"
         run: make install
       # Build executable and remove Herbie launcher

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "Install Packages"
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v1.11
+        uses: Bogdanp/setup-racket@v1.14
         with:
           version: "8.18"
       - name: Install Rust compiler
@@ -21,7 +21,7 @@ jobs:
         with:
             toolchain: stable
             components: rustfmt, clippy
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - name: "Install dependencies"
         run: make install
       - name: "Install SoftPosit support"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Racket
-        uses: Bogdanp/setup-racket@v1.11
+        uses: Bogdanp/setup-racket@v1.14
         with:
           version: 8.18
           architecture: ${{ matrix.arch }}
@@ -79,7 +79,7 @@ jobs:
           merge-multiple: true
 
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.20.0
         with:
           tag: ${{ github.ref }}
           name: ${{ github.ref }}

--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "Install Packages"
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v1.11
+        uses: Bogdanp/setup-racket@v1.14
         with:
           version: current
       - name: Install Rust compiler
@@ -25,7 +25,7 @@ jobs:
         with:
             toolchain: stable
             components: rustfmt, clippy
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - name: "Install dependencies"
         run: make install
       - name: Create a Resyntax pull request

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "Install Packages"
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v1.11
+        uses: Bogdanp/setup-racket@v1.14
         with:
           version: ${{ matrix.racket-version }}
       - name: Install Rust compiler
@@ -25,7 +25,7 @@ jobs:
         with:
             toolchain: stable
             components: rustfmt, clippy
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - name: "Install dependencies"
         run: make install
       - run: racket -y infra/ci.rkt --precision ${{ matrix.precision }} --seed 0 bench/hamming/

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "Install Packages"
         run: sudo apt-get install -y libmpfr6 libmpfr-dev
       - name: "Install Racket"
-        uses: Bogdanp/setup-racket@v1.11
+        uses: Bogdanp/setup-racket@v1.14
         with:
           version: "8.18"
       - name: Install Rust compiler
@@ -21,7 +21,7 @@ jobs:
         with:
             toolchain: stable
             components: rustfmt, clippy
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - name: "Install dependencies"
         run: make install
       # SoftPosit is required to test the softposit platform we use for testing
@@ -68,7 +68,7 @@ jobs:
       - run: cd egg-herbie && raco test ./
 
       # Test the API
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: "Test the endpoint"


### PR DESCRIPTION
This PR updates all the Action versions, the macOS runner version, and the Racket version, all to up-to-date versions. Not a big deal, just something we gotta do every now and then.