### PR TITLE
Woops, I typo'd the names of the newest Intel mac runners

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - os: macos-latest
             arch: aarch64
-          - os: macos-15-large
+          - os: macos-15-intel
             arch: x64
           - os: ubuntu-latest
             arch: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-latest
             os-name: macOS-m1
             arch: arm64
-          - os: macos-15-large
+          - os: macos-15-intel
             os-name: macOS
             arch: x64
 


### PR DESCRIPTION
It's `macos-15-intel`, which is free, not `macos-15-large`, which is paid. That broke CI. mb.