### PR TITLE
Update Rust version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ instructions, see the
 You can install Herbie from source if you want to participate in
 Herbie development. This requires
 [Racket](https://download.racket-lang.org/) (8.0 or later) and
-[Rust](https://www.rust-lang.org/tools/install) (1.60.0 or later).
+[Rust](https://www.rust-lang.org/tools/install) (1.87.0 or later).
 On Linux, avoid the Snap installer for Racket. Then, download the
 this repository and run:
 


### PR DESCRIPTION
The Rust requirement is now version 1.87.0 at least for running egglog. This is the version pinned in the egglog repo, and without this build will fail with:

```
error[E0658]: use of unstable library feature `string_extend_from_within`
   --> src/termdag.rs:154:24
    |
154 |                 result.extend_from_within(*start..*end);
    |                        ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #103806 <https://github.com/rust-lang/rust/issues/103806> for more information

For more information about this error, try `rustc --explain E0658`.
```