### PR TITLE
Move GC time to its own phase

### DIFF
--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -405,13 +405,14 @@
 (define (render-phase-allocations allocations)
   (define sorted (sort allocations > #:key second))
   (define total (apply + (map second sorted)))
-  `((dt "Allocations") (dd (table ((class "times"))
-                                  (thead (tr (th "Phase") (th "Allocated") (th "Percent")))
-                                  ,@(for/list ([rec (in-list sorted)])
-                                      (match-define (list type alloc) rec)
-                                      `(tr (td ,(~a type))
-                                           (td ,(~r (/ alloc (expt 2 20)) #:group-sep " " #:precision '(= 1)) " MiB")
-                                           (td ,(format-percent alloc total))))))))
+  `((dt "Allocations")
+    (dd (table ((class "times"))
+               (thead (tr (th "Phase") (th "Allocated") (th "Percent")))
+               ,@(for/list ([rec (in-list sorted)])
+                   (match-define (list type alloc) rec)
+                   `(tr (td ,(~a type))
+                        (td ,(~r (/ alloc (expt 2 20)) #:group-sep " " #:precision '(= 1)) " MiB")
+                        (td ,(format-percent alloc total))))))))
 
 ;; This next part handles summarizing several timelines into one details section for the report page.
 

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -250,7 +250,6 @@
       (hash-remove! phase* 'memory)
       phase*))
   (define gc-phase
-    (make-hasheq (list (cons 'type "gc")
-                       (cons 'time total-gc-time)
-                       (cons 'allocations allocation-table))))
+    (make-hasheq
+     (list (cons 'type "gc") (cons 'time total-gc-time) (cons 'allocations allocation-table))))
   (append adjusted-phases (list gc-phase)))


### PR DESCRIPTION
This PR moves all GC time to a separate "GC" phase for merged timelines, which has a table showing allocations as a percentage of the total. This might (might!) help @obround with his Rival-RS changes and probably will simplify other stuff too.