### PR TITLE
Graph live memory usage in `dump:trace`

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -82,6 +82,8 @@
          (define mode (~a (vector-ref data 1)))
          (define start (exact-floor (* 1000 (vector-ref data 9))))
          (define end (exact-floor (* 1000 (vector-ref data 10))))
+         (define post-amount (vector-ref data 5))
+         (define post-admin-amount (vector-ref data 6))
          (call-with-output-file "dump-trace.json"
                                 #:exists 'append
                                 (λ (out)
@@ -100,6 +102,20 @@
                                                     (equal-hash-code 'gc)
                                                     'args
                                                     (hash))
+                                              out)
+                                  (fprintf out ",")
+                                  (write-json (hash 'name
+                                                    "Memory"
+                                                    'ph
+                                                    "C"
+                                                    'ts
+                                                    end
+                                                    'pid
+                                                    0
+                                                    'tid
+                                                    (equal-hash-code 'gc)
+                                                    'args
+                                                    (hash 'live post-amount 'admin post-admin-amount))
                                               out)))
          (drain)]))))
 


### PR DESCRIPTION
This PR adds GC live memory (both with and without admin overhead) as counters to the trace. Perfetto can graph the result, it looks like this:

<img width="779" height="324" alt="image" src="https://github.com/user-attachments/assets/61f6b978-6ffd-4cfd-98c2-cc99139b430f" />

I think this is going to be useful to figure out why memory usage is so high. For example, I've already learned that the `bear` and `prospero` benchmarks have like 5GB live of just timeline; presumably that's fixable.