### PR TITLE
Use batches for arguments to `make-real-compiler`

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -9,6 +9,7 @@
          "../syntax/sugar.rkt"
          "../syntax/types.rkt"
          "../syntax/load-platform.rkt"
+         "../syntax/batch.rkt"
          "../core/localize.rkt"
          "../utils/alternative.rkt"
          "../core/compiler.rkt"
@@ -134,9 +135,10 @@
   (random) ;; Tick the random number generator, for backwards compatibility
   (define specification (prog->spec (or (test-spec test) (test-input test))))
   (define precondition (prog->spec (test-pre test)))
+  (define-values (batch brfs) (progs->batch (list specification)))
   (define sample
     (parameterize ([*num-points* (+ (*num-points*) (*reeval-pts*))])
-      (sample-points precondition (list specification) (list (*context*)))))
+      (sample-points precondition batch brfs (list (*context*)))))
   (apply mk-pcontext sample))
 
 ;;

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -128,7 +128,6 @@
       context?
       pcontext?
       valid-splitpoints?)
-  (define exprs (batch-exprs batch))
   (define repr ((batch-reprs batch ctx) brf))
 
   (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf) ctx)))
@@ -141,10 +140,8 @@
   (define start-prog-sub (extract-subexpression batch start-prog var brf ctx))
 
   ; Not totally clear if this should actually use the precondition
-  (define start-real-compiler
-    (and start-prog
-         (make-real-compiler (list (exprs (car (batch-to-spec! batch (list start-prog)))))
-                             (list ctx*))))
+  (define spec-brfs (and start-prog (batch-to-spec! batch (list start-prog))))
+  (define start-real-compiler (and start-prog (make-real-compiler batch spec-brfs (list ctx*))))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -8,6 +8,7 @@
          "../syntax/types.rkt"
          "../syntax/syntax.rkt"
          "../syntax/platform.rkt"
+         "../syntax/batch.rkt"
          "localize.rkt"
          "points.rkt"
          "programs.rkt"
@@ -72,9 +73,10 @@
   (define repr-hash
     (make-immutable-hash (map (lambda (e ctx) (cons e (context-repr ctx))) subexprs ctxs)))
 
+  (define-values (batch brfs) (progs->batch spec-list))
   (define subexprs-fn
     (parameterize ([*max-mpfr-prec* 128])
-      (eval-progs-real spec-list ctxs)))
+      (eval-progs-real batch brfs ctxs)))
   (values subexprs repr-hash subexprs-fn))
 
 (define (predict-errors ctx pctx subexprs-list repr-hash subexprs-fn)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -128,11 +128,10 @@
       (context '() repr '())))
 
   (define spec-brfs (batch-to-spec! global-batch brfs))
-  (define specs (map (batch-exprs global-batch) spec-brfs))
   (define-values (status pts)
-    (if (null? specs)
+    (if (null? spec-brfs)
         (values 'invalid #f)
-        (let ([real-compiler (make-real-compiler specs contexts)])
+        (let ([real-compiler (make-real-compiler global-batch spec-brfs contexts)])
           (real-apply real-compiler (vector)))))
   (define literals
     (for/list ([pt (in-list (if (equal? status 'valid)

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -8,6 +8,7 @@
          "../utils/float.rkt"
          "../utils/timeline.rkt"
          "../syntax/types.rkt"
+         "../syntax/batch.rkt"
          "searchreals.rkt"
          "rival.rkt")
 
@@ -174,9 +175,9 @@
   (for/fold ([t1 (hash-remove (hash-remove t1 'unknown) 'valid)]) ([(k v) (in-hash t2)])
     (hash-set t1 k (+ (hash-ref t1 k 0) (* (/ v t2-total) t1-base)))))
 
-(define (sample-points pre specs ctxs)
+(define (sample-points pre batch brfs ctxs)
   (timeline-event! 'analyze)
-  (define compiler (make-real-compiler specs ctxs #:pre pre))
+  (define compiler (make-real-compiler batch brfs ctxs #:pre pre))
   (define-values (sampler table) (make-sampler compiler))
   (timeline-event! 'sample)
   (define-values (results table2) (batch-prepare-points compiler sampler))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -4,6 +4,7 @@
 (require "../utils/common.rkt"
          "../utils/float.rkt"
          "../syntax/types.rkt"
+         "../syntax/batch.rkt"
          "rival.rkt"
          "rules.rkt"
          "programs.rkt"
@@ -35,10 +36,11 @@
   (match-define (rule name p1 p2 _) test-rule)
   (define ctx (env->ctx p1 p2))
 
+  (define-values (batch brfs) (progs->batch (list p1 (drop-sound p2))))
   (match-define (list pts exs1 exs2)
     (parameterize ([*num-points* (num-test-points)]
                    [*max-find-range-depth* 0])
-      (sample-points '(TRUE) (list p1 (drop-sound p2)) (list ctx ctx))))
+      (sample-points '(TRUE) batch brfs (list ctx ctx))))
 
   (for ([pt (in-list pts)]
         [v1 (in-list exs1)]

--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -6,7 +6,8 @@
 
 (require "../core/rival.rkt"
          "../config.rkt"
-         "types.rkt")
+         "types.rkt"
+         "batch.rkt")
 
 (provide from-rival
          from-ffi
@@ -32,7 +33,8 @@
                   (hash-clear! cache))))
 
 (define-generator ((from-rival #:cache? [cache? #t]) spec ctx)
-  (define compiler (make-real-compiler (list spec) (list ctx)))
+  (define-values (batch brfs) (progs->batch (list spec)))
+  (define compiler (make-real-compiler batch brfs (list ctx)))
   (define fail ((representation-bf->repr (context-repr ctx)) +nan.bf))
   (define (compute . pt)
     (define-values (_ exs) (real-apply compiler (list->vector pt)))


### PR DESCRIPTION
The `make-real-compiler` API is Herbie's abstraction layer over Rival. This PR makes it take batches as an input and converts to expressions internally.