### PR TITLE
Filter profiles to remove stdlib higher-order functions

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -1,7 +1,6 @@
 #lang racket
 
-(require profile
-         racket/engine
+(require racket/engine
          json)
 
 (require "../syntax/read.rkt"
@@ -199,11 +198,7 @@
   (define (in-engine _)
     (cond
       [profile?
-       (define result
-         (profile-thunk compute-result
-                        #:order 'total
-                        #:delay 0.05
-                        #:render (λ (p order) (set! profile (profile->json p)))))
+       (define result (profile-thunk compute-result (λ (p) (set! profile (profile->json p)))))
        (struct-copy job-result result [profile profile])]
       [else (compute-result)]))
 


### PR DESCRIPTION
This PR makes Herbie profiles a bit nicer. Standard Racket profiles often suffer from the "map is everything" problem. Basically, let's say function `f` calls `(map g ...)`. Then your call stack looks like `[f, map, g]`, and standard gprof profiles turn that into two edges: `f -> map` and `map -> g`. But since `map` is _so_ common, basically all of your functions point to map and basically everything is called by `map`.

This PR adds some clever filtration to filter out standard library functions from the middle of a call stack in the profile. So the stack `[f, map, g]` becomes `[f, g]` with an `f -> g` edge that you actually care about. Notably, the call stack `[f, map]`, which is taken inside `map` and thus shows `map` overhead, still gives you an `f -> map` edge, so you don't get any false attribution. I think this makes the profiles way cleaner to browse!