### PR TITLE
Reduce memory use by making `batchref`s ephemeral

### DIFF
--- a/src/syntax/batch.rkt
+++ b/src/syntax/batch.rkt
@@ -59,13 +59,7 @@
 
 (define (batch-push! b term)
   (define hashcons (batch-index b))
-  (hash-ref! hashcons
-             term
-             (lambda ()
-               (define idx (hash-count hashcons))
-               (hash-set! hashcons term idx)
-               (dvector-add! (batch-nodes b) term)
-               (batchref b idx))))
+  (batchref b (hash-ref! hashcons term (lambda () (dvector-add! (batch-nodes b) term)))))
 
 (define (batch-add! b expr)
   (define (munge prog)

--- a/src/utils/dvector.rkt
+++ b/src/utils/dvector.rkt
@@ -68,7 +68,8 @@
      (dvector-add! dvec elem)]
     [else
      (vector-set! vec len elem)
-     (set-dvector-length! dvec (add1 len))]))
+     (set-dvector-length! dvec (add1 len))
+     len]))
 
 (define (dvector-set! dvec idx elem)
   (match-define (dvector vec len _) dvec)


### PR DESCRIPTION
This PR fixes a tiny error that was causing enormous memory pressure. Each `batch` stores an index from term to its index in the batch, for deduplication. The index key is the batch'd term, usually a `(cons/c symbol? (listof fixnum?))`. But due to some confusing code, the value was a batchref. This is dumb: it should just be the integer index. And this dumb mistake had consequences for memory usage: the batchrefs are heap allocated and stay live since they're pointed to by the batch, which ultimately means loads of allocations sticking around.

This PR fixes all that by just making the index value be the integer, and wrapping ephemeral batchrefs around the value when needed.