### PR TITLE
Use a custodian to work around a memory leak in the profiler

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -204,12 +204,11 @@
 
   (define run-custodian (make-custodian))
   ;; Branch on whether or not we should run inside an engine
-  (begin0
-      (parameterize ([current-custodian run-custodian])
-        (define eng (engine in-engine))
-        (if (engine-run (*timeout*) eng)
-            (engine-result eng)
-            (on-timeout)))
+  (begin0 (parameterize ([current-custodian run-custodian])
+            (define eng (engine in-engine))
+            (if (engine-run (*timeout*) eng)
+                (engine-result eng)
+                (on-timeout)))
     (custodian-shutdown-all run-custodian)))
 
 (define (dummy-table-row-from-hash result-hash status link)


### PR DESCRIPTION
The profiler retains the thread it's running in even if that thread is otherwise dead, which causes a memory leak when Herbie benchmarks time out. This PR uses custodians to force cleanup.