### PR TITLE
Make `jsexpr->batch-exprs` return a CSE'd string

### DIFF
--- a/src/syntax/batch.rkt
+++ b/src/syntax/batch.rkt
@@ -192,11 +192,25 @@
         [_ (~a node)])))
   (hash 'nodes nodes 'roots (map batchref-idx brfs*)))
 
-;; Converts a jsexpr batch back to expression strings
-;; Returns a list of expression strings, one per root
+;; Converts a jsexpr batch to a single SSA-style string with O(n) size
 (define (jsexpr->batch-exprs jsexpr)
   (define nodes (hash-ref jsexpr 'nodes))
   (define roots (hash-ref jsexpr 'roots))
+
+  ;; Pass 1: count references to each node
+  (define ref-counts (make-vector (length nodes) 0))
+  (for ([root roots])
+    (vector-set! ref-counts root (+ 1 (vector-ref ref-counts root))))
+  (for ([i (in-naturals)]
+        [node (in-list nodes)])
+    (match node
+      [(list op args ...)
+       (for ([arg args])
+         (vector-set! ref-counts arg (+ 1 (vector-ref ref-counts arg))))]
+      ;; Never dedup constants & variables
+      [_ (vector-set! ref-counts i -inf.0)]))
+
+  ;; Pass 2: build expressions, using %N for multiply-referenced nodes
   (define exprs (make-vector (length nodes) #f))
   (for ([node (in-list nodes)]
         [i (in-naturals)])
@@ -204,14 +218,26 @@
                  i
                  (match node
                    [(list op args ...)
-                    (format "(~a~a)"
+                    (format "(~a ~a)"
                             op
-                            (apply string-append
-                                   (for/list ([arg args])
-                                     (format " ~a" (vector-ref exprs arg)))))]
-                   [_ node])))
-  (for/list ([root roots])
-    (vector-ref exprs root)))
+                            (string-join (for/list ([arg args])
+                                           (if (> (vector-ref ref-counts arg) 1)
+                                               (format "%~a" arg)
+                                               (vector-ref exprs arg)))))]
+                   [_ (~a node)])))
+
+  ;; Output: one line per multi-ref node, then root expressions
+  (define bindings
+    (for/list ([i (in-naturals)]
+               [node (in-list nodes)]
+               #:when (> (vector-ref ref-counts i) 1))
+      (format "%~a = ~a" i (vector-ref exprs i))))
+  (define return-exprs
+    (for/list ([root roots])
+      (if (> (vector-ref ref-counts root) 1)
+          (format "%~a" root)
+          (vector-ref exprs root))))
+  (string-join (append bindings return-exprs) "\n"))
 ;; --------------------------------- TESTS ---------------------------------------
 
 ; Tests for progs->batch and batch-exprs
@@ -266,15 +292,19 @@
    (zombie-test #:nodes (create-dvector 'x 2 1/2 '(sqrt 1) '(cbrt 1) '(* 0 0) (approx 5 1) '(pow 2 6))
                 #:roots (list 7 3))))
 
-; Tests for batch->jsexpr and jsexpr->batch-exprs roundtrip
+; Tests for batch->jsexpr and jsexpr->batch-exprs
 (module+ test
   (require rackunit)
-  (define (test-json-roundtrip expr)
+  (define (test-json-tostring expr expected)
     (define-values (batch brfs) (progs->batch (list expr)))
     (define jsexpr (batch->jsexpr batch brfs))
-    (define strs (jsexpr->batch-exprs jsexpr))
-    (check-equal? strs (map (compose ~a (batch-exprs batch)) brfs)))
+    (define str (jsexpr->batch-exprs jsexpr))
+    (check-equal? str expected))
 
-  (test-json-roundtrip '(+ x y))
-  (test-json-roundtrip '(* 1/2 (+ (exp x) (neg (/ 1 (exp x))))))
-  (test-json-roundtrip '(sqrt (+ (* x x) (* y y)))))
+  ; No sharing - just the expression
+  (test-json-tostring '(+ x y) "(+ x y)")
+  ; Shared subexpressions get their own bindings
+  (test-json-tostring '(* 1/2 (+ (exp x) (neg (/ 1 (exp x)))))
+                      "%2 = (exp x)\n(* 1/2 (+ %2 (neg (/ 1 %2))))")
+  ; Shared constants/variables are inlined
+  (test-json-tostring '(sqrt (+ (* x x) (* y y))) "(sqrt (+ (* x x) (* y y)))"))


### PR DESCRIPTION
This PR follows up on #1286 by using batches also when printing highly-duplicative expressions in the timeline. This avoids allocating enormous strings for exponentially-large expressions, and then attempting to write those exponentially-large strings to a file. The result doesn't really change stuff that much (because our most-duplicative benchmarks can't finish writing out their timelines anyway) but it reduces peak memory usage, which I guess is nice.

I took some care to ensure that an expression _without_ duplicates looks more or less the same as before, though for the `inputs` and `outputs` calls it'll look pretty darn different almost no matter what.

The output string is guaranteed to be linear in the size of the batch.