### PR TITLE
Switch to two nightly threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ minimal-distribution:
 	[ ! -f herbie ] || (raco distribute herbie-compiled herbie && rm herbie)
 
 nightly:
-	bash infra/nightly.sh bench/ reports/ --threads 4
+	bash infra/nightly.sh bench/ reports/ --threads 2
 
 upgrade:
 	git pull


### PR DESCRIPTION
This PR switches the nightly to run two Herbie worker threads. We allocate 3 cores (for some reason 2 leads to a degradation but 3 is enough; will investigate one day) so 2 cores saturates it. You can do more also, but it leads to minor slowdowns and probably eats more memory than we should.