### PR TITLE
Reduce allocation rate during `eval` phase

### DIFF
--- a/src/syntax/types.rkt
+++ b/src/syntax/types.rkt
@@ -2,8 +2,7 @@
 
 (require math/bigfloat
          math/base
-         math/flonum
-         racket/flonum)
+         math/flonum)
 
 (provide (struct-out representation)
          repr->prop

--- a/src/utils/float.rkt
+++ b/src/utils/float.rkt
@@ -1,8 +1,8 @@
 #lang racket
 
-(require math/bigfloat
-         math/base
-         racket/flonum)
+(require math/base
+         math/bigfloat
+         math/flonum)
 (require "../utils/common.rkt"
          "../syntax/types.rkt"
          "../utils/errors.rkt")


### PR DESCRIPTION
This PR makes two separate optimizations:

- For 64-bit floats it special-cases `flonums-between`; this is a little bit better and also more optimizable (working on it)
- It uses a mutable vector instead of immutable lists when generating error lists, which saves some allocation, maybe 10%