### PR TITLE
Multiple optimizations within regimes to cut memory usage

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -286,7 +286,8 @@
       ;; Set and fill temporary vectors with starting data
       ;; #f for best index and positive infinite for best cost
       (vector-fill! best-alt-idxs -1)
-      (set! best-alt-costs (make-flvector number-of-points +inf.0))
+      (for ([i (in-range number-of-points)])
+        (flvector-set! best-alt-costs i +inf.0))
 
       ;; For each alt loop over its vector of errors
       (for ([alt-idx (in-naturals)]


### PR DESCRIPTION
This PR does several conceptually-unrelated optimizations inside regimes to cut memory allocation:

- Precompute all branch expression evaluations once in `pareto-regimes` using a single `compile-batch`
- Avoid flipping error lists and instead transpose them while we convert to vectors
- Build prefix-sum flvectors directly instead of allocating an intermediate flvector
- Call `ulps->bits` while computing prefix-sums instead of doing a map of maps
- Avoid a second flip of the error lists inside `pick-errors`

In my experiments on the `mathematics` suite, this cuts total allocation inside `regimes` by about 50%. Since `regimes` is about 10% of all allocation on the nightly, this isn't going to make the world's biggest difference, but maybe it'll help and maybe it'll cut GC time a bit, we'll see. It might even conceivably speed up regimes though only by a little bit I think.