### PR TITLE
Fix race condition in nightlies by installing libraries into a virtual environment

### DIFF
--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -7,6 +7,8 @@ set -e -x
 export PATH="$HOME/.cargo/bin/:$PATH"
 rustup update
 
+# Keep nightly installs isolated and consistent across install/run steps.
+export PLTADDONDIR="${PLTADDONDIR:-pltlibs}"
 make install
 
 # Seed is fixed for the whole day; this way two branches run the same seed
@@ -33,4 +35,3 @@ done
 
 # merge reports
 racket -y infra/merge.rkt "$REPORTDIR" $dirs
-


### PR DESCRIPTION
Once I turned on concurrent nightlies, we started getting failures when two nightlies were started too close together or at inopportune times. This is because they'd make conflicting changes to the global raco pkg directory. This PR fixes this by using the `PLTADDONDIR` environment variable to install all dependencies *locally* per branch; in effect this gives every branch its own virtual environment, much like we do already with cargo.