### PR TITLE
Use a deterministic variable name for bsearch

### DIFF
--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -94,6 +94,14 @@
   (define vars* (set-subtract (list->set (context-vars ctx)) (free-vars pattern-brf)))
   (and (subset? (free-vars body-brf) (set-add vars* var)) body-brf))
 
+(define (deterministic-branch-var ctx)
+  (define used-vars (list->set (context-vars ctx)))
+  (let loop ([n 0])
+    (define var (string->symbol (format "branch-~a" n)))
+    (if (set-member? used-vars var)
+        (loop (add1 n))
+        var)))
+
 (define (prepend-argument evaluator val pcontext)
   (define pts
     (for/list ([(pt ex) (in-pcontext pcontext)])
@@ -132,7 +140,7 @@
 
   (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf) ctx)))
 
-  (define var (gensym 'branch))
+  (define var (deterministic-branch-var ctx))
   (define ctx* (context-extend ctx var repr))
   (define progs
     (for/list ([alt (in-list alts)])


### PR DESCRIPTION
This PR aims to fix a pretty dumb issue we discovered with `no-choose-alts`: every call to `bsearch`, even if the branch expression was identical, would add to the batch. That's because the batch was using a gensym, so every output expression was different even if it was basically the same. The fix in this PR is to derive a deterministic branch name.