### PR TITLE
Only check the start program for critical subexpressions

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -103,13 +103,13 @@
 
 (define (exprs-to-branch-on batch start-prog ctx)
   (define exprs (batch-exprs batch))
-  (define start-critexprs (all-critical-subexpressions (exprs start-prog) ctx))
+  (define start-expr (exprs start-prog))
   ;; We can only binary search if the branch expression is critical
-  ;; for the start program.
-  (define branch-exprs
-    (filter (λ (e) (equal? (representation-type (repr-of e ctx)) 'real)) start-critexprs))
-  ;; Convert to batchrefs
-  (map (curry batch-add! batch) branch-exprs))
+  ;; for the start program and is real-typed.
+  (for/list ([subexpr (set-union (context-vars ctx) (all-subexpressions start-expr))]
+             #:when (critical-subexpression? start-expr subexpr)
+             #:when (equal? (representation-type (repr-of subexpr ctx)) 'real))
+    (batch-add! batch subexpr)))
 
 ;; Requires that expr is not a λ expression
 (define (critical-subexpression? expr subexpr)
@@ -117,15 +117,6 @@
   (define replaced-expr (replace-expression expr subexpr 1))
   (define non-crit-vars (free-variables replaced-expr))
   (and (not (null? crit-vars)) (null? (set-intersect crit-vars non-crit-vars))))
-
-;; Requires that prog is a λ expression
-(define (all-critical-subexpressions expr ctx)
-  ;; We append all variables here in case of (λ (x y) 0) or similar,
-  ;; where the variables do not appear in the body but are still worth
-  ;; splitting on
-  (for/list ([subexpr (set-union (context-vars ctx) (all-subexpressions expr))]
-             #:when (critical-subexpression? expr subexpr))
-    subexpr))
 
 (define (brf-values* batch brfs ctx pcontext)
   (define count (length brfs))


### PR DESCRIPTION
Only "critical subexpressions" can be in branches created by `regimes`. Currently a branch expression must be critical in the start program, and at least one regime alt. In retrospect, the start program will probably be a regime alt, so the second clause does nothing and wastes time.