### PR TITLE
Change pareto-regimes into a single big DP

### DIFF
--- a/bench/mathematics/distance-on-a-great-circle.fpcore
+++ b/bench/mathematics/distance-on-a-great-circle.fpcore
@@ -1,0 +1,17 @@
+; -*- mode: scheme -*-
+
+(FPCore (R lambda1 lambda2 phi1 phi2)
+ :name "Distance on a great circle"
+ (let ((dlambda (- lambda1 lambda2)))
+   (let ((dphi (- phi1 phi2)))
+     (let ((a
+            (+
+             (pow (sin (/ dphi 2)) 2)
+             (* (* (*
+                     (cos phi1)
+                     (cos phi2))
+                   (sin (/ dlambda 2)))
+                (sin (/ dlambda 2))))))
+       (let ((c (* 2 (atan2 (sqrt a) (sqrt (- 1 a))))))
+         (let ((d (* R c)))
+           d))))))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -4,6 +4,7 @@
          "../utils/alternative.rkt"
          "../utils/common.rkt"
          "../utils/float.rkt"
+         "../utils/pareto.rkt"
          "../utils/timeline.rkt"
          "../syntax/types.rkt"
          "../syntax/batch.rkt"
@@ -26,9 +27,50 @@
   [(define (write-proc opt port mode)
      (fprintf port "#<option ~a>" (option-split-indices opt)))])
 
+(define (option-score opt)
+  (+ (errors-score (option-errors opt)) (length (option-split-indices opt))))
+
+(define (option-max-alt-index opt)
+  (si-cidx (argmax si-cidx (option-split-indices opt))))
+
+(define (option->pareto-point opt)
+  (pareto-point (option-max-alt-index opt) (option-score opt) (list opt)))
+
+(define (option-curve options)
+  (for/fold ([curve '()]) ([opt (in-vector options)])
+    (pareto-union (list (option->pareto-point opt)) curve #:combine append)))
+
+(define (log-option! batch err-cols-vec opt ctx)
+  (define alts* (option-alts opt))
+  (define alt-count (length alts*))
+  (timeline-push! 'inputs (batch->jsexpr batch (map alt-expr alts*)))
+  (timeline-push! 'count alt-count (length (option-split-indices opt)))
+  (define output-brfs
+    (for/list ([sidx (option-split-indices opt)])
+      (alt-expr (list-ref alts* (si-cidx sidx)))))
+  (timeline-push! 'outputs (batch->jsexpr batch output-brfs))
+  (define err-lsts*
+    (for/list ([errs (in-vector err-cols-vec 0 alt-count)])
+      (vector->list errs)))
+  (timeline-push! 'baseline (apply min (map errors-score err-lsts*)))
+  (timeline-push! 'accuracy (errors-score (option-errors opt)))
+  (define repr (context-repr ctx))
+  (timeline-push! 'repr (~a (representation-name repr)))
+  (timeline-push! 'oracle (errors-score (apply map max err-lsts*)))
+  (define brf-repr ((batch-reprs batch ctx) (option-expr opt)))
+  (timeline-push! 'branch
+                  (batch->jsexpr batch (list (option-expr opt)))
+                  (errors-score (option-errors opt))
+                  (length (option-split-indices opt))
+                  (~a (representation-name brf-repr))))
+
 (define (pareto-regimes batch sorted start-prog ctx pcontext)
   (timeline-event! 'regimes)
   (define err-lsts (batch-errors batch (map alt-expr sorted) pcontext ctx))
+  (define err-cols-vec (list->vector (map list->vector err-lsts)))
+  (define err-bits-cols-vec
+    (for/vector ([errs (in-vector err-cols-vec)])
+      (vector->flvector (vector-map ulps->bits errs))))
   (define branches
     (if (null? sorted)
         '()
@@ -38,69 +80,18 @@
         branches
         (map (curry batch-add! batch) (context-vars ctx))))
   (define brf-vals (brf-values* batch branch-brfs ctx pcontext))
-  (let loop ([alts sorted]
-             [errs (hash)]
-             [err-lsts err-lsts])
-    (cond
-      [(null? alts) '()]
-      ; Only return one option if not pareto mode
-      [else
-       (define-values (opt new-errs)
-         (infer-splitpoints batch branch-brfs brf-vals alts err-lsts #:errs errs ctx pcontext))
-       (define high (si-cidx (argmax (λ (x) (si-cidx x)) (option-split-indices opt))))
-       (cons opt (loop (take alts high) new-errs (take err-lsts high)))])))
-
-;; `infer-splitpoints` and `combine-alts` are split so the mainloop
-;; can insert a timeline break between them.
-
-(define (infer-splitpoints batch
-                           branch-brfs
-                           brf-vals
-                           alts
-                           err-lsts*
-                           #:errs [cerrs (hash)]
-                           ctx
-                           pcontext)
-  (timeline-push! 'inputs (batch->jsexpr batch (map alt-expr alts)))
-  (define brf-data (map cons branch-brfs brf-vals))
-  (define sorted-brfs
-    (sort brf-data (lambda (x y) (< (hash-ref cerrs (car x) -1) (hash-ref cerrs (car y) -1)))))
-  (define err-cols-vec (list->vector (map list->vector err-lsts*)))
-  (define err-bits-cols-vec
-    (for/vector ([errs (in-vector err-cols-vec)])
-      (vector->flvector (vector-map ulps->bits errs))))
   (define pts-vec (pcontext-points pcontext))
-
-  ;; invariant:
-  ;; errs[bexpr] is some best option on branch expression bexpr computed on more alts than we have right now.
-  (define-values (best best-err errs)
-    (for/fold ([best '()]
-               [best-err +inf.0]
-               [errs cerrs]
-               #:result (values best best-err errs))
-              ([(brf brf-vals) (in-dict sorted-brfs)]
-               ;; stop if we've computed this (and following) branch-brf on more alts and it's still worse
-               #:break (> (hash-ref cerrs brf -1) best-err))
-      (define opt (option-on-brf batch alts err-cols-vec err-bits-cols-vec pts-vec brf brf-vals ctx))
-      (define err
-        (+ (errors-score (option-errors opt))
-           (length (option-split-indices opt)))) ;; one-bit penalty per split
-      (define new-errs (hash-set errs brf err))
-      (if (< err best-err)
-          (values opt err new-errs)
-          (values best best-err new-errs))))
-
-  (timeline-push! 'count (length alts) (length (option-split-indices best)))
-  (define output-brfs
-    (for/list ([sidx (option-split-indices best)])
-      (alt-expr (list-ref alts (si-cidx sidx)))))
-  (timeline-push! 'outputs (batch->jsexpr batch output-brfs))
-  (timeline-push! 'baseline (apply min (map errors-score err-lsts*)))
-  (timeline-push! 'accuracy (errors-score (option-errors best)))
-  (define repr (context-repr ctx))
-  (timeline-push! 'repr (~a (representation-name repr)))
-  (timeline-push! 'oracle (errors-score (apply map max err-lsts*)))
-  (values best errs))
+  (define curve
+    (for/fold ([curve '()]) ([(brf brf-vals) (in-dict (map cons branch-brfs brf-vals))])
+      (define options
+        (option-table-on-brf batch sorted err-cols-vec err-bits-cols-vec pts-vec brf brf-vals ctx))
+      (pareto-union (option-curve options) curve #:combine append)))
+  (define opts
+    (for/list ([ppt (in-list curve)])
+      (car (pareto-point-data ppt))))
+  (for ([opt (in-list opts)])
+    (log-option! batch err-cols-vec opt ctx))
+  opts)
 
 (define (exprs-to-branch-on batch start-prog ctx)
   (define exprs (batch-exprs batch))
@@ -132,7 +123,7 @@
       (vector-set! (vector-ref vals i) p out)))
   (vector->list vals))
 
-(define (option-on-brf batch alts err-cols-vec err-bits-cols-vec pts-vec brf brf-vals-vec ctx)
+(define (option-table-on-brf batch alts err-cols-vec err-bits-cols-vec pts-vec brf brf-vals-vec ctx)
   (define timeline-stop! (timeline-start! 'times (batch->jsexpr batch (list brf))))
   (define repr ((batch-reprs batch ctx) brf))
   (define sorted-indices
@@ -148,15 +139,15 @@
           (for/list ([idx (in-vector sorted-indices 1)]
                      [prev-idx (in-vector sorted-indices 0 (sub1 (vector-length sorted-indices)))])
             (</total (vector-ref brf-vals-vec prev-idx) (vector-ref brf-vals-vec idx) repr))))
-  (define split-indices (infer-split-indices err-bits-cols-vec sorted-indices can-split?))
+  (define split-indices-table (infer-split-indices/all err-bits-cols-vec sorted-indices can-split?))
+  (define prefix-alts
+    (for/list ([alt-count (in-range 1 (add1 (length alts)))])
+      (take alts alt-count)))
   (define out
-    (option split-indices alts pts* brf (pick-errors split-indices sorted-indices err-cols-vec)))
+    (for/vector ([alts* (in-list prefix-alts)]
+                 [split-indices (in-vector split-indices-table)])
+      (option split-indices alts* pts* brf (pick-errors split-indices sorted-indices err-cols-vec))))
   (timeline-stop!)
-  (timeline-push! 'branch
-                  (batch->jsexpr batch (list brf))
-                  (errors-score (option-errors out))
-                  (length split-indices)
-                  (~a (representation-name repr)))
   out)
 
 (define/contract (pick-errors split-indices sorted-indices err-cols-vec)
@@ -184,8 +175,10 @@
     (define-values (batch brfs) (progs->batch (list expr)))
     (define brf (car brfs))
     (define brf-vals (car (brf-values* batch (list brf) ctx pctx)))
+    (define options
+      (option-table-on-brf batch alts err-cols-vec err-bits-cols-vec pts-vec brf brf-vals ctx))
     (check (lambda (x y) (equal? (map si-cidx (option-split-indices x)) y))
-           (option-on-brf batch alts err-cols-vec err-bits-cols-vec pts-vec brf brf-vals ctx)
+           (vector-ref options (sub1 (vector-length options)))
            goal))
 
   ;; This is a basic sanity test
@@ -199,15 +192,10 @@
   (test-regimes `(if.f64 (==.f64 x ,(literal 0.5 'binary64)) ,(literal 1 'binary64) (NAN.f64))
                 '(1 0)))
 
-;; Given error-lsts, returns a list of sp objects representing where the optimal splitpoints are.
-(define (valid-splitindices? can-split? split-indices)
-  (and (for/and ([pidx (map si-pidx (drop-right split-indices 1))])
-         (and (> pidx 0) (list-ref can-split? pidx)))
-       (= (si-pidx (last split-indices)) (length can-split?))))
-
 (module core typed/racket
   (provide (struct-out si)
-           infer-split-indices)
+           infer-split-indices
+           infer-split-indices/all)
   (require math/flonum)
 
   ;; Struct representing a splitindex
@@ -220,14 +208,23 @@
     (vector->flvector (vector-map (lambda ([point-idx : Integer]) (flvector-ref alt-errors point-idx))
                                   sorted-indices)))
 
-  ;; This is the core main loop of the regimes algorithm.
-  ;; Takes in alt-major error columns, point-sorting indices, and a list of
-  ;; split indices to determine when it's ok to split for another alt.
-  ;; Returns a list of split indices saying which alt to use for which
-  ;; range of points. Starting at 1 going up to num-points.
-  ;; Alts are indexed 0 and points are index 1.
-  (: infer-split-indices (-> (Vectorof FlVector) (Vectorof Integer) (Listof Boolean) (Listof si)))
-  (define (infer-split-indices err-bits-cols sorted-indices can-split)
+  (: reconstruct-split-indices (-> (Vectorof Integer) (Vectorof Integer) Integer (Listof si)))
+  (define (reconstruct-split-indices result-alt-idxs result-prev-idxs number-of-points)
+    (let loop ([i (- number-of-points 1)]
+               [rest (ann null (Listof si))])
+      (define alt-idx (vector-ref result-alt-idxs i))
+      (define next (vector-ref result-prev-idxs i))
+      (define sis (cons (si alt-idx (+ i 1)) rest))
+      (if (< next i)
+          (loop next sis)
+          sis)))
+
+  ;; Computes regimes for every alt prefix in one pass. The output at
+  ;; index i is the optimal split list when only alts [0..i] are
+  ;; available.
+  (: infer-split-indices/all
+     (-> (Vectorof FlVector) (Vectorof Integer) (Listof Boolean) (Vectorof (Listof si))))
+  (define (infer-split-indices/all err-bits-cols sorted-indices can-split)
     ;; Converts the list to vector form for faster processing
     (define can-split-vec (list->vector can-split))
     (define flvec-psums
@@ -241,99 +238,97 @@
     ;; min-weight is used as penalty to favor not adding split points
     (define min-weight (fl number-of-points))
 
-    ;; These 3 vectors are will contain the output data and be used for
-    ;; determining which alt is best for a given point
-    (define result-error-sums (make-flvector number-of-points +inf.0))
-    (define result-alt-idxs (make-vector number-of-points 0))
-    (define result-prev-idxs (make-vector number-of-points number-of-points))
+    (: result-error-sums* (Vectorof FlVector))
+    (: result-alt-idxs* (Vectorof (Vectorof Integer)))
+    (: result-prev-idxs* (Vectorof (Vectorof Integer)))
+    (define result-error-sums*
+      (for/vector :
+        (Vectorof FlVector)
+        ([_ (in-range number-of-alts)])
+        (make-flvector number-of-points +inf.0)))
+    (define result-alt-idxs*
+      (for/vector :
+        (Vectorof (Vectorof Integer))
+        ([_ (in-range number-of-alts)])
+        (make-vector number-of-points 0)))
+    (define result-prev-idxs*
+      (for/vector :
+        (Vectorof (Vectorof Integer))
+        ([_ (in-range number-of-alts)])
+        (make-vector number-of-points number-of-points)))
 
-    (for ([alt-idx (in-naturals)]
-          [alt-errors (in-vector flvec-psums)])
-      (for ([point-idx (in-range number-of-points)]
-            [err (in-flvector alt-errors)]
-            #:when (< err (flvector-ref result-error-sums point-idx)))
-        (flvector-set! result-error-sums point-idx err)
-        (vector-set! result-alt-idxs point-idx alt-idx)))
+    ;; Initialize with the best single-alt option for each alt prefix.
+    (for ([point-idx (in-range number-of-points)])
+      (define best-error +inf.0)
+      (define best-alt-idx 0)
+      (for ([alt-idx (in-range number-of-alts)])
+        (define alt-errors (vector-ref flvec-psums alt-idx))
+        (define err (flvector-ref alt-errors point-idx))
+        (when (< err best-error)
+          (set! best-error err)
+          (set! best-alt-idx alt-idx))
+        (flvector-set! (vector-ref result-error-sums* alt-idx) point-idx best-error)
+        (vector-set! (vector-ref result-alt-idxs* alt-idx) point-idx best-alt-idx)
+        (vector-set! (vector-ref result-prev-idxs* alt-idx) point-idx number-of-points)))
 
-    ;; Vectors are now filled with starting data. Beginning main loop of the
-    ;; regimes algorithm.
-
-    ;; Vectors used to determine if our current alt is better than our running
-    ;; best alt.
-    (: best-alt-idxs (Vectorof Integer))
-    (: best-alt-costs FlVector)
-    (define best-alt-idxs (make-vector number-of-points number-of-alts))
-    (define best-alt-costs (make-flvector number-of-points))
-
-    (for ([point-idx (in-range number-of-points)]
-          [current-alt-error (in-flvector result-error-sums)]
-          [current-alt-idx (in-vector result-alt-idxs)]
-          [current-prev-idx (in-vector result-prev-idxs)])
-      ;; Set and fill temporary vectors with starting data
-      ;; #f for best index and positive infinite for best cost
-      (vector-fill! best-alt-idxs -1)
-      (for ([i (in-range number-of-points)])
-        (flvector-set! best-alt-costs i +inf.0))
-
-      ;; For each alt loop over its vector of errors
-      (for ([alt-idx (in-naturals)]
-            [alt-error-sums (in-vector flvec-psums)])
-        ;; Loop over the points up to our current point
-        (for ([prev-split-idx (in-range point-idx)]
-              [prev-alt-error-sum (in-flvector alt-error-sums)]
-              [best-alt-idx (in-vector best-alt-idxs)]
-              [best-alt-cost (in-flvector best-alt-costs)]
-              [can-split (in-vector can-split-vec 1)]
-              #:when can-split)
-          ;; Check if we can add a split point
-          ;; compute the difference between the current error-sum and previous
-          (let ([current-error (- (flvector-ref alt-error-sums point-idx) prev-alt-error-sum)])
-            ;; if we have not set the best alt yet or
-            ;; the current alt-error-sum is less then previous
-            (when (or (= best-alt-idx number-of-alts) (< current-error best-alt-cost))
-              ;; update best cost and best index
-              (flvector-set! best-alt-costs prev-split-idx current-error)
-              (vector-set! best-alt-idxs prev-split-idx alt-idx)))))
-      ;; We have now have the index of the best alt and its error up to our
-      ;; current point-idx.
-      ;; Now we compare against our current best saved in the 3 vectors above
+    ;; Main DP loop. For each point and split, scan alt prefixes once
+    ;; while carrying the best suffix-alt candidate.
+    (for ([point-idx (in-range number-of-points)])
       (for ([prev-split-idx (in-range point-idx)]
-            [r-error-sum (in-flvector result-error-sums)]
-            [best-alt-idx (in-vector best-alt-idxs)]
-            [best-alt-cost (in-flvector best-alt-costs)]
             [can-split (in-vector can-split-vec 1)]
             #:when can-split)
-        ;; Re compute the error sum for a potential better alt
-        (define alt-error-sum (+ r-error-sum best-alt-cost min-weight))
-        ;; Check if the new alt-error-sum is better then the current
-        (define set-cond
-          ;; give benefit to previous best alt
-          (cond
-            [(< alt-error-sum current-alt-error) #t]
-            ;; Tie breaker if error are the same favor first alt
-            [(and (= alt-error-sum current-alt-error) (> current-alt-idx best-alt-idx)) #t]
-            ;; Tie breaker for if error and alt is the same
-            [(and (= alt-error-sum current-alt-error)
-                  (= current-alt-idx best-alt-idx)
-                  (> current-prev-idx prev-split-idx))
-             #t]
-            [else #f]))
-        (when set-cond
-          (set! current-alt-error alt-error-sum)
-          (set! current-alt-idx best-alt-idx)
-          (set! current-prev-idx prev-split-idx)))
-      (flvector-set! result-error-sums point-idx current-alt-error)
-      (vector-set! result-alt-idxs point-idx current-alt-idx)
-      (vector-set! result-prev-idxs point-idx current-prev-idx))
+        (define best-segment-cost +inf.0)
+        (define best-segment-alt-idx number-of-alts)
+        (for ([alt-idx (in-range number-of-alts)])
+          (define alt-error-sums (vector-ref flvec-psums alt-idx))
+          (define segment-error
+            (- (flvector-ref alt-error-sums point-idx) (flvector-ref alt-error-sums prev-split-idx)))
+          (when (< segment-error best-segment-cost)
+            (set! best-segment-cost segment-error)
+            (set! best-segment-alt-idx alt-idx))
 
-    ;; Loop over results vectors in reverse and build the output split index list
-    (let loop ([i (- number-of-points 1)]
-               [rest (ann null (Listof si))])
-      (define alt-idx (vector-ref result-alt-idxs i))
-      (define next (vector-ref result-prev-idxs i))
-      (define sis (cons (si alt-idx (+ i 1)) rest))
-      (if (< next i)
-          (loop next sis)
-          sis))))
+          (define result-error-sums (vector-ref result-error-sums* alt-idx))
+          (define result-alt-idxs (vector-ref result-alt-idxs* alt-idx))
+          (define result-prev-idxs (vector-ref result-prev-idxs* alt-idx))
+
+          (define current-alt-error (flvector-ref result-error-sums point-idx))
+          (define current-alt-idx (vector-ref result-alt-idxs point-idx))
+          (define current-prev-idx (vector-ref result-prev-idxs point-idx))
+          (define alt-error-sum
+            (+ (flvector-ref result-error-sums prev-split-idx) best-segment-cost min-weight))
+
+          (define set-cond
+            (cond
+              [(< alt-error-sum current-alt-error) #t]
+              [(and (= alt-error-sum current-alt-error) (> current-alt-idx best-segment-alt-idx)) #t]
+              [(and (= alt-error-sum current-alt-error)
+                    (= current-alt-idx best-segment-alt-idx)
+                    (> current-prev-idx prev-split-idx))
+               #t]
+              [else #f]))
+          (when set-cond
+            (flvector-set! result-error-sums point-idx alt-error-sum)
+            (vector-set! result-alt-idxs point-idx best-segment-alt-idx)
+            (vector-set! result-prev-idxs point-idx prev-split-idx)))))
+
+    (for/vector :
+      (Vectorof (Listof si))
+      ([alt-idx (in-range number-of-alts)])
+      (reconstruct-split-indices (vector-ref result-alt-idxs* alt-idx)
+                                 (vector-ref result-prev-idxs* alt-idx)
+                                 number-of-points)))
+
+  ;; This is the core main loop of the regimes algorithm.
+  ;; Takes in alt-major error columns, point-sorting indices, and a list of
+  ;; split indices to determine when it's ok to split for another alt.
+  ;; Returns a list of split indices saying which alt to use for which
+  ;; range of points. Starting at 1 going up to num-points.
+  ;; Alts are indexed 0 and points are index 1.
+  (: infer-split-indices (-> (Vectorof FlVector) (Vectorof Integer) (Listof Boolean) (Listof si)))
+  (define (infer-split-indices err-bits-cols sorted-indices can-split)
+    (define all-split-indices (infer-split-indices/all err-bits-cols sorted-indices can-split))
+    (if (zero? (vector-length all-split-indices))
+        null
+        (vector-ref all-split-indices (sub1 (vector-length all-split-indices))))))
 
 (require (submod "." core))


### PR DESCRIPTION
This PR rewrites the regimes phase from scratch to use a fancier, scarier DP that computes the whole pareto curve in one go. Consequently it massively simplifies the rest of the regimes code.

Here's the intuition for the DP:

- Suppose we have a set of alts A, in order from cheapest to most expensive. We want the cheapest regime split, per branch expression B, for *every prefix of* A.
- Fix the branch expression B. Consider the best regime split that covers indices 0..j.
- This split uses some alt in A for the last leg i..j, plus the best regime split that covers indices 0..i
- To get the pareto curve, first consider the best choice of alt in i..j for each max cost point. Then walk the pareto curves for 0..i (across all i) and the curve for i..j in parallel.
- The result is the pareto curve for 0..j

I'm seeing 2x speedups on some regimes-heavy benchmarks, which BTW is a lot of benchmarks in `no-choose-alts` mode.