### PR TITLE
Fix `pcontext->json` for mixed-repr expressions

### DIFF
--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -491,8 +491,8 @@
 (define (make-sample-result herbie-result job-id)
   (define test (job-result-test herbie-result))
   (define pctx (job-result-backend herbie-result))
-  (define repr (context-repr (test-context test)))
-  (hasheq 'points (pcontext->json pctx repr)))
+  (define ctx (test-context test))
+  (hasheq 'points (pcontext->json pctx ctx)))
 
 (define (make-cost-result herbie-result job-id)
   (hasheq 'cost (job-result-backend herbie-result)))


### PR DESCRIPTION
In theory, Herbie supports mixed-repr expressions like:

```
(FPCore ((! :precision binary32 x) y)
  :precision binary64
  ...)
```

In practice support has never been good. Anyway, here's a bug Artem fixed in #1448 that I'd like to just merge directly so it doesn't live in that (big) PR.