### PR TITLE
Undo plot changes in arrays support

### DIFF
--- a/src/reports/pages.rkt
+++ b/src/reports/pages.rkt
@@ -13,6 +13,14 @@
          make-page-timeout
          page-error-handler)
 
+(define (make-points-json-safe result-hash)
+  (with-handlers ([exn:fail? (lambda (e)
+                               (eprintf "Error generating `points.json` for \"~a\":\n  ~a\n"
+                                        (hash-ref result-hash 'name)
+                                        (exn-message e))
+                               '())])
+    (make-points-json result-hash)))
+
 (define (all-pages result-hash)
   (define good? (equal? (hash-ref result-hash 'status) "success"))
   (define default-pages '("graph.html" "timeline.html" "timeline.json"))
@@ -46,7 +54,7 @@
      (write-html (make-timeline name (hash-ref result-hash 'timeline) #:path "..") out)]
     ["timeline.json" (write-json (hash-ref result-hash 'timeline) out)]
     ["profile.json" (write-json (hash-ref result-hash 'profile) out)]
-    ["points.json" (write-json (make-points-json result-hash) out)]))
+    ["points.json" (write-json (make-points-json-safe result-hash) out)]))
 
 (define (make-graph-html result-hash output? profile?)
   (define status (hash-ref result-hash 'status))


### PR DESCRIPTION
#1448 had a big diff from wrapping `plot.rkt` in a try-catch block. That's probably still necessary (can't plot arrays!) but it can have a small diff instead.