### PR TITLE
Move special-values handling to `ulp-difference`

### DIFF
--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -43,16 +43,16 @@
 ;; Local error is high when `f` is highly sensitive to rounding error
 ;; in its inputs `x` and `y`.
 
-(define (local-error exact node repr get-exact)
+(define (local-error exact node ulps get-exact)
   (match node
     [(? literal?) 1]
     [(? symbol?) 1]
-    [(approx _ impl) (ulp-difference exact (get-exact impl) repr)]
+    [(approx _ impl) (ulps exact (get-exact impl))]
     [`(if ,c ,ift ,iff) 1]
     [(list f args ...)
      (define argapprox (map get-exact args))
      (define approx (apply (impl-info f 'fl) argapprox))
-     (ulp-difference exact approx repr)]))
+     (ulps exact approx)]))
 
 (define (make-matrix roots pcontext)
   (for/vector #:length (vector-length roots)
@@ -63,6 +63,7 @@
 (define (compute-local-errors subexprss ctx pcontext)
   (define exprs-list (append* subexprss)) ; unroll subexprss
   (define reprs-list (map (curryr repr-of ctx) exprs-list))
+  (define ulps-list (map repr-ulps reprs-list))
   (define ctx-list
     (for/list ([subexpr (in-list exprs-list)]
                [repr (in-list reprs-list)])
@@ -83,10 +84,10 @@
       (vector-ref exacts (vector-member (batchref-idx brf) roots)))
     (for ([expr (in-list exprs-list)]
           [brf brfs]
-          [repr (in-list reprs-list)]
+          [ulps (in-list ulps-list)]
           [exact (in-vector exacts)]
           [expr-idx (in-naturals)])
-      (define err (local-error exact (deref brf) repr get-exact))
+      (define err (local-error exact (deref brf) ulps get-exact))
       (vector-set! (vector-ref errs expr-idx) pt-idx err)))
 
   (define n 0)
@@ -117,6 +118,7 @@
   ;; And the real result
   (define spec-list (map prog->spec exprs-list))
   (define reprs-list (map (curryr repr-of ctx) exprs-list))
+  (define ulps-list (map repr-ulps reprs-list))
   (define ctx-list
     (for/list ([subexpr (in-list exprs-list)]
                [repr (in-list reprs-list)])
@@ -164,13 +166,13 @@
     (define pt* (vector-append pt (remove-infinities actuals reprs-list)))
     (define deltas (list->vector (delta-fn pt*)))
 
-    (for ([repr (in-list reprs-list)]
+    (for ([ulps (in-list ulps-list)]
           [brf brfs]
           [exact (in-vector exacts)]
           [actual (in-vector actuals)]
           [delta (in-vector deltas)]
           [expr-idx (in-naturals)])
-      (define ulp-err (local-error exact (deref brf) repr get-exact))
+      (define ulp-err (local-error exact (deref brf) ulps get-exact))
       (vector-set! (vector-ref exacts-out expr-idx) pt-idx exact)
       (vector-set! (vector-ref approx-out expr-idx) pt-idx actual)
       (vector-set! (vector-ref ulp-errs expr-idx) pt-idx ulp-err)

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -77,7 +77,7 @@
   (generate-errors fn pcontext ctx num-exprs))
 
 (define (generate-errors fn pcontext ctx num-exprs)
-  (define repr (context-repr ctx))
+  (define ulps (repr-ulps (context-repr ctx)))
 
   ;; This generates the errors array in reverse because that's how lists work
   (define num-points (pcontext-length pcontext))
@@ -87,5 +87,5 @@
     (define outs (fn point))
     (for ([out (in-vector outs)]
           [i (in-naturals)])
-      (vector-set! results i (cons (ulp-difference out exact repr) (vector-ref results i)))))
+      (vector-set! results i (cons (ulps out exact) (vector-ref results i)))))
   (vector->list results))

--- a/src/core/rival.rkt
+++ b/src/core/rival.rkt
@@ -49,9 +49,10 @@
                 (r3:discretization (repr->disc-type repr) target (representation-bf->repr repr)))))
       (cons r2:boolean-discretization
             (for/list ([repr (in-list reprs)])
+              (define ulps (repr-ulps repr))
               (r2:discretization (representation-total-bits repr)
                                  (representation-bf->repr repr)
-                                 (lambda (x y) (- (ulp-difference x y repr) 1)))))))
+                                 (lambda (x y) (- (ulps x y) 1)))))))
 
 (define (exn:rival:invalid? e)
   (or (r2:exn:rival:invalid? e) (r3:exn:rival:invalid? e)))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -35,6 +35,7 @@
 (define (check-rule test-rule)
   (match-define (rule name p1 p2 _) test-rule)
   (define ctx (env->ctx p1 p2))
+  (define ulps (repr-ulps (context-repr ctx)))
 
   (define-values (batch brfs) (progs->batch (list p1 (drop-sound p2))))
   (match-define (list pts exs1 exs2)
@@ -46,9 +47,7 @@
         [v1 (in-list exs1)]
         [v2 (in-list exs2)])
     (with-check-info* (map make-check-info (context-vars ctx) (vector->list pt))
-                      (λ ()
-                        (with-check-info (['lhs v1] ['rhs v2])
-                                         (check-eq? (ulp-difference v1 v2 (context-repr ctx)) 1))))))
+                      (λ () (with-check-info (['lhs v1] ['rhs v2]) (check-eq? (ulps v1 v2) 1))))))
 
 (module+ main
   (num-test-points (* 100 (num-test-points)))

--- a/src/utils/float.rkt
+++ b/src/utils/float.rkt
@@ -7,7 +7,7 @@
          "../syntax/types.rkt"
          "../utils/errors.rkt")
 
-(provide ulp-difference
+(provide repr-ulps
          ulps->bits
          midpoint
          two-midpoints
@@ -20,15 +20,19 @@
          real->repr
          repr->real)
 
-(define (ulp-difference x y repr)
+(define (repr-ulps repr)
   (define ->ordinal (representation-repr->ordinal repr))
   (define special? (representation-special-value? repr))
   (define max-error (+ 1 (expt 2 (representation-total-bits repr))))
-  (if (or (special? x) (special? y))
-      max-error
-      (if (eq? repr <binary64>)
-          (+ 1 (abs (flonums-between x y)))
-          (+ 1 (abs (- (->ordinal y) (->ordinal x)))))))
+  (if (eq? repr <binary64>)
+      (lambda (x y)
+        (if (or (special? x) (special? y))
+            max-error
+            (+ 1 (abs (flonums-between x y)))))
+      (lambda (x y)
+        (if (or (special? x) (special? y))
+            max-error
+            (+ 1 (abs (- (->ordinal y) (->ordinal x))))))))
 
 ;; Returns the midpoint of the representation's ordinal values,
 ;; not the real-valued midpoint


### PR DESCRIPTION
Special values are NaNs. Right now we handle them in `generate-errors` but handling them in `ulp-difference` is a lot cleaner. Maybe it's slower? I hope not! This PR is split out of #1448.