### PR TITLE
Fix egglog rewrite rollback when e-graphs exceed the size limit

### DIFF
--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -425,16 +425,22 @@
     (define lines1 (egglog-extract subproc '(extract (const1) 1)))
     (check-equal? lines1 '((Var "x")))
 
-    ;; Print size
+    (match-define (list '() (list "false"))
+      (egglog-send subproc '(run unsound-rule 1) '(extract (unsound))))
+    (check-equal? (egglog-total-size subproc) 7)
 
-    (match-define (list node-values '() (list "false"))
-      (egglog-send subproc '(print-size) '(run unsound-rule 1) '(extract (unsound))))
-    (define parsed-node-values
-      (for/list ([entry (in-list (with-input-from-string (string-join node-values "\n") read))])
-        (match entry
-          [(list relation count) (cons relation count)])))
-    (check-equal? (sort parsed-node-values symbol<? #:key car)
-                  '((Add . 1) (Var . 2) (const1 . 1) (const2 . 1) (const3 . 1) (unsound . 1)))
+    (egglog-send subproc
+                 '(push)
+                 '(let $extra1 (Var
+                                "z")
+                    )
+                 '(let $extra2 (Add
+                                $extra1
+                                $extra1)
+                    ))
+    (check-equal? (egglog-total-size subproc) 11)
+    (egglog-send subproc '(pop))
+    (check-equal? (egglog-total-size subproc) 7)
 
     ;; last two
     (check-equal? '((Var "y")) (egglog-extract subproc '(extract (const2) 1)))

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -556,19 +556,16 @@
   (define node-limit (*node-limit*))
   (define iter-limit (*default-egglog-iter-limit*))
 
-  ;; Use egglog's :until guard with get-size! to stop when node limit is reached.
-  ;; After each iteration, we check for unsound merges via bad-merge-rule.
-  ;; The schedule runs until:
-  ;;   1. Node limit is reached (get-size! >= node-limit)
-  ;;   2. Saturation (no more progress)
-  ;;   3. Iter limit is reached
-  ;;   4. Unsoundness is detected (bad-merge? becomes true)
-
-  (egglog-send subproc
-               `(run-schedule (repeat ,iter-limit
-                                      (seq (run ,tag :until (<= ,node-limit (get-size!)))
-                                           (run const-fold :until (<= ,node-limit (get-size!)))
-                                           (run bad-merge-rule :until (bad-merge?))))))
+  ;; Rewrite one iteration at a time and keep a checkpoint before each step.
+  ;; If a rewrite iteration pushes the e-graph past the node limit, pop once to
+  ;; roll back just that iteration and stop rewriting.
+  (let loop ([iter 0])
+    (when (< iter iter-limit)
+      (egglog-send subproc '(push))
+      (egglog-send subproc `(run ,tag 1) '(run const-fold 1) '(run bad-merge-rule 1))
+      (if (> (egglog-total-size subproc) node-limit)
+          (egglog-send subproc '(pop))
+          (loop (add1 iter)))))
   (void))
 
 (define (egglog-num? id)

--- a/src/core/egglog-subprocess.rkt
+++ b/src/core/egglog-subprocess.rkt
@@ -5,6 +5,7 @@
 (provide (struct-out egglog-subprocess)
          create-new-egglog-subprocess
          egglog-send
+         egglog-total-size
          egglog-extract
          egglog-multi-extract
          egglog-subprocess-close)
@@ -66,6 +67,10 @@
       (if (equal? next "(done)")
           (reverse out)
           (loop (cons next out))))))
+
+(define (egglog-total-size subproc)
+  (match (first (egglog-send subproc '(extract (get-size!))))
+    [(list size) (string->number size)]))
 
 ;; Send extract commands and read results
 (define (egglog-extract subproc extract-command)


### PR DESCRIPTION
The egglog rewrite loop can overshoot the node limit in a single iteration, which lets the e-graph grow far past the intended cap before the schedule stops. I found that this sometimes makes the lowering phase run for many seconds, creating intense slowdowns. This change checkpoints each rewrite iteration and rolls it back if the resulting graph is too large. Kinda ugly—the ideal would be a hard-stop at the node limit. But it might still improve performance.

**Summary**
- Run egglog `rewrite`, `const-fold`, and `bad-merge-rule` one iteration at a time under `push`/`pop`
- Check size each iteration with `(extract (get-size!))` and roll back if it exceeds the node limit.