### PR TITLE
Fix formatting on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ start-server:
 		--log infra/server.log --quiet 2>&1
 
 fmt:
-	@raco fmt -i $(shell find egg-herbie/ src/ infra/ -name '*.rkt' -not -path 'src/platforms/*.rkt' -not -path "infra/softposit.rkt")
+	@raco fmt -i $(shell find egg-herbie src infra -name '*.rkt' -not -path 'src/platforms/*.rkt' -not -path 'infra/softposit.rkt')
 
 coverage:
 	@racket infra/coverage.rkt --benchmark $(or $(BENCH),bench/hamming) $(ARGS)


### PR DESCRIPTION
When I run `make fmt` on the `main` branch, a bunch of files get modified:

```
	modified:   infra/softposit.rkt
	modified:   src/platforms/c-windows.rkt
	modified:   src/platforms/c.rkt
	modified:   src/platforms/herbie10.rkt
	modified:   src/platforms/herbie20.rkt
	modified:   src/platforms/julia.rkt
	modified:   src/platforms/math.rkt
	modified:   src/platforms/python.rkt
	modified:   src/platforms/racket.rkt
	modified:   src/platforms/reflow.rkt
	modified:   src/platforms/rival.rkt
```

Codex diagnosed this and found that on MacOS, the find tool inserts "/"s after the folders, so it would emit a path like `src//platforms/c.rkt` and not get excluded by `src/platforms/*.rkt`.

This fixes that. 

Codex says that the formatting will still work on non-MacOS, but it's hard for me to test this, so I would appreciate someone double-checking this. Another option is just formatting the platforms and softposit.rkt, not sure why they're excluded currently. 