### PR TITLE
Add egraph-unary for maximal unary context extraction

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -26,10 +26,14 @@
          egraph-prove
          egraph-best
          egraph-variations
+         egraph-unary
          egraph-analyze-rewrite-impact)
 
 (module+ test
-  (require rackunit))
+  (require rackunit
+           "../syntax/float.rkt"
+           "../syntax/load-platform.rkt")
+  (activate-platform! (*platform-name*)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; FFI utils
@@ -259,9 +263,6 @@
   (egg-parsed->expr (flatten-let egg-expr) ctx (context-repr ctx)))
 
 (module+ test
-  (require "../syntax/float.rkt"
-           "../syntax/load-platform.rkt")
-  (activate-platform! (*platform-name*))
   (define ctx (context '(x y z) <binary64> (make-list 3 <binary64>)))
 
   (define test-exprs
@@ -309,6 +310,80 @@
     (for ([expr extended-expr-list])
       (define egg-expr (expr->egg-expr expr ctx))
       (check-equal? (egg-expr->expr egg-expr ctx) expr))))
+
+(module+ test
+  (define (check-domain-expr domain id expr)
+    (check-equal? (hash-ref domain id) expr))
+
+  (define (compute-domain-exprs expr vars queries)
+    (define ctx (context vars <binary64> (make-list (length vars) <binary64>)))
+    (define-values (batch brfs) (progs->batch (list expr)))
+    (define runner (make-egraph batch brfs (list <binary64>) '() ctx))
+    (define egg-graph (egg-runner-egg-graph runner))
+    (define regraph (make-regraph egg-graph ctx))
+    (define canon (regraph-canon regraph))
+    (define domain-exprs (analyze-eclass-domain-exprs regraph))
+    (define (query-type expr)
+      (if (spec-prog? expr) 'real <binary64>))
+
+    (define-values (sub-batch sub-brfs) (progs->batch (map cdr queries)))
+    (define egg-ids
+      (for/list ([brf (in-list sub-brfs)])
+        (egraph_find egg-graph (first (egraph-add-exprs egg-graph sub-batch (list brf) ctx)))))
+
+    (define typed-ids
+      (for/hash ([name+expr (in-list queries)]
+                 [egg-id (in-list egg-ids)])
+        (values (car name+expr) (hash-ref canon (cons egg-id (query-type (cdr name+expr)))))))
+
+    (values typed-ids domain-exprs))
+
+  (let-values ([(typed-ids domain-exprs)
+                (compute-domain-exprs '(log (+ (exp a) (exp b)))
+                                      '(a b)
+                                      (list (cons 'root '(log (+ (exp a) (exp b))))
+                                            (cons 'a 'a)
+                                            (cons 'b 'b)
+                                            (cons 'exp-a '(exp a))
+                                            (cons 'exp-b '(exp b))
+                                            (cons 'plus-ab '(+ (exp a) (exp b)))))])
+    (define root-id (hash-ref typed-ids 'root))
+    (define plus-id (hash-ref typed-ids 'plus-ab))
+    (define exp-a-id (hash-ref typed-ids 'exp-a))
+    (define exp-b-id (hash-ref typed-ids 'exp-b))
+    (define a-id (hash-ref typed-ids 'a))
+    (define b-id (hash-ref typed-ids 'b))
+
+    (check-equal? (vector-ref domain-exprs a-id) (hash a-id 'x))
+    (check-equal? (vector-ref domain-exprs b-id) (hash b-id 'x))
+    (check-domain-expr (vector-ref domain-exprs exp-a-id) exp-a-id 'x)
+    (check-domain-expr (vector-ref domain-exprs exp-a-id) a-id '(exp x))
+    (check-domain-expr (vector-ref domain-exprs exp-b-id) exp-b-id 'x)
+    (check-domain-expr (vector-ref domain-exprs exp-b-id) b-id '(exp x))
+    (check-domain-expr (vector-ref domain-exprs plus-id) plus-id 'x)
+    (check-false (hash-has-key? (vector-ref domain-exprs plus-id) a-id))
+    (check-false (hash-has-key? (vector-ref domain-exprs plus-id) b-id))
+    (check-domain-expr (vector-ref domain-exprs root-id) root-id 'x)
+    (check-domain-expr (vector-ref domain-exprs root-id) plus-id '(log x)))
+
+  (let-values ([(typed-ids domain-exprs)
+                (compute-domain-exprs
+                 '(+ (exp a) (exp a))
+                 '(a)
+                 (list (cons 'a 'a) (cons 'exp-a '(exp a)) (cons 'plus-aa '(+ (exp a) (exp a)))))])
+    (define plus-id (hash-ref typed-ids 'plus-aa))
+    (define exp-a-id (hash-ref typed-ids 'exp-a))
+    (define a-id (hash-ref typed-ids 'a))
+    (check-domain-expr (vector-ref domain-exprs plus-id) plus-id 'x)
+    (check-domain-expr (vector-ref domain-exprs plus-id) exp-a-id '(+ x x))
+    (check-domain-expr (vector-ref domain-exprs plus-id) a-id '(+ (exp x) (exp x))))
+
+  (let-values
+      ([(typed-ids domain-exprs)
+        (compute-domain-exprs '(+ (exp a) (exp a)) '(a) (list (cons 'plus-aa '(+ (exp a) (exp a)))))])
+    (define plus-id (hash-ref typed-ids 'plus-aa))
+    (check-equal? (domain-exprs->maximal-exprs domain-exprs (vector-ref domain-exprs plus-id))
+                  (list '(+ (exp x) (exp x))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Proofs
@@ -740,6 +815,69 @@
 
   (values parents leaf? constants))
 
+;; Domain-expression analysis:
+;;  dom(enode n = f(e1, e2, ...)) intersects child domains on common keys
+;;  and wraps f around the corresponding child expressions.
+;;  dom(eclass e = {n1, n2, ...}) = {e -> x} union union_i dom(ni)
+(define (analyze-eclass-domain-exprs regraph)
+  (define (hash-add-new out key value)
+    (if (hash-has-key? out key)
+        out
+        (hash-set out key value)))
+
+  (define (wrap-enode op exprs)
+    (cons op exprs))
+
+  (define (enode-domain-exprs domain-exprs enode)
+    (match enode
+      [(list op ids ...)
+       (match ids
+         [(list) (hash)]
+         [(list id)
+          (define child-domain-exprs (vector-ref domain-exprs id))
+          (and child-domain-exprs
+               (for/hash ([(key expr) (in-hash child-domain-exprs)])
+                 (values key (wrap-enode op (list expr)))))]
+         [(list id ids ...)
+          (define child-domain-exprs0 (vector-ref domain-exprs id))
+          (and child-domain-exprs0
+               (for/fold ([out (hash)]) ([(key expr0) (in-hash child-domain-exprs0)])
+                 (define other-exprs
+                   (for/list ([child-id (in-list ids)])
+                     (define child-domain-exprs (vector-ref domain-exprs child-id))
+                     (and child-domain-exprs (hash-ref child-domain-exprs key #f))))
+                 (if (member #f other-exprs)
+                     out
+                     (hash-set out key (wrap-enode op (cons expr0 other-exprs))))))])]
+      [_ (hash)]))
+
+  (define domain-exprs (make-vector (vector-length (regraph-eclasses regraph)) #f))
+  (define (eclass-set-domain-exprs! domain-exprs _changed?-vec _iter eclass id)
+    (define domain-expr
+      (for/fold ([out (hash id 'x)]) ([enode (in-vector eclass)])
+        (define enode-domain-expr (enode-domain-exprs domain-exprs enode))
+        (if enode-domain-expr
+            (for/fold ([out out]) ([(key expr) (in-hash enode-domain-expr)])
+              (hash-add-new out key expr))
+            out)))
+    (define prev-domain-expr (vector-ref domain-exprs id))
+    (unless (equal? prev-domain-expr domain-expr)
+      (vector-set! domain-exprs id domain-expr))
+    (not (equal? prev-domain-expr domain-expr)))
+
+  (regraph-analyze regraph eclass-set-domain-exprs! #:analysis domain-exprs))
+
+(define (domain-exprs->maximal-exprs domain-exprs domain-expr)
+  (define keys (sort (hash-keys domain-expr) <))
+  (define maximal-keys
+    (filter (lambda (key)
+              (not (for/or ([other-key (in-list keys)]
+                            #:unless (= key other-key))
+                     (hash-has-key? (vector-ref domain-exprs key) other-key))))
+            keys))
+  (remove-duplicates (for/list ([key (in-list maximal-keys)])
+                       (hash-ref domain-expr key))))
+
 ;; Constructs a Racket egraph from an S-expr representation of
 ;; an egraph and data to translate egg IR to herbie IR.
 (define (make-regraph ptr ctx)
@@ -1165,6 +1303,7 @@
 ;;  - `egraph-prove`: return a proof that two expressions are equal
 ;;  - `egraph-best`: return a batch with the best versions of another batch
 ;;  - `egraph-variations`: return a batch with all versions of another batch
+;;  - `egraph-unary`: return maximal unary contexts for another batch
 
 ;; Herbie's version of an egg runner.
 ;; Defines parameters for running rewrite rules with egg
@@ -1275,3 +1414,22 @@
      (for/list ([id (in-list root-ids)]
                 [repr (in-list reprs)])
        (regraph-extract-variants regraph extract-id id repr))]))
+
+(define (egraph-unary runner _batch)
+  (define ctx (egg-runner-ctx runner))
+  (define root-ids (egg-runner-new-roots runner))
+  (define egg-graph (egg-runner-egg-graph runner))
+
+  (cond
+    [(egraph_is_unsound_detected egg-graph) (map (const empty) root-ids)]
+    [else
+     (define regraph (make-regraph egg-graph ctx))
+     (define domain-exprs (analyze-eclass-domain-exprs regraph))
+     (define canon (regraph-canon regraph))
+     (define reprs (egg-runner-reprs runner))
+     (for/list ([id (in-list root-ids)]
+                [repr (in-list reprs)])
+       (define id* (hash-ref canon (cons id repr) #f))
+       (if id*
+           (domain-exprs->maximal-exprs domain-exprs (vector-ref domain-exprs id*))
+           empty))]))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -129,11 +129,6 @@
 (define (set-intersect-size keys set)
   (for/sum ([key (in-list keys)] #:when (set-member? set key)) 1))
 
-(define (expr-recurse-impl expr f)
-  (match expr
-    [(approx _ impl) (f impl)]
-    [_ (expr-recurse expr f)]))
-
 ;; Converts a patch to full alt with valid history
 (define (reconstruct! starting-alts new-alts)
   (timeline-event! 'reconstruct)
@@ -285,14 +280,12 @@
      (for/list ([opt (in-list opts)])
        (match-define (option splitindices opt-alts _ brf) opt)
        (timeline-event! 'bsearch)
-       (define exprs (batch-exprs batch))
-       (define branch-expr (exprs brf))
        (define use-binary?
          (and (flag-set? 'reduce 'binary-search)
               (> (length splitindices) 1)
-              (critical-subexpression? (exprs start-prog) branch-expr)
+              (critical-subexpression? batch start-prog brf (context-vars ctx))
               (for/and ([alt (in-list opt-alts)])
-                (critical-subexpression? (exprs (alt-expr alt)) branch-expr))))
+                (critical-subexpression? batch (alt-expr alt) brf (context-vars ctx)))))
        (cond
          [(= (length splitindices) 1) (list-ref opt-alts (si-cidx (first splitindices)))]
          [use-binary? (combine-alts/binary batch opt start-prog ctx (*pcontext*))]

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -13,6 +13,7 @@
          "../utils/common.rkt"
          "../utils/pareto.rkt"
          "../syntax/float.rkt"
+         "../syntax/syntax.rkt"
          "../utils/timeline.rkt"
          "../syntax/types.rkt"
          "../syntax/batch.rkt"
@@ -27,7 +28,11 @@
 (module+ test
   (require rackunit
            "../syntax/syntax.rkt"
-           "../syntax/sugar.rkt"))
+           "../syntax/sugar.rkt")
+
+  (define (check-critical expr subexpr)
+    (define-values (batch brfs) (progs->batch (list expr)))
+    (critical-subexpression? batch (first brfs) (batch-add! batch subexpr) (free-variables expr))))
 
 (struct option (split-indices alts pts expr)
   #:transparent
@@ -90,21 +95,69 @@
     opt))
 
 (define (exprs-to-branch-on batch start-prog ctx)
-  (define exprs (batch-exprs batch))
-  (define start-expr (exprs start-prog))
+  (define reprs (batch-reprs batch ctx))
   ;; We can only binary search if the branch expression is critical
   ;; for the start program and is real-typed.
-  (for/list ([subexpr (set-union (context-vars ctx) (all-subexpressions start-expr))]
-             #:when (critical-subexpression? start-expr subexpr)
-             #:when (equal? (representation-type (repr-of subexpr ctx)) 'real))
-    (batch-add! batch subexpr)))
+  (define real-branch-brfs
+    (for/list ([sub-brf
+                (in-list (cons start-prog
+                               (critical-subexpressions batch start-prog (context-vars ctx))))]
+               #:when (equal? (representation-type (reprs sub-brf)) 'real))
+      sub-brf))
+  (if (null? real-branch-brfs)
+      (list start-prog)
+      real-branch-brfs))
 
-;; Requires that expr is not a λ expression
-(define (critical-subexpression? expr subexpr)
-  (define crit-vars (free-variables subexpr))
-  (define replaced-expr (replace-expression expr subexpr 1))
-  (define non-crit-vars (free-variables replaced-expr))
-  (and (not (null? crit-vars)) (null? (set-intersect crit-vars non-crit-vars))))
+(define (critical-subexpression? batch root-brf sub-brf vars)
+  (or (equal? root-brf sub-brf)
+      (and (member sub-brf (critical-subexpressions batch root-brf vars) equal?) #t)))
+
+(define (critical-subexpressions batch root-brf vars)
+  (define dom-parents (build-dominator-tree batch root-brf))
+  (define critical-brfs (mutable-set))
+  (define root-idx (batchref-idx root-brf))
+
+  (for ([var (in-list vars)])
+    (define brf (batch-add! batch var))
+    (define idx (batchref-idx brf))
+    (when (vector-ref dom-parents idx)
+      (let loop ([brf brf])
+        (define idx (batchref-idx brf))
+        (unless (or (= idx root-idx) (set-member? critical-brfs brf))
+          (set-add! critical-brfs brf)
+          (loop (batchref batch (vector-ref dom-parents idx)))))))
+
+  (set->list critical-brfs))
+
+(define (build-dominator-tree batch root-brf)
+  (define root-idx (batchref-idx root-brf))
+  (define dom-parents (make-vector (batch-length batch) #f))
+  (define (update-child! idx child-idx)
+    (define old-parent (vector-ref dom-parents child-idx))
+    (define new-parent
+      (if old-parent
+          (dominator-lca idx old-parent dom-parents)
+          idx))
+    (vector-set! dom-parents child-idx new-parent))
+  (vector-set! dom-parents root-idx root-idx)
+  (define (walk-body brf recurse)
+    (define idx (batchref-idx brf))
+    (expr-recurse-impl (deref brf)
+                       (lambda (child)
+                         (define child-idx (batchref-idx child))
+                         (update-child! idx child-idx)
+                         (recurse child)))
+    (void))
+  ((batch-recurse batch walk-body) root-brf)
+  dom-parents)
+
+(define (dominator-lca idx1 idx2 dom-parents)
+  (let loop ([idx1 idx1]
+             [idx2 idx2])
+    (cond
+      [(= idx1 idx2) idx1]
+      [(< idx1 idx2) (loop (vector-ref dom-parents idx1) idx2)]
+      [else (loop idx1 (vector-ref dom-parents idx2))])))
 
 (define (baseline-errors-score err-cols count)
   (for/fold ([best +inf.0]) ([err-col (in-list (take err-cols count))])
@@ -200,7 +253,25 @@
   (test-regimes `(if.f64 (==.f64 x ,(literal 0.5 'binary64)) ,(literal 1 'binary64) (NAN.f64)) '(1 0))
 
   (check-equal? (baseline-errors-score err-cols 2) 26.5)
-  (check-equal? (oracle-errors-score err-cols 2) 0.0))
+  (check-equal? (oracle-errors-score err-cols 2) 0.0)
+
+  (check-true (check-critical '(+.f64 (sin.f64 x) y) '(sin.f64 x)))
+  (check-false (check-critical '(+.f64 (sin.f64 x) x) '(sin.f64 x)))
+  (check-true (check-critical '(+.f64 x x) 'x))
+  (check-true (check-critical '(+.f64 x x) '(+.f64 x x)))
+  (check-true (check-critical '(sin.f64 x) '(sin.f64 x)))
+
+  (let ()
+    (define vec2-ctx
+      (context '(a b)
+               <binary64>
+               (list (make-array-representation #:elem <binary64> #:len 2)
+                     (make-array-representation #:elem <binary64> #:len 2))))
+    (define dot-product
+      '(+.f64 (*.f64 (ref.f64 a #s(literal 0 binary64)) (ref.f64 b #s(literal 0 binary64)))
+              (*.f64 (ref.f64 a #s(literal 1 binary64)) (ref.f64 b #s(literal 1 binary64)))))
+    (define-values (batch brfs) (progs->batch (list dot-product)))
+    (check-equal? (first (exprs-to-branch-on batch (first brfs) vec2-ctx)) (first brfs))))
 
 (define (valid-splitindices? can-split? split-indices)
   (and (for/and ([pidx (map si-pidx (drop-right split-indices 1))])

--- a/src/syntax/batch.rkt
+++ b/src/syntax/batch.rkt
@@ -7,6 +7,7 @@
 (provide progs->batch ; List<Expr> -> (Batch, List<Batchref>)
 
          expr-recurse
+         expr-recurse-impl
          (struct-out batch)
          batch-empty ; Batch
          batch-push!
@@ -53,6 +54,11 @@
     [(list op arg1 arg2 arg3) (list op (f arg1) (f arg2) (f arg3))]
     [(list op args ...) (cons op (map f args))]
     [_ expr]))
+
+(define (expr-recurse-impl expr f)
+  (match expr
+    [(approx _ impl) (f impl)]
+    [_ (expr-recurse expr f)]))
 
 (define (batch-length b)
   (dvector-length (batch-nodes b)))


### PR DESCRIPTION
Unary expressions are special in numerics: they can be efficiently and accurately approximated by polynomials. So one thing we might want is to rewrite an expression like `log(exp(a) + exp(b))` into a form like `a + log(1 + exp(b - 1))`, where there's a nice unary subcomponent like `log(1 + exp(x))`. Since this requires some rewriting, we want to do it on an e-graph.

This PR thus adds `egraph-unary`, which extracts non-trivial (not `x` or `sin(x)`) distinct unary expressions in an e-graph. It works is a pretty straightforward way, though I got here in a complicated way involving dominator trees:

- Each eclass `e` is a unary function of `e` with expression `x`
- Each enode `f(e_1, ..., e_n)` is also a unary function of `e` if each `e_i` is a unary function of `e`, with the obvious witness term

So you compute this via an eclass analysis where the value is a map `{ eclass → expr }` such that if the data for `e1` has `{ e2 → E[x] }` then `e1 = E[e2]`. Pretty neat and pretty fast! Kinda ugly to do this on the Racket side but whatever.