### PR TITLE
Add Taylor keep-rate tracking by free-variable count

### DIFF
--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -252,8 +252,8 @@
     (match (taylor-record altn)
       [(alt _ `(taylor ,start-expr ,transform ,var ,order) prevs)
        (define kept? (set-member? final-active-set altn))
-       (define nfree (set-count (free-vars start-expr)))
-       (timeline-push! 'taylor-count (~a transform) order nfree 1 (if kept? 1 0))]
+       (define nvars (min (set-count (free-vars start-expr)) 2))
+       (timeline-push! 'taylor-count (~a transform) order nvars 1 (if kept? 1 0))]
       [#f (void)]))
 
   (define repr (context-repr (*context*)))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -131,11 +131,11 @@
 
 (define (taylor-record altn)
   (match altn
-    [(alt _ `(taylor ,start-expr ,transform ,var ,order) prevs) (list (~a transform) order)]
+    [(alt _ `(taylor ,start-expr ,transform ,var ,order) prevs) altn]
     [(alt _
           `(rr ,start-expr ,end-expr ,input ,proof)
           (list (alt _ `(taylor ,prev-start-expr ,transform ,var ,order) prevs)))
-     (list (~a transform) order)]
+     (car (alt-prevs altn))]
     [_ #f]))
 ;; Converts a patch to full alt with valid history
 (define (reconstruct! starting-alts new-alts)
@@ -247,10 +247,13 @@
           'picked
           (list (length picked-alts) (set-intersect-size picked-alts final-done-set))))
   (timeline-push! 'kept data)
+  (define free-vars (batch-free-vars (*global-batch*)))
   (for ([altn (in-list patched)])
     (match (taylor-record altn)
-      [(list transform order)
-       (timeline-push! 'taylor-count transform order 1 (if (set-member? final-active-set altn) 1 0))]
+      [(alt _ `(taylor ,start-expr ,transform ,var ,order) prevs)
+       (define kept? (set-member? final-active-set altn))
+       (define nfree (set-count (free-vars start-expr)))
+       (timeline-push! 'taylor-count (~a transform) order nfree 1 (if kept? 1 0))]
       [#f (void)]))
 
   (define repr (context-repr (*context*)))

--- a/src/reports/timeline.rkt
+++ b/src/reports/timeline.rkt
@@ -295,18 +295,20 @@
               (td ,(~r (apply + (map altnum '(new fresh picked done))) #:group-sep " "))))))))
 
 (define (render-phase-taylor-counts records)
-  (define sorted-records
-    (sort (sort (sort records < #:key second) string<? #:key first) > #:key fourth))
+  (define sorted-records (sort records > #:key fifth))
   `((dt "Taylor")
-    (dd (table ((class "times"))
-               (thead (tr (th "Generated") (th "Kept") (th "% Kept") (th "Transform") (th "Order")))
-               (tbody ,@(for/list ([rec (in-list sorted-records)])
-                          (match-define (list transform order generated kept) rec)
-                          `(tr (td ,(~r generated #:group-sep " ") "×")
-                               (td ,(~r kept #:group-sep " ") "×")
-                               (td ,(format-percent kept generated))
-                               (td (code ,transform))
-                               (td ,(~a order)))))))))
+    (dd (table
+         ((class "times"))
+         (thead
+          (tr (th "Generated") (th "Kept") (th "% Kept") (th "# Vars") (th "Transform") (th "Order")))
+         (tbody ,@(for/list ([rec (in-list sorted-records)])
+                    (match-define (list transform order vars generated kept) rec)
+                    `(tr (td ,(~r generated #:group-sep " ") "×")
+                         (td ,(~r kept #:group-sep " ") "×")
+                         (td ,(format-percent kept generated))
+                         (td ,(~a vars))
+                         (td (code ,transform))
+                         (td ,(~a order)))))))))
 
 (define (render-phase-memory mem gc-time)
   (match-define (list live alloc) (car mem))

--- a/src/utils/timeline.rkt
+++ b/src/utils/timeline.rkt
@@ -210,7 +210,7 @@
 (define-timeline symmetry #:unmergable)
 (define-timeline bstep #:unmergable)
 (define-timeline kept #:unmergable)
-(define-timeline taylor-count [transform false] [order false] [generated +] [kept +])
+(define-timeline taylor-count [transform false] [order false] [vars false] [generated +] [kept +])
 (define-timeline min-error #:unmergable)
 (define-timeline egraph #:unmergable)
 (define-timeline stop [reason false] [count +])


### PR DESCRIPTION
I have the hypothesis that Taylor is more valuable for unary expressions and less so for multi-variable expressions, but I'm actually not sure if this is the case and initial experiments suggested otherwise. So this PR adds tracking for that to the timeline.