### PR TITLE
Fix reducer handling of odd rational powers

### DIFF
--- a/src/core/batch-reduce.rkt
+++ b/src/core/batch-reduce.rkt
@@ -320,10 +320,6 @@
   (match term
     [(cons 1 x) x]
     [(cons -1 x) (batch-add! (global-batch) `(/ 1 ,x))]
-    [(cons 1/2 x) (batch-add! (global-batch) `(sqrt ,x))]
-    [(cons -1/2 x) (batch-add! (global-batch) `(/ 1 (sqrt ,x)))]
-    [(cons 1/3 x) (batch-add! (global-batch) `(cbrt ,x))]
-    [(cons -1/3 x) (batch-add! (global-batch) `(/ 1 (cbrt ,x)))]
     [(cons (? rational? power) x)
      (match (denominator power)
        [2 (mterm->expr (cons (numerator power) (batch-add! (global-batch) `(sqrt ,x))))]

--- a/src/core/batch-reduce.rkt
+++ b/src/core/batch-reduce.rkt
@@ -324,6 +324,11 @@
     [(cons -1/2 x) (batch-add! (global-batch) `(/ 1 (sqrt ,x)))]
     [(cons 1/3 x) (batch-add! (global-batch) `(cbrt ,x))]
     [(cons -1/3 x) (batch-add! (global-batch) `(/ 1 (cbrt ,x)))]
+    [(cons (? rational? power) x)
+     (match (denominator power)
+       [2 (mterm->expr (cons (numerator power) (batch-add! (global-batch) `(sqrt ,x))))]
+       [3 (mterm->expr (cons (numerator power) (batch-add! (global-batch) `(cbrt ,x))))]
+       [_ (batch-add! (global-batch) `(pow ,x ,power))])]
     [(cons power x) (batch-add! (global-batch) `(pow ,x ,power))]))
 
 (module+ test
@@ -381,4 +386,6 @@
                 (reduce-results '(+ (* (/ 1 x) (/ 1 x)) (+ (/ 1 x) (/ 1 x)))))
   (check-equal? '(+ (* 2 (/ 1 x)) (/ 1 (pow x 2)))
                 (reduce-results '(+ (* (/ 1 x) (/ 1 x)) (+ (/ 1 x) (/ 1 x)))))
+  (check-equal? '(pow (cbrt x) 5) (reduce-results '(* x (cbrt x) (cbrt x))))
+  (check-equal? '(/ 1 (pow (cbrt x) 5)) (reduce-results '(/ 1 (* x (cbrt x) (cbrt x)))))
   (check-equal? '(/ 1 (* (cbrt 2) (cbrt a))) (reduce-results '(pow (+ a a) -1/3))))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -611,6 +611,6 @@
   (check-equal? (coeffs '(cbrt (+ 1 x))) '(1 1/3 -1/9 5/81 -10/243 22/729 -154/6561))
   (check-equal? (coeffs '(sqrt x)) '((sqrt x) 0 0 0 0 0 0))
   (check-equal? (coeffs '(cbrt x)) '((cbrt x) 0 0 0 0 0 0))
-  (check-equal? (coeffs '(cbrt (* x x))) '((pow x 2/3) 0 0 0 0 0 0))
+  (check-equal? (coeffs '(cbrt (* x x))) '((pow (cbrt x) 2) 0 0 0 0 0 0))
   (check-equal? (coeffs '(fabs (+ 2 x))) '(2 1 0 0 0 0 0))
   (check-equal? (coeffs '(fabs (+ -2 x))) '(2 -1 0 0 0 0 0)))


### PR DESCRIPTION
This PR adjusts `reduce`, the special-purpose Taylor simplifier, to simplify things like `pow(x, 2/3)` to `(pow (cbrt x) 2)`, since odd powers don't otherwise work.