### PR TITLE
Make variables cost-free

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -771,7 +771,7 @@
       (if (representation? type)
           (match enode
             [(? number?) (platform-repr-cost (*active-platform*) type)]
-            [(? symbol?) (platform-repr-cost (*active-platform*) type)]
+            [(? symbol?) 0]
             [(list '$approx x y) 0]
             [(list op args ...) (impl-info op 'cost)])
           1))
@@ -1035,9 +1035,8 @@
      (match node
        ; numbers (repr is unused)
        [(? number? n) ((node-cost-proc (literal n type) type))]
-       [(? symbol?) ; variables
-        (define repr (context-lookup ctx (egg-var->var node ctx)))
-        ((node-cost-proc node repr))]
+       ; variables
+       [(? symbol?) 0]
        ; approx node
        [(list '$approx _ impl) (rec impl)]
        [(list (? impl-exists?) args ...) ; impls

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -287,8 +287,7 @@
 
 (define (var-typed-nodes pform)
   (for/list ([repr (in-list (all-repr-names))])
-    (define cost (normalize-cost (platform-repr-cost pform (get-representation repr))))
-    `(,(typed-var-id repr) String :cost ,cost)))
+    `(,(typed-var-id repr) String :cost 0)))
 
 (define (num-lowering-rules)
   (for/list ([repr (in-list (all-repr-names))]

--- a/src/reports/resources/report-page.js
+++ b/src/reports/resources/report-page.js
@@ -159,16 +159,27 @@ function formatTime(ms) {
     }
 }
 
+function relativeCost(cost, initialCost) {
+    if (initialCost === 0) {
+        return cost === 0 ? 1 : Number.POSITIVE_INFINITY;
+    }
+    return cost / initialCost;
+}
+
+function formatSpeedup(speedup) {
+    if (speedup === Number.POSITIVE_INFINITY) {
+        return "∞×";
+    }
+    return speedup.toFixed(1) + "×";
+}
+
 function calculateSpeedup(mergedCostAccuracy) {
     const initial_accuracy = mergedCostAccuracy[0][1]
     const frontier = mergedCostAccuracy[1]
     for (const point of [...frontier].reverse()) {
         if (point[1] > initial_accuracy) {
             if (typeof point[0] == 'number') {
-                return point[0].toFixed(1) + "×";
-            }
-            else {
-                return point[0];
+                return formatSpeedup(point[0]);
             }
         }
     }
@@ -326,14 +337,11 @@ function calculateMergedCostAccuracy(tests) {
             const [initialPoint, bestPoint, otherPoints] = costAccuracy;
             const initialCost = Number(initialPoint[0]);
             return [initialPoint, bestPoint].concat(otherPoints).map((point) => [
-                point[0] / initialCost,
+                relativeCost(Number(point[0]), initialCost),
                 point[1],
             ]);
         });
     const frontier = paretoCombine(rescaled).map(([cost, accuracy]) => {
-        if (cost === 0) {
-            return ["N/A", 1 - accuracy / maximumAccuracy];
-        }
         return [testsLength / cost, 1 - accuracy / maximumAccuracy];
     });
     return [[1.0, initialAccuracy], frontier];
@@ -458,13 +466,15 @@ function plotPareto(jsonData, otherJsonData) {
     }
 
     const [initial, frontier] = mergedCostAccuracy;
+    const plottedFrontier = frontier.filter(([speedup, accuracy]) =>
+        Number.isFinite(speedup) && Number.isFinite(accuracy));
     let marks = [
         Plot.dot([initial], {
             stroke: "#00a",
             symbol: "square",
             strokeWidth: 2,
         }),
-        Plot.line(frontier, {
+        Plot.line(plottedFrontier, {
             stroke: "#00a",
             strokeWidth: 2,
         }),
@@ -480,13 +490,15 @@ function plotPareto(jsonData, otherJsonData) {
         }
 
         const [initial2, frontier2] = otherMergedCostAccuracy;
+        const plottedFrontier2 = frontier2.filter(([speedup, accuracy]) =>
+            Number.isFinite(speedup) && Number.isFinite(accuracy));
         marks = [
             Plot.dot([initial2], {
                 stroke: "#900",
                 symbol: "square",
                 strokeWidth: 2,
             }),
-            Plot.line(frontier2, {
+            Plot.line(plottedFrontier2, {
                 stroke: "#900",
                 strokeWidth: 2,
             })

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -151,7 +151,7 @@
 (define ((platform-node-cost-proc platform) expr repr)
   (match expr
     [(? literal?) (lambda () (platform-repr-cost platform repr))]
-    [(? symbol?) (lambda () (platform-repr-cost platform repr))]
+    [(? symbol?) (lambda () 0)]
     [(list impl args ...)
      (define impl-cost (impl-info impl 'cost))
      (define impl-agg (impl-info impl 'aggregate))


### PR DESCRIPTION
Make symbol/variable nodes cost `0` in the shared platform cost model. This way inlining a la #1484 is cost-neutral, and also I guess it's just one less thing to think about.