### PR TITLE
Test a "drop" pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: help install egg-herbie nightly index start-server deploy coverage
 
+REPORT_FLAGS := --enable generate:drop --disable generate:taylor
+
 help:
 	@echo "Type 'make install' to install Herbie"
 	@echo "Then type 'racket -l herbie web' to run it."
@@ -46,7 +48,7 @@ minimal-distribution:
 	[ ! -f herbie ] || (raco distribute herbie-compiled herbie && rm herbie)
 
 nightly:
-	bash infra/nightly.sh bench reports --threads 2
+	bash infra/nightly.sh bench reports --threads 2 $(REPORT_FLAGS)
 
 upgrade:
 	git pull

--- a/src/config.rkt
+++ b/src/config.rkt
@@ -24,7 +24,9 @@
         [rules . (numerics special bools branches)]))
 
 (define debug-flags
-  #hash([generate . (egglog)] [dump . (egg rival egglog trace intermediates)] [setup . (rival2)]))
+  #hash([generate . (egglog drop)]
+        [dump . (egg rival egglog trace intermediates)]
+        [setup . (rival2)]))
 
 (define all-flags (hash-union default-flags deprecated-flags debug-flags #:combine set-union))
 

--- a/src/core/alternative.rkt
+++ b/src/core/alternative.rkt
@@ -33,6 +33,7 @@
   (define (unmunge-event event)
     (match event
       [(list 'evaluate (? batchref? start-expr)) (list 'evaluate (exprs start-expr))]
+      [(list 'drop (? batchref? start-expr)) (list 'drop (exprs start-expr))]
       [(list 'taylor (? batchref? start-expr) name var order)
        (list 'taylor (exprs start-expr) name var order)]
       [(list 'rr (? batchref? start-expr) (? batchref? end-expr) input proof)

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -185,6 +185,7 @@
          (define event*
            (match event
              [(list 'evaluate) (list 'evaluate start-expr)]
+             [(list 'drop) (list 'drop start-expr)]
              [(list 'taylor name var order) (list 'taylor start-expr name var order)]
              [(list 'rr input proof) (list 'rr (alt-expr prev) cur-expr input proof)]))
          (define expr* (batch-replace-subexpr batch (alt-expr orig) start-expr cur-expr can-refer))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -18,6 +18,29 @@
 (provide generate-candidates
          get-starting-expr)
 
+(define (approx-key altn)
+  (define expr (deref (alt-expr altn)))
+  (if (approx? expr)
+      (approx-impl expr)
+      expr))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; Drop ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (run-drop altns global-batch)
+  (define brfs (map alt-expr altns))
+  (define spec-brfs (batch-to-spec! global-batch brfs))
+  (define reprs (map (batch-reprs global-batch (*context*)) brfs))
+
+  (remove-duplicates (for/list ([spec-brf (in-list spec-brfs)]
+                                [repr (in-list reprs)]
+                                [altn (in-list altns)])
+                       (define zero-brf
+                         (batch-add! global-batch (literal 0 (representation-name repr))))
+                       (define gen (approx spec-brf zero-brf))
+                       (define brf (batch-add! global-batch gen))
+                       (alt brf '(drop) (list altn)))
+                     #:key approx-key))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Taylor ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define transforms-to-try
@@ -84,14 +107,9 @@
 
 (define (run-taylor altns global-batch spec-batch reducer)
   (timeline-event! 'series)
-  (define (key x)
-    (define expr (deref (alt-expr x)))
-    (if (approx? expr)
-        (approx-impl expr)
-        expr))
-
-  (define approxs (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key key))
-  (define approxs* (remove-duplicates (run-lowering approxs global-batch) #:key key))
+  (define approxs
+    (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key approx-key))
+  (define approxs* (remove-duplicates (run-lowering approxs global-batch) #:key approx-key))
 
   (timeline-push! 'inputs (batch->jsexpr global-batch (map alt-expr altns)))
   (timeline-push! 'outputs (batch->jsexpr global-batch (map alt-expr approxs*)))
@@ -231,6 +249,12 @@
         '()))
 
   ; Series expand
+  (define dropped
+    (if (flag-set? 'generate 'drop)
+        (run-drop start-altns batch)
+        '()))
+
+  ; Series expand
   (define approximations
     (if (flag-set? 'generate 'taylor)
         (run-taylor start-altns batch spec-batch reducer)
@@ -242,5 +266,5 @@
         (run-rr start-altns batch)
         '()))
 
-  (remove-duplicates (append evaluations rewritten approximations)
+  (remove-duplicates (append evaluations rewritten dropped approximations)
                      #:key (λ (altn) (cons (alt-expr altn) (get-starting-expr altn)))))

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -109,6 +109,7 @@
             [(alt prog 'start (list)) (void)]
             [(alt prog 'add-preprocessing `(,prev)) (loop prev)]
             [(alt prog `(evaluate ,start-expr) `(,prev)) (loop prev)]
+            [(alt prog `(drop ,start-expr) `(,prev)) (loop prev)]
             [(alt _ `(regimes ,splitpoints) prevs) (for-each loop prevs)]
             [(alt prog `(taylor ,start-expr ,pt ,var ,order) `(,prev)) (loop prev)]
             [(alt prog `(rr ,start-expr ,end-expr ,input ,proof) `(,prev))
@@ -160,6 +161,12 @@
      (define prev (hash-ref json 'prev))
      `(,@(render-history prev ctx)
        (li (p "Evaluated real constant" (span ((class "error")) ,err))
+           (div ((class "math")) "\\[\\leadsto " ,(fpcore->tex prog) "\\]")))]
+
+    ["drop"
+     (define prev (hash-ref json 'prev))
+     `(,@(render-history prev ctx)
+       (li (p "Dropped to 0" (span ((class "error")) ,err))
            (div ((class "math")) "\\[\\leadsto " ,(fpcore->tex prog) "\\]")))]
 
     ["rr"
@@ -250,6 +257,12 @@
     [(alt prog `(evaluate ,start-expr) `(,prev))
      `#hash((program . ,(program->json-string prog ctx fpcore-cache))
             (type . "evaluate")
+            (prev . ,(render-json prev pcontext ctx errcache mask fpcore-cache))
+            (error . ,err))]
+
+    [(alt prog `(drop ,start-expr) `(,prev))
+     `#hash((program . ,(program->json-string prog ctx fpcore-cache))
+            (type . "drop")
             (prev . ,(render-json prev pcontext ctx errcache mask fpcore-cache))
             (error . ,err))]
 


### PR DESCRIPTION
I saw in #1583 that order-0 and order--1 expansions are most of what is kept in Herbie. So I thought—both of those are equivalent to just replacing something—a variable, or a whole expression—with zero. That would also be super cheap. Hence: the "drop" pass. This PR adds that.