### PR TITLE
Lower Taylor order cap to 1

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -129,7 +129,7 @@
 (define *proof-max-string-length* (make-parameter 10000))
 
 ;; How long of a Taylor series to generate; too long and we time out
-(define *taylor-order-limit* (make-parameter 4))
+(define *taylor-order-limit* (make-parameter 2))
 
 ;; How accurate to make the binary search
 (define *binary-search-test-points* (make-parameter 16))


### PR DESCRIPTION
It turns out that higher-order Taylor series barely do anything, and they're pretty slow. So this PR limits Taylor to outputting two terms at most. One term is probably too aggressive.