### PR TITLE
Refactor batch-to-spec API and simplify callers

### DIFF
--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -187,8 +187,9 @@
     (raise-user-error
      'sindices->spoints/binary
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
-  (define spec-brfs (batch-to-spec! batch (list start-prog)))
-  (define start-real-compiler (make-real-compiler batch spec-brfs (list ctx*)))
+  (define spec-batch (batch-empty))
+  (define spec-brfs (batch-to-spec! batch (list start-prog) spec-batch))
+  (define start-real-compiler (make-real-compiler spec-batch spec-brfs (list ctx*)))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -188,8 +188,8 @@
      'sindices->spoints/binary
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
   (define spec-batch (batch-empty))
-  (define spec-brfs (batch-to-spec! batch (list start-prog) spec-batch))
-  (define start-real-compiler (make-real-compiler spec-batch spec-brfs (list ctx*)))
+  (define start-spec-brf ((batch-to-spec batch spec-batch) start-prog))
+  (define start-real-compiler (make-real-compiler spec-batch (list start-spec-brf) (list ctx*)))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -13,6 +13,7 @@
 (require "../utils/common.rkt"
          "../utils/errors.rkt"
          "../utils/timeline.rkt"
+         "../syntax/matcher.rkt"
          "../syntax/platform.rkt"
          "../syntax/syntax.rkt"
          "../syntax/types.rkt"
@@ -84,22 +85,30 @@
       [(list op ids ...) (egraph_add_node ptr (~s op) (list->u32vec ids))]
       [(? (disjoin symbol? number?) x) (egraph_add_node ptr (~s x) 0-vec)]))
 
-  (define reprs (batch-reprs batch ctx))
-  (define add-to-egraph
+  (define add-spec-to-egraph
+    (batch-recurse batch
+                   (lambda (brf recurse)
+                     (define node (deref brf))
+                     (match node
+                       [(? number?) (insert-node! node)]
+                       [(? symbol?) (insert-node! (var->egg-var node ctx))]
+                       [(list op args ...) (insert-node! (cons op (map recurse args)))]))))
+
+  (define add-impl-to-egraph
     (batch-recurse
      batch
-     (λ (brf recurse)
+     (lambda (brf recurse)
        (define node (deref brf))
        (match node
          [(literal v _) (insert-node! v)]
          [(? number?) (insert-node! node)]
          [(? symbol?) (insert-node! (var->egg-var node ctx))]
-         [(hole prec spec) (recurse spec)] ; "hole" terms currently disappear
-         [(approx spec impl) (insert-node! (list '$approx (recurse spec) (recurse impl)))]
-         [(list op (app recurse args) ...) (insert-node! (cons op args))]))))
+         [(hole _ spec) (add-spec-to-egraph spec)] ; "hole" terms currently disappear
+         [(approx spec impl) (insert-node! (list '$approx (add-spec-to-egraph spec) (recurse impl)))]
+         [(list op args ...) (insert-node! (cons op (map recurse args)))]))))
 
   (for/list ([brf (in-list brfs)])
-    (define brf-id (add-to-egraph brf)) ; remapping of brf
+    (define brf-id (add-impl-to-egraph brf)) ; remapping of brf
     (egraph_add_root ptr brf-id)
     brf-id))
 

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -49,7 +49,7 @@
 
 ;; Herbie's version of an egglog runner.
 ;; Defines parameters for running rewrite rules with egglog
-(struct egglog-runner (batch brfs reprs schedule ctx)
+(struct egglog-runner (batch spec-batch brfs reprs schedule ctx)
   #:transparent ; for equality
   #:methods gen:custom-write ; for abbreviated printing
   [(define (write-proc alt port mode)
@@ -62,7 +62,7 @@
 ;;  - `rewrite`: run rewrite rules up to node limit with backoff scheduler
 ;;  - `unsound`: run sound-removal rules for 1 iteration with simple scheduler
 ;;  - `lower`: run lowering rules for 1 iteration with simple scheduler
-(define (make-egglog-runner batch brfs reprs schedule ctx)
+(define (make-egglog-runner batch brfs reprs schedule ctx #:spec-batch [spec-batch batch])
   (define (oops! fmt . args)
     (apply error 'verify-schedule! fmt args))
   ; verify the schedule
@@ -71,11 +71,12 @@
       (oops! "unknown schedule step `~a`" step)))
 
   ; make the runner
-  (egglog-runner batch brfs reprs schedule ctx))
+  (egglog-runner batch spec-batch brfs reprs schedule ctx))
 
 ;; Runs egglog using an egglog runner by extracting multiple variants
 (define (run-egglog runner output-batch [label #f] #:extract extract) ; multi expression extraction
   (define insert-batch (egglog-runner-batch runner))
+  (define insert-spec-batch (egglog-runner-spec-batch runner))
   (define insert-brfs (egglog-runner-brfs runner))
   (define schedule (egglog-runner-schedule runner))
   (define pform (*active-platform*))
@@ -131,7 +132,7 @@
   ;; keep track of the mapping between each binding and its corresponding constructor.
 
   (define-values (all-bindings extract-bindings)
-    (egglog-add-exprs insert-batch insert-brfs (egglog-runner-ctx runner) subproc))
+    (egglog-add-exprs insert-batch insert-spec-batch insert-brfs (egglog-runner-ctx runner) subproc))
 
   (egglog-send subproc
                `(ruleset run-extract-commands)
@@ -380,16 +381,33 @@
               :ruleset
               ,tag)))
 
-(define (egglog-add-exprs batch brfs ctx subproc)
+(define (egglog-add-exprs batch spec-batch brfs ctx subproc)
   (define mappings (build-vector (batch-length batch) values))
   (define bindings (make-hash))
   (define vars (make-hash))
+  (define all-brfs
+    (for/list ([n (in-range (batch-length batch))])
+      (batchref batch n)))
+  (define all-spec-brfs (batch-to-spec! batch all-brfs spec-batch))
+  (define spec-idxs
+    (for/vector #:length (batch-length batch)
+                ([spec-brf (in-list all-spec-brfs)])
+      (batchref-idx spec-brf)))
+  (define spec-mappings (build-vector (batch-length spec-batch) values))
+  (define spec-vars (make-hash))
+  (define (spec-binding-name n)
+    (string->symbol (format "?s~a" n)))
+  (define (remap-spec x)
+    (cond
+      [(hash-has-key? spec-vars x) (string->symbol (format "?s~a" (hash-ref spec-vars x)))]
+      [else (vector-ref spec-mappings x)]))
   (define (remap x spec?)
     (cond
       [(hash-has-key? vars x)
        (if spec?
            (string->symbol (format "?s~a" (hash-ref vars x)))
            (string->symbol (format "?t~a" (hash-ref vars x))))]
+      [spec? (remap-spec (vector-ref spec-idxs x))]
       [else (vector-ref mappings x)]))
 
   ; node -> egglog node binding
@@ -399,6 +417,11 @@
       (if root?
           (string->symbol (format "?r~a" n))
           (string->symbol (format "?b~a" n))))
+    (hash-set! bindings binding node)
+    binding)
+
+  (define (insert-spec-node! node n)
+    (define binding (spec-binding-name n))
     (hash-set! bindings binding node)
     binding)
 
@@ -428,6 +451,19 @@
 
   (for ([brf (in-list brfs)])
     (vector-set! root-mask (batchref-idx brf) #t))
+  (for ([node (in-batch spec-batch)]
+        [n (in-naturals)])
+    (define node*
+      (match node
+        [(? number?) `(Num ,(real->bigrat node))]
+        [(? symbol?) #f]
+        [(list op args ...)
+         `(,(serialize-spec-op op (length args)) ,@(for/list ([arg (in-list args)])
+                                                     (remap-spec arg)))]))
+
+    (if node*
+        (vector-set! spec-mappings n (insert-spec-node! node* n))
+        (hash-set! spec-vars n node)))
   (for ([node (in-batch batch)]
         [root? (in-vector root-mask)]
         [n (in-naturals)])
@@ -513,6 +549,23 @@
 
     ; Add the binding and constructor union to all-bindings for the future rule
     (set! all-bindings (cons curr-var-typed-binding all-bindings))
+    (set! all-bindings (cons `(union (,constructor-name) ,binding-name) all-bindings))
+
+    (set! constructor-num (add1 constructor-num)))
+
+  ; Spec bindings for every non-variable impl node
+  (for ([node (in-batch spec-batch)]
+        [n (in-naturals)]
+        #:unless (hash-has-key? spec-vars n))
+    (define binding-name (spec-binding-name n))
+    (define constructor-name (string->symbol (format "const~a" constructor-num)))
+    (hash-set! binding->constructor binding-name constructor-name)
+
+    (define curr-spec-binding `(let ,binding-name ,(hash-ref bindings binding-name)))
+
+    (egglog-send subproc `(constructor ,constructor-name () M :unextractable))
+
+    (set! all-bindings (cons curr-spec-binding all-bindings))
     (set! all-bindings (cons `(union (,constructor-name) ,binding-name) all-bindings))
 
     (set! constructor-num (add1 constructor-num)))

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -388,7 +388,7 @@
   (define all-brfs
     (for/list ([n (in-range (batch-length batch))])
       (batchref batch n)))
-  (define all-spec-brfs (batch-to-spec! batch all-brfs spec-batch))
+  (define all-spec-brfs (map (batch-to-spec batch spec-batch) all-brfs))
   (define reachable-spec-brfs (batch-reachable spec-batch all-spec-brfs))
   (define spec-idxs
     (for/vector #:length (batch-length batch)

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -389,18 +389,24 @@
     (for/list ([n (in-range (batch-length batch))])
       (batchref batch n)))
   (define all-spec-brfs (batch-to-spec! batch all-brfs spec-batch))
+  (define reachable-spec-brfs (batch-reachable spec-batch all-spec-brfs))
   (define spec-idxs
     (for/vector #:length (batch-length batch)
                 ([spec-brf (in-list all-spec-brfs)])
       (batchref-idx spec-brf)))
   (define spec-mappings (build-vector (batch-length spec-batch) values))
   (define spec-vars (make-hash))
+  (define (spec-idx x)
+    (if (batchref? x)
+        (batchref-idx x)
+        x))
   (define (spec-binding-name n)
     (string->symbol (format "?s~a" n)))
   (define (remap-spec x)
+    (define n (spec-idx x))
     (cond
-      [(hash-has-key? spec-vars x) (string->symbol (format "?s~a" (hash-ref spec-vars x)))]
-      [else (vector-ref spec-mappings x)]))
+      [(hash-has-key? spec-vars n) (string->symbol (format "?s~a" (hash-ref spec-vars n)))]
+      [else (vector-ref spec-mappings n)]))
   (define (remap x spec?)
     (cond
       [(hash-has-key? vars x)
@@ -451,8 +457,9 @@
 
   (for ([brf (in-list brfs)])
     (vector-set! root-mask (batchref-idx brf) #t))
-  (for ([node (in-batch spec-batch)]
-        [n (in-naturals)])
+  (for ([spec-brf (in-list reachable-spec-brfs)])
+    (define n (batchref-idx spec-brf))
+    (define node (deref spec-brf))
     (define node*
       (match node
         [(? number?) `(Num ,(real->bigrat node))]
@@ -554,8 +561,8 @@
     (set! constructor-num (add1 constructor-num)))
 
   ; Spec bindings for every non-variable impl node
-  (for ([node (in-batch spec-batch)]
-        [n (in-naturals)]
+  (for ([spec-brf (in-list reachable-spec-brfs)]
+        #:do [(define n (batchref-idx spec-brf))]
         #:unless (hash-has-key? spec-vars n))
     (define binding-name (spec-binding-name n))
     (define constructor-name (string->symbol (format "const~a" constructor-num)))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -56,7 +56,8 @@
 
   (parameterize ([*global-batch* (batch-empty)])
     (define global-spec-batch (batch-empty))
-    (define spec-reducer (batch-reduce global-spec-batch))
+    (define taylor-spec-batch (batch-empty))
+    (define spec-reducer (batch-reduce taylor-spec-batch))
 
     (*preprocessing* preprocessing)
     (define initial-brf (batch-add! (*global-batch*) initial))
@@ -66,7 +67,7 @@
 
     (for ([_ (in-range (*num-iterations*))]
           #:break (atab-completed? (^table^)))
-      (run-iteration! global-spec-batch spec-reducer))
+      (run-iteration! global-spec-batch taylor-spec-batch spec-reducer))
     (define alternatives (extract!))
     (timeline-event! 'preprocess)
     (for/list ([altn alternatives])
@@ -259,7 +260,7 @@
                   (format "~a" (representation-name repr)))
   (void))
 
-(define (run-iteration! global-spec-batch spec-reducer)
+(define (run-iteration! global-spec-batch taylor-spec-batch spec-reducer)
   (define pending-alts (atab-not-done-alts (^table^)))
   (timeline-push-alts! pending-alts)
   (^table^ (atab-set-picked (^table^) pending-alts))
@@ -267,7 +268,8 @@
   (define brfs (map alt-expr pending-alts))
   (define brfs* (batch-reachable (*global-batch*) brfs #:condition node-is-impl?))
 
-  (define results (generate-candidates (*global-batch*) brfs* global-spec-batch spec-reducer))
+  (define results
+    (generate-candidates (*global-batch*) brfs* global-spec-batch taylor-spec-batch spec-reducer))
   (define patched (reconstruct! pending-alts results))
   (finalize-iter! pending-alts patched)
   (void))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -81,7 +81,7 @@
             (set! idx (add1 idx))
             (timeline-stop!)))))
 
-(define (run-taylor altns global-batch spec-batch reducer)
+(define (run-taylor altns global-batch shared-spec-batch taylor-spec-batch reducer)
   (timeline-event! 'series)
   (define (key x)
     (define expr (deref (alt-expr x)))
@@ -89,8 +89,10 @@
         (approx-impl expr)
         expr))
 
-  (define approxs (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key key))
-  (define approxs* (remove-duplicates (run-lowering approxs global-batch spec-batch) #:key key))
+  (define approxs
+    (remove-duplicates (taylor-alts altns global-batch taylor-spec-batch reducer) #:key key))
+  (define approxs*
+    (remove-duplicates (run-lowering approxs global-batch shared-spec-batch) #:key key))
 
   (timeline-push! 'inputs (batch->jsexpr global-batch (map alt-expr altns)))
   (timeline-push! 'outputs (batch->jsexpr global-batch (map alt-expr approxs*)))
@@ -218,7 +220,7 @@
     [(list) (alt-expr altn)]
     [(list prev) (get-starting-expr prev)]))
 
-(define (generate-candidates batch brfs spec-batch reducer)
+(define (generate-candidates batch brfs shared-spec-batch taylor-spec-batch reducer)
   ; Starting alternatives
   (define start-altns
     (for/list ([brf brfs])
@@ -232,13 +234,13 @@
   ; Series expand
   (define approximations
     (if (flag-set? 'generate 'taylor)
-        (run-taylor start-altns batch spec-batch reducer)
+        (run-taylor start-altns batch shared-spec-batch taylor-spec-batch reducer)
         '()))
 
   ; Recursive rewrite
   (define rewritten
     (if (flag-set? 'generate 'rr)
-        (run-rr start-altns batch spec-batch)
+        (run-rr start-altns batch shared-spec-batch)
         '()))
 
   (remove-duplicates (append evaluations rewritten approximations)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -38,11 +38,9 @@
   (define brfs (map alt-expr altns))
   (define reprs (map (batch-reprs global-batch (*context*)) brfs))
   ;; Specs
-  (define spec-brfs (batch-to-spec! global-batch brfs)) ;; These specs will go into (approx spec impl)
-  (define free-vars (map (batch-free-vars global-batch) spec-brfs))
-  (define spec-brfs*
-    (map (batch-copy-only! spec-batch global-batch)
-         spec-brfs)) ;; copy from global-batch to spec-batch
+  (define spec-brfs
+    (batch-to-spec! global-batch brfs spec-batch)) ;; These specs will go into (approx spec impl)
+  (define free-vars (map (batch-free-vars spec-batch) spec-brfs))
   (define copier (batch-copy-only! global-batch spec-batch)) ;; copy from spec-batch to global-batch
 
   (reap [sow]
@@ -54,13 +52,13 @@
                 [altn (in-list altns)]
                 #:when (equal? (representation-type repr) 'real))
             (define genexpr0 (batch-add! global-batch 0))
-            (define gen0 (approx spec-brf (hole (representation-name repr) genexpr0)))
+            (define gen0 (approx (copier spec-brf) (hole (representation-name repr) genexpr0)))
             (define brf0 (batch-add! global-batch gen0))
             (sow (alt brf0 `(taylor zero undef-var -1) (list altn))))
 
           ;; Taylor expansions
           ;; List<List<(cons offset coeffs)>>
-          (define taylor-coeffs (taylor-coefficients spec-batch spec-brfs* vars transforms-to-try))
+          (define taylor-coeffs (taylor-coefficients spec-batch spec-brfs vars transforms-to-try))
           (define idx 0)
           (for* ([var (in-list vars)]
                  [transform-type transforms-to-try])
@@ -76,7 +74,8 @@
                   #:when (set-member? fv var)) ;; check whether var exists in expr at all
               (for ([i (in-range (*taylor-order-limit*))])
                 ;; adding a new expansion to the global batch
-                (define gen (approx spec-brf (hole (representation-name repr) (copier (genexpr)))))
+                (define gen
+                  (approx (copier spec-brf) (hole (representation-name repr) (copier (genexpr)))))
                 (define brf (batch-add! global-batch gen))
                 (sow (alt brf `(taylor ,name ,var ,i) (list altn)))))
             (set! idx (add1 idx))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -39,7 +39,7 @@
   (define reprs (map (batch-reprs global-batch (*context*)) brfs))
   ;; Specs
   (define spec-brfs
-    (batch-to-spec! global-batch brfs spec-batch)) ;; These specs will go into (approx spec impl)
+    (map (batch-to-spec global-batch spec-batch) brfs)) ;; These specs will go into (approx spec impl)
   (define free-vars (map (batch-free-vars spec-batch) spec-brfs))
   (define copier (batch-copy-only! global-batch spec-batch)) ;; copy from spec-batch to global-batch
 
@@ -130,7 +130,7 @@
 (define (run-evaluate altns global-batch)
   (timeline-event! 'sample)
   (define all-brfs (map alt-expr altns))
-  (define spec-brfs (batch-to-spec! global-batch all-brfs))
+  (define spec-brfs (map (batch-to-spec global-batch) all-brfs))
   (define free-vars (batch-free-vars global-batch))
   (define repr-of (batch-reprs global-batch (*context*)))
   (define real-pairs

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -90,14 +90,14 @@
         expr))
 
   (define approxs (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key key))
-  (define approxs* (remove-duplicates (run-lowering approxs global-batch) #:key key))
+  (define approxs* (remove-duplicates (run-lowering approxs global-batch spec-batch) #:key key))
 
   (timeline-push! 'inputs (batch->jsexpr global-batch (map alt-expr altns)))
   (timeline-push! 'outputs (batch->jsexpr global-batch (map alt-expr approxs*)))
   (timeline-push! 'count (length altns) (length approxs*))
   approxs*)
 
-(define (run-lowering altns global-batch)
+(define (run-lowering altns global-batch spec-batch)
   (define schedule '(lower))
 
   ; run egg
@@ -108,10 +108,9 @@
     (cond
       [(flag-set? 'generate 'egglog)
        (define batch* (batch-empty))
-       (define spec-batch* (batch-empty))
        (define copy-f (batch-copy-only! batch* global-batch))
        (define brfs* (map copy-f brfs))
-       (make-egglog-runner batch* brfs* reprs schedule (*context*) #:spec-batch spec-batch*)]
+       (make-egglog-runner batch* brfs* reprs schedule (*context*) #:spec-batch spec-batch)]
       [else (make-egraph global-batch brfs reprs schedule (*context*))]))
 
   (define batchrefss
@@ -175,7 +174,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;; Recursive Rewrite ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (run-rr altns global-batch)
+(define (run-rr altns global-batch spec-batch)
   (timeline-event! 'rewrite)
 
   ; egg schedule (4-phases for mathematical rewrites, sound-X removal, and implementation selection)
@@ -188,10 +187,9 @@
     (cond
       [(flag-set? 'generate 'egglog)
        (define batch* (batch-empty))
-       (define spec-batch* (batch-empty))
        (define copy-f (batch-copy-only! batch* global-batch))
        (define brfs* (map copy-f brfs))
-       (make-egglog-runner batch* brfs* reprs schedule (*context*) #:spec-batch spec-batch*)]
+       (make-egglog-runner batch* brfs* reprs schedule (*context*) #:spec-batch spec-batch)]
       [else (make-egraph global-batch brfs reprs schedule (*context*))]))
 
   (define batchrefss
@@ -240,7 +238,7 @@
   ; Recursive rewrite
   (define rewritten
     (if (flag-set? 'generate 'rr)
-        (run-rr start-altns batch)
+        (run-rr start-altns batch spec-batch)
         '()))
 
   (remove-duplicates (append evaluations rewritten approximations)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -108,9 +108,10 @@
     (cond
       [(flag-set? 'generate 'egglog)
        (define batch* (batch-empty))
+       (define spec-batch* (batch-empty))
        (define copy-f (batch-copy-only! batch* global-batch))
        (define brfs* (map copy-f brfs))
-       (make-egglog-runner batch* brfs* reprs schedule (*context*))]
+       (make-egglog-runner batch* brfs* reprs schedule (*context*) #:spec-batch spec-batch*)]
       [else (make-egraph global-batch brfs reprs schedule (*context*))]))
 
   (define batchrefss
@@ -187,9 +188,10 @@
     (cond
       [(flag-set? 'generate 'egglog)
        (define batch* (batch-empty))
+       (define spec-batch* (batch-empty))
        (define copy-f (batch-copy-only! batch* global-batch))
        (define brfs* (map copy-f brfs))
-       (make-egglog-runner batch* brfs* reprs schedule (*context*))]
+       (make-egglog-runner batch* brfs* reprs schedule (*context*) #:spec-batch spec-batch*)]
       [else (make-egraph global-batch brfs reprs schedule (*context*))]))
 
   (define batchrefss

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -33,7 +33,7 @@
          impl-exists?
          impl-info
          prog->spec
-         batch-to-spec!
+         batch-to-spec
          get-fpcore-impl
          (struct-out $platform)
          ;; Platform API
@@ -88,26 +88,23 @@
      (define env (map cons vars (map prog->spec args)))
      (pattern-substitute spec env)]))
 
-(define (batch-to-spec! in-batch brfs [out-batch in-batch])
-  (define lower
-    (batch-recurse in-batch
-                   (lambda (brf recurse)
-                     (define node (deref brf))
-                     (match node
-                       [(? literal?) (batch-push! out-batch (literal-value node))]
-                       [(? number?) (batch-push! out-batch node)]
-                       [(? symbol?) (batch-push! out-batch node)]
-                       [(hole _ spec) (recurse spec)]
-                       [(approx spec _) (recurse spec)]
-                       [(list (? impl-exists? impl) args ...)
-                        (define vars (impl-info impl 'vars))
-                        (define spec (impl-info impl 'spec))
-                        (define env (map cons vars (map recurse args)))
-                        (batch-add! out-batch (pattern-substitute spec env))]
-                       [(list op args ...)
-                        (batch-push! out-batch
-                                     (cons op (map (compose batchref-idx recurse) args)))]))))
-  (map lower brfs))
+(define (batch-to-spec in-batch [out-batch in-batch])
+  (batch-recurse in-batch
+                 (lambda (brf recurse)
+                   (define node (deref brf))
+                   (match node
+                     [(? literal?) (batch-push! out-batch (literal-value node))]
+                     [(? number?) (batch-push! out-batch node)]
+                     [(? symbol?) (batch-push! out-batch node)]
+                     [(hole _ spec) (recurse spec)]
+                     [(approx spec _) (recurse spec)]
+                     [(list (? impl-exists? impl) args ...)
+                      (define vars (impl-info impl 'vars))
+                      (define spec (impl-info impl 'spec))
+                      (define env (map cons vars (map recurse args)))
+                      (batch-add! out-batch (pattern-substitute spec env))]
+                     [(list op args ...)
+                      (batch-push! out-batch (cons op (map (compose batchref-idx recurse) args)))]))))
 
 ;; Expression predicates ;;
 

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -88,24 +88,25 @@
      (define env (map cons vars (map prog->spec args)))
      (pattern-substitute spec env)]))
 
-(define (batch-to-spec! batch brfs)
+(define (batch-to-spec! in-batch brfs [out-batch in-batch])
   (define lower
-    (batch-recurse batch
+    (batch-recurse in-batch
                    (lambda (brf recurse)
                      (define node (deref brf))
                      (match node
-                       [(? literal?) (batch-push! batch (literal-value node))]
-                       [(? number?) brf]
-                       [(? symbol?) brf]
+                       [(? literal?) (batch-push! out-batch (literal-value node))]
+                       [(? number?) (batch-push! out-batch node)]
+                       [(? symbol?) (batch-push! out-batch node)]
                        [(hole _ spec) (recurse spec)]
                        [(approx spec _) (recurse spec)]
                        [(list (? impl-exists? impl) args ...)
                         (define vars (impl-info impl 'vars))
                         (define spec (impl-info impl 'spec))
                         (define env (map cons vars (map recurse args)))
-                        (batch-add! batch (pattern-substitute spec env))]
+                        (batch-add! out-batch (pattern-substitute spec env))]
                        [(list op args ...)
-                        (batch-push! batch (cons op (map (compose batchref-idx recurse) args)))]))))
+                        (batch-push! out-batch
+                                     (cons op (map (compose batchref-idx recurse) args)))]))))
   (map lower brfs))
 
 ;; Expression predicates ;;


### PR DESCRIPTION
## Summary
- Change `batch-to-spec` to return a reusable converter function instead of mapping internally.
- Update bsearch, Taylor lowering, egglog insertion, and evaluation call sites to do their own mapping.
- Remove now-unnecessary temporary bindings in the updated callers.
- Keep `prog->spec` intact; it still has live callers in sandbox, preprocess, explain, and localize paths.

## Testing
- `make fmt`
- `raco test src/syntax/platform.rkt src/core/bsearch.rkt src/core/patch.rkt src/core/egglog-herbie.rkt`
- `racket src/main.rkt report --seed 1 --timeout 30 bench/tutorial.fpcore tmp-batch-to-spec`