### PR TITLE
Fix integer power reconstruction in batch-reduce

### DIFF
--- a/bench/hamming/series.fpcore
+++ b/bench/hamming/series.fpcore
@@ -57,6 +57,10 @@
  :alt 
  (! :herbie-platform c
   (+ (/ 1 a) (/ 1 b)))
+ :alt
+ (! :herbie-platform c
+  (+ eps (+ (/ (if (== (* a eps) 0) 1 (/ (* eps a) (expm1 (* eps a)))) a)
+            (/ (if (== (* b eps) 0) 1 (/ (* eps b) (expm1 (* eps b)))) b))))
 
  (/
   (* eps (- (exp (* (+ a b) eps)) 1))

--- a/src/core/batch-reduce.rkt
+++ b/src/core/batch-reduce.rkt
@@ -318,8 +318,15 @@
 
 (define (mterm->expr term)
   (match term
-    [(cons 1 x) x]
-    [(cons -1 x) (batch-add! (global-batch) `(/ 1 ,x))]
+    [(cons (? exact-integer? power) x)
+     (cond
+       [(zero? power) (batch-push! (global-batch) 1)]
+       [(= power 1) x]
+       [(negative? power) (batch-add! (global-batch) `(/ 1 ,(mterm->expr (cons (- power) x))))]
+       [(even? power)
+        (define factor (mterm->expr (cons (/ power 2) x)))
+        (batch-add! (global-batch) `(* ,factor ,factor))]
+       [else (batch-add! (global-batch) `(* ,x ,(mterm->expr (cons (sub1 power) x))))])]
     [(cons (? rational? power) x)
      (match (denominator power)
        [2 (mterm->expr (cons (numerator power) (batch-add! (global-batch) `(sqrt ,x))))]
@@ -373,15 +380,18 @@
   (define reduce (batch-reduce batch))
   (define (reduce-results expr)
     ((batch-exprs batch) (reduce (batch-add! batch expr))))
-  (check-equal? '(- (pow (+ 1 x) 2) 1) (reduce-results '(- (* (+ x 1) (+ x 1)) 1)))
+  (check-equal? '(- (* (+ 1 x) (+ 1 x)) 1) (reduce-results '(- (* (+ x 1) (+ x 1)) 1)))
   (check-equal? '(neg (* 2 (/ 1 x))) (reduce-results '(+ (/ 1 (neg x)) (/ 1 (neg x)))))
-  (check-equal? '(- (pow (- 1 (/ 1 x)) 2) 1)
+  (check-equal? '(- (* (- 1 (/ 1 x)) (- 1 (/ 1 x))) 1)
                 (reduce-results '(- (* (+ (/ 1 (neg x)) 1) (+ (/ 1 (neg x)) 1)) 1)))
-  (check-equal? '(pow (- 1 (/ 1 x)) 2) (reduce-results '(* (+ (/ 1 (neg x)) 1) (+ (/ 1 (neg x)) 1))))
-  (check-equal? '(+ (* 2 (/ 1 x)) (/ 1 (pow x 2)))
+  (check-equal? '(* (- 1 (/ 1 x)) (- 1 (/ 1 x)))
+                (reduce-results '(* (+ (/ 1 (neg x)) 1) (+ (/ 1 (neg x)) 1))))
+  (check-equal? '(+ (* 2 (/ 1 x)) (/ 1 (* x x)))
                 (reduce-results '(+ (* (/ 1 x) (/ 1 x)) (+ (/ 1 x) (/ 1 x)))))
-  (check-equal? '(+ (* 2 (/ 1 x)) (/ 1 (pow x 2)))
+  (check-equal? '(+ (* 2 (/ 1 x)) (/ 1 (* x x)))
                 (reduce-results '(+ (* (/ 1 x) (/ 1 x)) (+ (/ 1 x) (/ 1 x)))))
-  (check-equal? '(pow (cbrt x) 5) (reduce-results '(* x (cbrt x) (cbrt x))))
-  (check-equal? '(/ 1 (pow (cbrt x) 5)) (reduce-results '(/ 1 (* x (cbrt x) (cbrt x)))))
+  (check-equal? '(* (cbrt x) (* (* (cbrt x) (cbrt x)) (* (cbrt x) (cbrt x))))
+                (reduce-results '(* x (cbrt x) (cbrt x))))
+  (check-equal? '(/ 1 (* (cbrt x) (* (* (cbrt x) (cbrt x)) (* (cbrt x) (cbrt x)))))
+                (reduce-results '(/ 1 (* x (cbrt x) (cbrt x)))))
   (check-equal? '(/ 1 (* (cbrt 2) (cbrt a))) (reduce-results '(pow (+ a a) -1/3))))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -611,6 +611,6 @@
   (check-equal? (coeffs '(cbrt (+ 1 x))) '(1 1/3 -1/9 5/81 -10/243 22/729 -154/6561))
   (check-equal? (coeffs '(sqrt x)) '((sqrt x) 0 0 0 0 0 0))
   (check-equal? (coeffs '(cbrt x)) '((cbrt x) 0 0 0 0 0 0))
-  (check-equal? (coeffs '(cbrt (* x x))) '((pow (cbrt x) 2) 0 0 0 0 0 0))
+  (check-equal? (coeffs '(cbrt (* x x))) '((* (cbrt x) (cbrt x)) 0 0 0 0 0 0))
   (check-equal? (coeffs '(fabs (+ 2 x))) '(2 1 0 0 0 0 0))
   (check-equal? (coeffs '(fabs (+ -2 x))) '(2 -1 0 0 0 0 0)))


### PR DESCRIPTION
This PR handles exact integer powers recursively in the reducer, so that integer powers become little trees of multiplies instead of calls to `pow`. This should be faster and support more platforms.

Unrelatedly, it adds a new target to the `expq3` benchmark that's better than the old one.