### PR TITLE
Add DAG cost to pruning alt selection

### DIFF
--- a/src/config.rkt
+++ b/src/config.rkt
@@ -24,7 +24,10 @@
         [rules . (numerics special bools branches)]))
 
 (define debug-flags
-  #hash([generate . (egglog)] [dump . (egg rival egglog trace intermediates)] [setup . (rival2)]))
+  #hash([generate . (egglog)]
+        [reduce . (dag-cost)]
+        [dump . (egg rival egglog trace intermediates)]
+        [setup . (rival2)]))
 
 (define all-flags (hash-union default-flags deprecated-flags debug-flags #:combine set-union))
 

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -1,7 +1,8 @@
 #lang racket
 
-(require math/flonum)
-(require "../core/alternative.rkt"
+(require math/flonum
+         "../config.rkt"
+         "../core/alternative.rkt"
          "../utils/common.rkt"
          "../utils/pareto.rkt"
          "../syntax/types.rkt"
@@ -11,17 +12,16 @@
          "points.rkt"
          "programs.rkt")
 
-(provide (contract-out (make-alt-table (batch? pcontext? alt? any/c . -> . alt-table?))
+(provide (contract-out (make-alt-table (batch? pcontext? alt? . -> . alt-table?))
                        (atab-active-alts (alt-table? . -> . (listof alt?)))
                        (atab-all-alts (alt-table? . -> . (listof alt?)))
                        (atab-not-done-alts (alt-table? . -> . (listof alt?)))
-                       (atab-eval-altns
-                        (alt-table? batch? (listof alt?) context? . -> . (values any/c any/c)))
-                       (atab-add-altns (alt-table? (listof alt?) any/c any/c context? . -> . alt-table?))
+                       (atab-eval-altns (alt-table? batch? (listof alt?) . -> . (values any/c any/c)))
+                       (atab-add-altns (alt-table? (listof alt?) any/c any/c . -> . alt-table?))
                        (atab-set-picked (alt-table? (listof alt?) . -> . alt-table?))
                        (atab-completed? (alt-table? . -> . boolean?))
                        (atab-min-errors (alt-table? . -> . flvector?))
-                       (alt-batch-costs (batch? context? . -> . (batchref? . -> . real?)))))
+                       (alt-batch-costs (batch? . -> . (batchref? . -> . real?)))))
 
 ;; Public API
 
@@ -37,12 +37,11 @@
        [(< x y) (cons y (sorted-index-union xs ys*))]
        [else (cons x (sorted-index-union xs* ys*))])]))
 
-(define (alt-batch-costs batch ctx)
-  (define reprs (batch-reprs batch ctx))
+(define (alt-batch-costs batch)
   (define active-platform (*active-platform*))
   (define (node-cost brf)
     (match (deref brf)
-      [(? literal?) (platform-repr-cost active-platform (reprs brf))]
+      [(? literal?) (platform-repr-cost active-platform (batch-repr-of brf))]
       [(? symbol?) 0]
       [(? number?) 0] ; specs
       [(approx _ _) 0]
@@ -71,11 +70,19 @@
       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
       [(list impl args ...) (sum-set (reachable-mask brf))]
       [_ (node-cost brf)]))
-  (batch-recurse batch dag-cost))
+  (define (tree-cost brf recurse)
+    (match (deref brf)
+      [(? number?) 0] ; specs
+      [(approx _ impl) (recurse impl)]
+      [(list (? (negate impl-exists?) _) args ...) 0] ; specs
+      [(list impl args ...)
+       (+ (node-cost brf) (for/sum ([arg (in-list args)]) (recurse arg)))]
+      [_ (node-cost brf)]))
+  (batch-recurse batch (if (flag-set? 'reduce 'dag-cost) dag-cost tree-cost)))
 
-(define (make-alt-table batch pcontext initial-alt ctx)
-  (define cost ((alt-batch-costs batch ctx) (alt-expr initial-alt)))
-  (define errs (batchref-errors (alt-expr initial-alt) pcontext ctx))
+(define (make-alt-table batch pcontext initial-alt)
+  (define cost ((alt-batch-costs batch) (alt-expr initial-alt)))
+  (define errs (first (batch-errors batch (list (alt-expr initial-alt)) pcontext)))
   (alt-table (for/vector #:length (pcontext-length pcontext)
                          ([err (in-flvector errs)])
                (list (pareto-point cost err (list initial-alt))))
@@ -203,19 +210,19 @@
                [alt->done? (hash-remove* alt->done? altns)]
                [alt->cost (hash-remove* alt->cost altns)]))
 
-(define (atab-eval-altns atab batch altns ctx)
+(define (atab-eval-altns atab batch altns)
   (define brfs (map alt-expr altns))
-  (define errss (batch-errors batch brfs (alt-table-pcontext atab) ctx))
-  (define costs (map (alt-batch-costs batch ctx) brfs))
+  (define errss (batch-errors batch brfs (alt-table-pcontext atab)))
+  (define costs (map (alt-batch-costs batch) brfs))
   (values errss costs))
 
-(define (atab-add-altns atab altns errss costs ctx)
+(define (atab-add-altns atab altns errss costs)
   (define atab*
     (for/fold ([atab atab])
               ([altn (in-list altns)]
                [errs (in-list errss)]
                [cost (in-list costs)])
-      (atab-add-altn atab altn errs cost ctx)))
+      (atab-add-altn atab altn errs cost)))
   (define atab**
     (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab*))]))
   (define atab*** (atab-prune atab**))
@@ -234,12 +241,13 @@
       (hash-update! alt->points* alt (λ (v) (cons idx v)) '())))
   (make-immutable-hasheq (hash->list alt->points*)))
 
-(define (atab-add-altn atab altn errs cost ctx)
+(define (atab-add-altn atab altn errs cost)
   (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
-  (define max-valid-bits (representation-total-bits (context-repr ctx)))
   ;; Check  whether altn is already inserted into atab
   (match (hash-has-key? alt->point-idxs altn)
     [#f
+     (define brf (alt-expr altn))
+     (define max-valid-bits (representation-total-bits (batch-repr-of brf)))
      (define point-idx->alts*
        (for/vector #:length (vector-length point-idx->alts)
                    ([pcurve (in-vector point-idx->alts)]

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -1,6 +1,5 @@
 #lang racket
 
-(require racket/hash)
 (require math/flonum)
 (require "../core/alternative.rkt"
          "../utils/common.rkt"
@@ -28,6 +27,16 @@
 
 (struct alt-table (point-idx->alts alt->point-idxs alt->done? alt->cost pcontext all) #:prefab)
 
+(define (sorted-index-union xs ys)
+  (match* (xs ys)
+    [('() _) ys]
+    [(_ '()) xs]
+    [((cons x xs*) (cons y ys*))
+     (cond
+       [(> x y) (cons x (sorted-index-union xs* ys))]
+       [(< x y) (cons y (sorted-index-union xs ys*))]
+       [else (cons x (sorted-index-union xs* ys*))])]))
+
 (define (alt-batch-costs batch ctx)
   (define reprs (batch-reprs batch ctx))
   (define active-platform (*active-platform*))
@@ -40,18 +49,18 @@
       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
       [(list impl args ...) (impl-info impl 'cost)]))
   (define (sum-set nodes)
-    (for/sum ([idx (in-set nodes)]) (node-cost (batchref batch idx))))
+    (for/sum ([idx (in-list nodes)]) (node-cost (batchref batch idx))))
   (define (node-reachable-mask brf recurse)
     (define node (deref brf))
     (define idx (batchref-idx brf))
-    (define self-set (seteq idx))
+    (define self-set (list idx))
     (match node
-      [(? number?) (seteq)] ; specs
+      [(? number?) '()] ; specs
       [(approx _ impl) (recurse impl)]
-      [(list (? (negate impl-exists?) _) args ...) (seteq)] ; specs
+      [(list (? (negate impl-exists?) _) args ...) '()] ; specs
       [(list impl args ...)
        (for/fold ([nodes self-set]) ([arg (in-list args)])
-         (set-union nodes (recurse arg)))]
+         (sorted-index-union nodes (recurse arg)))]
       [_ self-set]))
   (define reachable-mask (batch-recurse batch node-reachable-mask))
   (define (dag-cost brf recurse)

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -24,10 +24,6 @@
                        (atab-min-errors (alt-table? . -> . flvector?))
                        (alt-batch-costs (batch? context? . -> . (batchref? . -> . real?)))))
 
-(define bitwise-first-bit-set
-  (or (dynamic-require 'racket/base 'bitwise-first-bit-set (const #f))
-      (λ (mask) (sub1 (integer-length (bitwise-and mask (- mask)))))))
-
 ;; Public API
 
 (struct alt-table (point-idx->alts alt->point-idxs alt->done? alt->cost pcontext all) #:prefab)
@@ -43,39 +39,28 @@
       [(approx _ _) 0]
       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
       [(list impl args ...) (impl-info impl 'cost)]))
-  (define (sum-mask mask)
-    (let loop ([mask mask]
-               [cost 0])
-      (cond
-        [(zero? mask) cost]
-        [else
-         (define idx (bitwise-first-bit-set mask))
-         (loop (bitwise-and mask (sub1 mask)) (+ cost (node-cost (batchref batch idx))))])))
+  (define (sum-set nodes)
+    (for/sum ([idx (in-set nodes)]) (node-cost (batchref batch idx))))
   (define (node-reachable-mask brf recurse)
     (define node (deref brf))
     (define idx (batchref-idx brf))
-    (define self-mask (arithmetic-shift 1 idx))
+    (define self-set (seteq idx))
     (match node
-      [(? number?) 0] ; specs
+      [(? number?) (seteq)] ; specs
       [(approx _ impl) (recurse impl)]
-      [(list (? (negate impl-exists?) _) args ...) 0] ; specs
+      [(list (? (negate impl-exists?) _) args ...) (seteq)] ; specs
       [(list impl args ...)
-       (for/fold ([mask self-mask]) ([arg (in-list args)])
-         (bitwise-ior mask (recurse arg)))]
-      [_ self-mask]))
+       (for/fold ([nodes self-set]) ([arg (in-list args)])
+         (set-union nodes (recurse arg)))]
+      [_ self-set]))
   (define reachable-mask (batch-recurse batch node-reachable-mask))
   (define (dag-cost brf recurse)
     (define node (deref brf))
-    (define idx (batchref-idx brf))
     (match node
       [(? number?) 0] ; specs
       [(approx _ impl) (recurse impl)]
       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
-      [(list impl) (node-cost brf)]
-      [(list impl arg args ...)
-       (define base (argmax batchref-idx (cons arg args)))
-       (+ (recurse base)
-          (sum-mask (bitwise-and (reachable-mask brf) (bitwise-not (reachable-mask base)))))]
+      [(list impl args ...) (sum-set (reachable-mask brf))]
       [_ (node-cost brf)]))
   (batch-recurse batch dag-cost))
 

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -29,38 +29,51 @@
 (struct alt-table (point-idx->alts alt->point-idxs alt->done? alt->cost pcontext all) #:prefab)
 
 (define (alt-batch-costs batch ctx)
-  (define node-cost-proc (platform-node-cost-proc (*active-platform*)))
   (define reprs (batch-reprs batch ctx))
-  (define node-costs
-    (batch-recurse batch
-                   (λ (brf _)
-                     (define node (deref brf))
-                     (define repr (reprs brf))
-                     (match node
-                       [(? literal?) ((node-cost-proc node repr))]
-                       [(? symbol?) ((node-cost-proc node repr))]
-                       [(? number?) 0] ; specs
-                       [(approx _ _) 0]
-                       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
-                       [(list impl args ...)
-                        (define cost-proc (node-cost-proc node repr))
-                        (apply cost-proc (make-list (length args) 0))]))))
-  (define reachable
-    (batch-recurse batch
-                   (λ (brf recurse)
-                     (define node (deref brf))
-                     (define idx (batchref-idx brf))
-                     (match node
-                       [(? number?) (set)] ; specs
-                       [(approx _ impl) (recurse impl)]
-                       [(list (? (negate impl-exists?) _) args ...) (set)] ; specs
-                       [(list impl args ...)
-                        (for/fold ([reachable (set idx)]) ([arg (in-list args)])
-                          (set-union reachable (recurse arg)))]
-                       [_ (set idx)]))))
-  (λ (brf)
-    (for/sum ([idx (in-list (sort (set->list (reachable brf)) <))])
-             (node-costs (batchref batch idx)))))
+  (define active-platform (*active-platform*))
+  (define (node-cost brf)
+    (match (deref brf)
+      [(? literal?) (platform-repr-cost active-platform (reprs brf))]
+      [(? symbol?) 0]
+      [(? number?) 0] ; specs
+      [(approx _ _) 0]
+      [(list (? (negate impl-exists?) _) args ...) 0] ; specs
+      [(list impl args ...) (impl-info impl 'cost)]))
+  (define (sum-mask mask)
+    (let loop ([mask mask]
+               [cost 0])
+      (cond
+        [(zero? mask) cost]
+        [else
+         (define idx (bitwise-first-bit-set mask))
+         (loop (bitwise-and mask (sub1 mask)) (+ cost (node-cost (batchref batch idx))))])))
+  (define (node-reachable-mask brf recurse)
+    (define node (deref brf))
+    (define idx (batchref-idx brf))
+    (define self-mask (arithmetic-shift 1 idx))
+    (match node
+      [(? number?) 0] ; specs
+      [(approx _ impl) (recurse impl)]
+      [(list (? (negate impl-exists?) _) args ...) 0] ; specs
+      [(list impl args ...)
+       (for/fold ([mask self-mask]) ([arg (in-list args)])
+         (bitwise-ior mask (recurse arg)))]
+      [_ self-mask]))
+  (define reachable-mask (batch-recurse batch node-reachable-mask))
+  (define (dag-cost brf recurse)
+    (define node (deref brf))
+    (define idx (batchref-idx brf))
+    (match node
+      [(? number?) 0] ; specs
+      [(approx _ impl) (recurse impl)]
+      [(list (? (negate impl-exists?) _) args ...) 0] ; specs
+      [(list impl) (node-cost brf)]
+      [(list impl arg args ...)
+       (define base (argmax batchref-idx (cons arg args)))
+       (+ (recurse base)
+          (sum-mask (bitwise-and (reachable-mask brf) (bitwise-not (reachable-mask base)))))]
+      [_ (node-cost brf)]))
+  (batch-recurse batch dag-cost))
 
 (define (make-alt-table batch pcontext initial-alt ctx)
   (define cost ((alt-batch-costs batch ctx) (alt-expr initial-alt)))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -12,39 +12,59 @@
          "points.rkt"
          "programs.rkt")
 
-(provide (contract-out (make-alt-table (batch? pcontext? alt? . -> . alt-table?))
+(provide (contract-out (make-alt-table (batch? pcontext? alt? any/c . -> . alt-table?))
                        (atab-active-alts (alt-table? . -> . (listof alt?)))
                        (atab-all-alts (alt-table? . -> . (listof alt?)))
                        (atab-not-done-alts (alt-table? . -> . (listof alt?)))
-                       (atab-eval-altns (alt-table? batch? (listof alt?) . -> . (values any/c any/c)))
-                       (atab-add-altns (alt-table? (listof alt?) any/c any/c . -> . alt-table?))
+                       (atab-eval-altns
+                        (alt-table? batch? (listof alt?) context? . -> . (values any/c any/c)))
+                       (atab-add-altns (alt-table? (listof alt?) any/c any/c context? . -> . alt-table?))
                        (atab-set-picked (alt-table? (listof alt?) . -> . alt-table?))
                        (atab-completed? (alt-table? . -> . boolean?))
                        (atab-min-errors (alt-table? . -> . flvector?))
-                       (alt-batch-costs (batch? . -> . (batchref? . -> . real?)))))
+                       (alt-batch-costs (batch? context? . -> . (batchref? . -> . real?)))))
 
 ;; Public API
 
 (struct alt-table (point-idx->alts alt->point-idxs alt->done? alt->cost pcontext all) #:prefab)
 
-(define (alt-batch-costs batch)
+(define (alt-batch-costs batch ctx)
   (define node-cost-proc (platform-node-cost-proc (*active-platform*)))
-  (batch-recurse batch
-                 (λ (brf recurse)
-                   (define node (deref brf))
-                   (match node
-                     [(? literal?) ((node-cost-proc node))]
-                     [(? symbol?) ((node-cost-proc node))]
-                     [(? number?) 0] ; specs
-                     [(approx _ impl) (recurse impl)]
-                     [(list (? (negate impl-exists?) impl) args ...) 0] ; specs
-                     [(list impl args ...)
-                      (define cost-proc (node-cost-proc node))
-                      (apply cost-proc (map recurse args))]))))
+  (define reprs (batch-reprs batch ctx))
+  (define node-costs
+    (batch-recurse batch
+                   (λ (brf _)
+                     (define node (deref brf))
+                     (define repr (reprs brf))
+                     (match node
+                       [(? literal?) ((node-cost-proc node repr))]
+                       [(? symbol?) ((node-cost-proc node repr))]
+                       [(? number?) 0] ; specs
+                       [(approx _ _) 0]
+                       [(list (? (negate impl-exists?) _) args ...) 0] ; specs
+                       [(list impl args ...)
+                        (define cost-proc (node-cost-proc node repr))
+                        (apply cost-proc (make-list (length args) 0))]))))
+  (define reachable
+    (batch-recurse batch
+                   (λ (brf recurse)
+                     (define node (deref brf))
+                     (define idx (batchref-idx brf))
+                     (match node
+                       [(? number?) (set)] ; specs
+                       [(approx _ impl) (recurse impl)]
+                       [(list (? (negate impl-exists?) _) args ...) (set)] ; specs
+                       [(list impl args ...)
+                        (for/fold ([reachable (set idx)]) ([arg (in-list args)])
+                          (set-union reachable (recurse arg)))]
+                       [_ (set idx)]))))
+  (λ (brf)
+    (for/sum ([idx (in-list (sort (set->list (reachable brf)) <))])
+             (node-costs (batchref batch idx)))))
 
-(define (make-alt-table batch pcontext initial-alt)
-  (define cost ((alt-batch-costs batch) (alt-expr initial-alt)))
-  (define errs (first (batch-errors batch (list (alt-expr initial-alt)) pcontext)))
+(define (make-alt-table batch pcontext initial-alt ctx)
+  (define cost ((alt-batch-costs batch ctx) (alt-expr initial-alt)))
+  (define errs (batchref-errors (alt-expr initial-alt) pcontext ctx))
   (alt-table (for/vector #:length (pcontext-length pcontext)
                          ([err (in-flvector errs)])
                (list (pareto-point cost err (list initial-alt))))
@@ -172,19 +192,19 @@
                [alt->done? (hash-remove* alt->done? altns)]
                [alt->cost (hash-remove* alt->cost altns)]))
 
-(define (atab-eval-altns atab batch altns)
+(define (atab-eval-altns atab batch altns ctx)
   (define brfs (map alt-expr altns))
-  (define errss (batch-errors batch brfs (alt-table-pcontext atab)))
-  (define costs (map (alt-batch-costs batch) brfs))
+  (define errss (batch-errors batch brfs (alt-table-pcontext atab) ctx))
+  (define costs (map (alt-batch-costs batch ctx) brfs))
   (values errss costs))
 
-(define (atab-add-altns atab altns errss costs)
+(define (atab-add-altns atab altns errss costs ctx)
   (define atab*
     (for/fold ([atab atab])
               ([altn (in-list altns)]
                [errs (in-list errss)]
                [cost (in-list costs)])
-      (atab-add-altn atab altn errs cost)))
+      (atab-add-altn atab altn errs cost ctx)))
   (define atab**
     (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab*))]))
   (define atab*** (atab-prune atab**))
@@ -203,13 +223,12 @@
       (hash-update! alt->points* alt (λ (v) (cons idx v)) '())))
   (make-immutable-hasheq (hash->list alt->points*)))
 
-(define (atab-add-altn atab altn errs cost)
+(define (atab-add-altn atab altn errs cost ctx)
   (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
+  (define max-valid-bits (representation-total-bits (context-repr ctx)))
   ;; Check  whether altn is already inserted into atab
   (match (hash-has-key? alt->point-idxs altn)
     [#f
-     (define brf (alt-expr altn))
-     (define max-valid-bits (representation-total-bits (batch-repr-of brf)))
      (define point-idx->alts*
        (for/vector #:length (vector-length point-idx->alts)
                    ([pcurve (in-vector point-idx->alts)]

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -1,7 +1,6 @@
 #lang racket
 
 (require racket/hash)
-(require (for-syntax racket/string))
 (require math/flonum)
 (require "../core/alternative.rkt"
          "../utils/common.rkt"
@@ -25,19 +24,9 @@
                        (atab-min-errors (alt-table? . -> . flvector?))
                        (alt-batch-costs (batch? context? . -> . (batchref? . -> . real?)))))
 
-(define-for-syntax (racket-version>=? major minor)
-  (define parts (map string->number (string-split (version) ".")))
-  (define current-major (car parts))
-  (define current-minor (cadr parts))
-  (or (> current-major major) (and (= current-major major) (>= current-minor minor))))
-
-(define-syntax (define-bitwise-first-bit-set stx)
-  #`(define bitwise-first-bit-set
-      #,(if (racket-version>=? 8 16)
-            #'(dynamic-require 'racket/base 'bitwise-first-bit-set)
-            #'(λ (mask) (sub1 (integer-length (bitwise-and mask (- mask))))))))
-
-(define-bitwise-first-bit-set)
+(define bitwise-first-bit-set
+  (or (dynamic-require 'racket/base 'bitwise-first-bit-set (const #f))
+      (λ (mask) (sub1 (integer-length (bitwise-and mask (- mask)))))))
 
 ;; Public API
 

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
 (require racket/hash)
+(require (for-syntax racket/string))
 (require math/flonum)
 (require "../core/alternative.rkt"
          "../utils/common.rkt"
@@ -23,6 +24,20 @@
                        (atab-completed? (alt-table? . -> . boolean?))
                        (atab-min-errors (alt-table? . -> . flvector?))
                        (alt-batch-costs (batch? context? . -> . (batchref? . -> . real?)))))
+
+(define-for-syntax (racket-version>=? major minor)
+  (define parts (map string->number (string-split (version) ".")))
+  (define current-major (car parts))
+  (define current-minor (cadr parts))
+  (or (> current-major major) (and (= current-major major) (>= current-minor minor))))
+
+(define-syntax (define-bitwise-first-bit-set stx)
+  #`(define bitwise-first-bit-set
+      #,(if (racket-version>=? 8 16)
+            #'(dynamic-require 'racket/base 'bitwise-first-bit-set)
+            #'(λ (mask) (sub1 (integer-length (bitwise-and mask (- mask))))))))
+
+(define-bitwise-first-bit-set)
 
 ;; Public API
 

--- a/www/doc/2.3/options.html
+++ b/www/doc/2.3/options.html
@@ -258,6 +258,12 @@
       expressions, not just variables. This slows Herbie down,
       particularly for large programs. If turned off, Herbie will only
       try to branch on variables.</dd>
+
+    <dt><code>reduce:dag-cost</code></dt>
+    <dd>This option, off by default, uses a more complex algorithm
+    when pruning. It slows Herbie down, particularly for large
+    programs. If turned on, Herbie will use more common subexpressions
+    and make more use of functions that return arrays.</dd>
   </dl>
 
 </body>


### PR DESCRIPTION
Currently we measure alt cost with "tree cost", which means that repeated subexpressions are "charged" for every use. #1590 shows that that's the wrong approach, especially for arrays (where each `ref` into an array surely shouldn't pay for the array as a whole!). Using DAG cost in e-graph extraction is expensive, but using it for pruning is a good middle ground.

The key is an efficient implementation. This PR uses the following optimization tricks:

- Reachability masks use bitsets for efficiency
- The sum-reachable step picks a previous node and only computes extra nodes on top of it
- Cache everything and use clean code

That helps a ton, but it's still not fast enough to turn on by default, so it's currently hidden behind the `reduce:dag-cost` flag.

Remaining nits:
- [ ] No clear story for "aggregate functions", meaning `if` statements.