### PR TITLE
Remove the reproduce tool

### DIFF
--- a/src/api/run.rkt
+++ b/src/api/run.rkt
@@ -6,9 +6,8 @@
          "../reports/pages.rkt"
          "../reports/timeline.rkt"
          "../syntax/read.rkt"
-         "../syntax/sugar.rkt"
-         "../syntax/types.rkt"
          "../syntax/platform.rkt"
+         "../syntax/types.rkt"
          "../syntax/load-platform.rkt"
          "../utils/common.rkt"
          "../utils/profile.rkt"
@@ -18,40 +17,11 @@
          "sandbox.rkt"
          "server.rkt")
 
-(provide make-report
-         rerun-report)
-
-(define (extract-test row)
-  (define vars (table-row-vars row))
-  (define repr (get-representation (table-row-precision row)))
-  (define var-reprs (map (curryr cons repr) vars))
-  (define ctx (context vars repr (map (const repr) vars)))
-  (test (table-row-name row)
-        (table-row-identifier row)
-        (table-row-vars row)
-        (fpcore->prog (table-row-input row) ctx)
-        (fpcore->prog (table-row-output row) ctx)
-        (table-row-target-prog row)
-        (fpcore->prog (table-row-spec row) ctx)
-        (fpcore->prog (table-row-pre row) ctx)
-        (representation-name repr)
-        (for/list ([(k v) (in-dict var-reprs)])
-          (cons k (representation-name v)))
-        (table-row-conversions row)))
+(provide make-report)
 
 (define (make-report bench-dirs #:dir dir #:threads threads)
   (activate-platform! (*platform-name*))
   (define tests (sort (append-map load-tests bench-dirs) string-ci<? #:key test-name))
-  (run-tests tests #:dir dir #:threads threads))
-
-(define (rerun-report json-file #:dir dir #:threads threads)
-  (define data (call-with-input-file json-file read-datafile))
-  (define tests (map extract-test (report-info-tests data)))
-  (activate-platform! (*platform-name*))
-  (*flags* (report-info-flags data))
-  (set-seed! (report-info-seed data))
-  (*num-points* (report-info-points data))
-  (*num-iterations* (report-info-iterations data))
   (run-tests tests #:dir dir #:threads threads))
 
 (define (read-json-files info dir name)

--- a/src/main.rkt
+++ b/src/main.rkt
@@ -9,7 +9,7 @@
 
 ;; Define the built-in platforms to force bundling them
 (lazy-require ["api/demo.rkt" (run-demo)]
-              ["api/run.rkt" (make-report rerun-report)]
+              ["api/run.rkt" (make-report)]
               ["api/shell.rkt" (run-shell run-improve)])
 
 (define (string->thread-count th)
@@ -147,10 +147,6 @@
     "Run Herbie on an FPCore file, producing an HTML report"
     #:args (input output)
     (make-report (list input) #:dir output #:threads threads)]
-   [reproduce
-    "Rerun an HTML report"
-    #:args (input output)
-    (rerun-report input #:dir output #:threads threads)]
    #:args files
    (match files
      ['()

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -1,15 +1,9 @@
 #lang racket
 
-(require (only-in xml write-xexpr xexpr?)
-         (only-in fpbench core->tex *expr-cse-able?* [core-common-subexpr-elim core-cse]))
 (require math/flonum)
 
-(require "../core/alternative.rkt"
-         "../utils/common.rkt"
-         "../syntax/float.rkt"
+(require "../utils/common.rkt"
          "../syntax/read.rkt"
-         "../syntax/types.rkt"
-         "../core/bsearch.rkt"
          "../core/points.rkt"
          "common.rkt"
          "history.rkt")

--- a/src/reports/traceback.rkt
+++ b/src/reports/traceback.rkt
@@ -1,6 +1,5 @@
 #lang racket
 
-(require (only-in xml write-xexpr xexpr?))
 (require "../utils/common.rkt"
          "../syntax/read.rkt"
          "common.rkt")


### PR DESCRIPTION
#1587 revealed that the `reproduce` tool has actually long been broken. In fact, it's worse than that, because that PR didn't fix it! So, thinking things through, probably we should just remove this tool—clearly no one uses it, we've never documented it, and there's no point maintaining it now that the nightlies are our primary form of reproducible execution.