### PR TITLE
Ban odd denominator `pow` during extraction

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1039,10 +1039,24 @@
        [(? symbol?) 0]
        ; approx node
        [(list '$approx _ impl) (rec impl)]
-       [(list (? impl-exists?) args ...) ; impls
-        (define cost-proc (node-cost-proc node type))
-        (apply cost-proc (map rec args))])]
+       [(list (? impl-exists? impl) args ...) ; impls
+        (match (pow-impl-args impl args)
+          [(cons _ e)
+           #:when (let ([n (vector-ref (regraph-constants regraph) e)])
+                    (fraction-with-odd-denominator? n))
+           +inf.0]
+          [_
+           (define cost-proc (node-cost-proc node type))
+           (apply cost-proc (map rec args))])])]
     [else (default-egg-cost-proc regraph cache node type rec)]))
+
+(module+ test
+  (define cost-regraph (regraph #() #() #f (vector #f #f 2/3 1/2) #() #hash() ctx))
+  (define (test-rec _)
+    1)
+  (check-equal? (platform-egg-cost-proc cost-regraph #f '(pow.f64 0 2) <binary64> test-rec) +inf.0)
+  (check-not-equal? (platform-egg-cost-proc cost-regraph #f '(pow.f64 0 3) <binary64> test-rec)
+                    +inf.0))
 
 ;; Extracts the best expression according to the extractor.
 ;; Result is a single element list.


### PR DESCRIPTION
Does it feel like we've done this before? Yes, yes it does. I don't know what happened. But, to review, `(pow x 2/3)` is bad because, after you round `2/3`, this won't work for negative `x`.