### PR TITLE
Replace Kalman filter example with subroutines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,14 @@ FROM rust:1.88.0 AS egg-herbie-builder
 WORKDIR /herbie
 COPY egg-herbie egg-herbie
 RUN cargo build --release --manifest-path=egg-herbie/Cargo.toml
-RUN cargo install egglog --version 1.0.0
+RUN cargo install --git "https://github.com/egraphs-good/egglog-experimental" --rev eae9570d78105c53497fccdf0ff7fb1937592036 egglog-experimental
 
 # Production image
 FROM racket/racket:8.17-full AS production
 LABEL maintainer="Pavel Panchekha <me@pavpanchekha.com>"
 COPY --from=egg-herbie-builder /herbie/egg-herbie /src/egg-herbie
 RUN raco pkg install --no-docs /src/egg-herbie
-COPY --from=egg-herbie-builder /usr/local/cargo/bin/egglog /usr/local/bin/egglog
+COPY --from=egg-herbie-builder /usr/local/cargo/bin/egglog-experimental /usr/local/bin/egglog-experimental
 COPY src /src/herbie
 RUN raco pkg install --no-docs --auto /src/herbie
 ENTRYPOINT ["racket", "/src/herbie/main.rkt"]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ egg-herbie:
 	raco pkg install ./egg-herbie
 
 egglog-herbie:
-	cargo install --git "https://github.com/egraphs-good/egglog-experimental" --branch main egglog-experimental
+	cargo install --git "https://github.com/egraphs-good/egglog-experimental" --rev eae9570d78105c53497fccdf0ff7fb1937592036 egglog-experimental
 
 distribution: minimal-distribution
 	cp -r bench herbie-compiled/

--- a/bench/physics/kalman.fpcore
+++ b/bench/physics/kalman.fpcore
@@ -1,235 +1,127 @@
-(FPCore (dt r)
-        :name "Kalman filter per K"
-        :pre (and (> dt 0) (> r 0))
-        ; initializing matrices
-        (let ([p00 25.0]
-              [p01 0.0]
-              [p02 0.0]
-              [p10 0.0]
-              [p11 10.0]
-              [p12 0.0]
-              [p20 0.0]
-              [p21 0.0]
-              [p22 1.0]
-        
-              [f00 1.0]
-              [f01 dt]
-              [f02 (* 0.5 (* dt dt))]
-              [f10 0.0]
-              [f11 1.0]
-              [f12 dt]
-              [f20 0.0]
-              [f21 0.0]
-              [f22 1.0]
-        
-              [q00 (* 0.25 (* dt (* dt (* dt dt))))]
-              [q01 (* 0.5 (* dt (* dt dt)))]
-              [q02 (* 0.5 (* dt dt))]
-              [q10 (* 0.5 (* dt (* dt dt)))]
-              [q11 (* dt dt)]
-              [q12 dt]
-              [q20 (* 0.5 (* dt dt))]
-              [q21 dt]
-              [q22 1])
-          ; axbT_33(P, F, P)
-          (let ([p00* (+ (+ (* p00 f00) (* p01 f01)) (* p02 f02))]
-                [p01* (+ (+ (* p00 f10) (* p01 f11)) (* p02 f12))]
-                [p02* (+ (+ (* p00 f20) (* p01 f21)) (* p02 f22))]
-                [p10* (+ (+ (* p10 f00) (* p11 f01)) (* p12 f02))]
-                [p11* (+ (+ (* p10 f10) (* p11 f11)) (* p12 f12))]
-                [p12* (+ (+ (* p10 f20) (* p11 f21)) (* p12 f22))]
-                [p20* (+ (+ (* p20 f00) (* p21 f01)) (* p22 f02))]
-                [p21* (+ (+ (* p20 f10) (* p21 f11)) (* p22 f12))]
-                [p22* (+ (+ (* p20 f20) (* p21 f21)) (* p22 f22))])
-            ; axb_33(F, P, P)
-            (let ([p00** (+ (+ (* f00 p00*) (* f01 p10*)) (* f02 p20*))]
-                  [p01** (+ (+ (* f00 p01*) (* f01 p11*)) (* f02 p21*))]
-                  [p02** (+ (+ (* f00 p02*) (* f01 p12*)) (* f02 p22*))]
-                  [p10** (+ (+ (* f10 p00*) (* f11 p10*)) (* f12 p20*))]
-                  [p11** (+ (+ (* f10 p01*) (* f11 p11*)) (* f12 p21*))]
-                  [p12** (+ (+ (* f10 p02*) (* f11 p12*)) (* f12 p22*))]
-                  [p20** (+ (+ (* f20 p00*) (* f21 p10*)) (* f22 p20*))]
-                  [p21** (+ (+ (* f20 p01*) (* f21 p11*)) (* f22 p21*))]
-                  [p22** (+ (+ (* f20 p02*) (* f21 p12*)) (* f22 p22*))])
-              ; a_add_b_33(P, Q, P)
-              (let ([p00*** (+ p00** q00)]
-                    [p01*** (+ p01** q01)]
-                    [p02*** (+ p02** q02)]
-                    [p10*** (+ p10** q10)]
-                    [p11*** (+ p11** q11)]
-                    [p12*** (+ p12** q12)]
-                    [p20*** (+ p20** q20)]
-                    [p21*** (+ p21** q21)]
-                    [p22*** (+ p22** q22)])
-                ; update_K
-                (let ([K0 (/ p00*** (+ p00*** r))]
-                      [K1 (/ p10*** (+ p00*** r))]
-                      [K2 (/ p20*** (+ p00*** r))])
-                  K0))))))
-                      
-(FPCore (x0 x1 x2 dt r sensor)
-        :name "Kalman filter per x"
-        :pre (and (> dt 0) (> r 0) (> sensor 0))
-        ; initializing matrices
-        (let ([p00 25.0]
-              [p01 0.0]
-              [p02 0.0]
-              [p10 0.0]
-              [p11 10.0]
-              [p12 0.0]
-              [p20 0.0]
-              [p21 0.0]
-              [p22 1.0]
-        
-              [f00 1.0]
-              [f01 dt]
-              [f02 (* 0.5 (* dt dt))]
-              [f10 0.0]
-              [f11 1.0]
-              [f12 dt]
-              [f20 0.0]
-              [f21 0.0]
-              [f22 1.0]
-        
-              [q00 (* 0.25 (* dt (* dt (* dt dt))))]
-              [q01 (* 0.5 (* dt (* dt dt)))]
-              [q02 (* 0.5 (* dt dt))]
-              [q10 (* 0.5 (* dt (* dt dt)))]
-              [q11 (* dt dt)]
-              [q12 dt]
-              [q20 (* 0.5 (* dt dt))]
-              [q21 dt]
-              [q22 1])
-          ; axbT_33(P, F, P)
-          (let ([p00* (+ (+ (* p00 f00) (* p01 f01)) (* p02 f02))]
-                [p01* (+ (+ (* p00 f10) (* p01 f11)) (* p02 f12))]
-                [p02* (+ (+ (* p00 f20) (* p01 f21)) (* p02 f22))]
-                [p10* (+ (+ (* p10 f00) (* p11 f01)) (* p12 f02))]
-                [p11* (+ (+ (* p10 f10) (* p11 f11)) (* p12 f12))]
-                [p12* (+ (+ (* p10 f20) (* p11 f21)) (* p12 f22))]
-                [p20* (+ (+ (* p20 f00) (* p21 f01)) (* p22 f02))]
-                [p21* (+ (+ (* p20 f10) (* p21 f11)) (* p22 f12))]
-                [p22* (+ (+ (* p20 f20) (* p21 f21)) (* p22 f22))])
-            ; axb_33(F, P, P)
-            (let ([p00** (+ (+ (* f00 p00*) (* f01 p10*)) (* f02 p20*))]
-                  [p01** (+ (+ (* f00 p01*) (* f01 p11*)) (* f02 p21*))]
-                  [p02** (+ (+ (* f00 p02*) (* f01 p12*)) (* f02 p22*))]
-                  [p10** (+ (+ (* f10 p00*) (* f11 p10*)) (* f12 p20*))]
-                  [p11** (+ (+ (* f10 p01*) (* f11 p11*)) (* f12 p21*))]
-                  [p12** (+ (+ (* f10 p02*) (* f11 p12*)) (* f12 p22*))]
-                  [p20** (+ (+ (* f20 p00*) (* f21 p10*)) (* f22 p20*))]
-                  [p21** (+ (+ (* f20 p01*) (* f21 p11*)) (* f22 p21*))]
-                  [p22** (+ (+ (* f20 p02*) (* f21 p12*)) (* f22 p22*))])
-              ; a_add_b_33(P, Q, P)
-              (let ([p00*** (+ p00** q00)]
-                    [p01*** (+ p01** q01)]
-                    [p02*** (+ p02** q02)]
-                    [p10*** (+ p10** q10)]
-                    [p11*** (+ p11** q11)]
-                    [p12*** (+ p12** q12)]
-                    [p20*** (+ p20** q20)]
-                    [p21*** (+ p21** q21)]
-                    [p22*** (+ p22** q22)])
-                ; update_K
-                (let ([K0 (/ p00*** (+ p00*** r))]
-                      [K1 (/ p10*** (+ p00*** r))]
-                      [K2 (/ p20*** (+ p00*** r))])
-                  ; predict_x
-                  (let ([x0* (+ x0 (+ x1 (* 0.5 (* dt (* dt x2)))))]
-                        [x1* (+ x1 x2)]
-                        [x2* x2])
-                    (let ([y (- sensor x0*)])
-                      ; update_x
-                      (let ([x0** (+ x0* (* K0 y))]
-                            [x1** (+ x1* (* K1 y))]
-                            [x2** (+ x2* (* K2 y))])
-                        x0**)))))))))
-                        
-(FPCore (dt r)
-        :name "Kalman filter per P"
-        :pre (and (> dt 0) (> r 0))
-        ; initializing matrices
-        (let ([p00 25.0]
-              [p01 0.0]
-              [p02 0.0]
-              [p10 0.0]
-              [p11 10.0]
-              [p12 0.0]
-              [p20 0.0]
-              [p21 0.0]
-              [p22 1.0]
-        
-              [f00 1.0]
-              [f01 dt]
-              [f02 (* 0.5 (* dt dt))]
-              [f10 0.0]
-              [f11 1.0]
-              [f12 dt]
-              [f20 0.0]
-              [f21 0.0]
-              [f22 1.0]
-        
-              [q00 (* 0.25 (* dt (* dt (* dt dt))))]
-              [q01 (* 0.5 (* dt (* dt dt)))]
-              [q02 (* 0.5 (* dt dt))]
-              [q10 (* 0.5 (* dt (* dt dt)))]
-              [q11 (* dt dt)]
-              [q12 dt]
-              [q20 (* 0.5 (* dt dt))]
-              [q21 dt]
-              [q22 1])
-          ; axbT_33(P, F, P)
-          (let ([p00* (+ (+ (* p00 f00) (* p01 f01)) (* p02 f02))]
-                [p01* (+ (+ (* p00 f10) (* p01 f11)) (* p02 f12))]
-                [p02* (+ (+ (* p00 f20) (* p01 f21)) (* p02 f22))]
-                [p10* (+ (+ (* p10 f00) (* p11 f01)) (* p12 f02))]
-                [p11* (+ (+ (* p10 f10) (* p11 f11)) (* p12 f12))]
-                [p12* (+ (+ (* p10 f20) (* p11 f21)) (* p12 f22))]
-                [p20* (+ (+ (* p20 f00) (* p21 f01)) (* p22 f02))]
-                [p21* (+ (+ (* p20 f10) (* p21 f11)) (* p22 f12))]
-                [p22* (+ (+ (* p20 f20) (* p21 f21)) (* p22 f22))])
-            ; axb_33(F, P, P)
-            (let ([p00** (+ (+ (* f00 p00*) (* f01 p10*)) (* f02 p20*))]
-                  [p01** (+ (+ (* f00 p01*) (* f01 p11*)) (* f02 p21*))]
-                  [p02** (+ (+ (* f00 p02*) (* f01 p12*)) (* f02 p22*))]
-                  [p10** (+ (+ (* f10 p00*) (* f11 p10*)) (* f12 p20*))]
-                  [p11** (+ (+ (* f10 p01*) (* f11 p11*)) (* f12 p21*))]
-                  [p12** (+ (+ (* f10 p02*) (* f11 p12*)) (* f12 p22*))]
-                  [p20** (+ (+ (* f20 p00*) (* f21 p10*)) (* f22 p20*))]
-                  [p21** (+ (+ (* f20 p01*) (* f21 p11*)) (* f22 p21*))]
-                  [p22** (+ (+ (* f20 p02*) (* f21 p12*)) (* f22 p22*))])
-              ; a_add_b_33(P, Q, P)
-              (let ([p00*** (+ p00** q00)]
-                    [p01*** (+ p01** q01)]
-                    [p02*** (+ p02** q02)]
-                    [p10*** (+ p10** q10)]
-                    [p11*** (+ p11** q11)]
-                    [p12*** (+ p12** q12)]
-                    [p20*** (+ p20** q20)]
-                    [p21*** (+ p21** q21)]
-                    [p22*** (+ p22** q22)])
-                ; update_K
-                (let ([K0 (/ p00*** (+ p00*** r))]
-                      [K1 (/ p10*** (+ p00*** r))]
-                      [K2 (/ p20*** (+ p00*** r))])
-                  ; update_P
-                  (let ([eyekh00 (- 1 K0)]
-                        [eyekh01 0.0]
-                        [eyekh02 0.0]
-                        [eyekh10 (- K1)]
-                        [eyekh11 1.0]
-                        [eyekh12 0.0]
-                        [eyekh20 (- K2)]
-                        [eyekh21 0.0]
-                        [eyekh22 1.0])
-                    ; axb_33(&eyekh, P, P)
-                    (let ([p00**** (+ (+ (* eyekh00 p00***) (* eyekh01 p10***)) (* eyekh02 p20***))]
-                          [p01**** (+ (+ (* eyekh00 p01***) (* eyekh01 p11***)) (* eyekh02 p21***))]
-                          [p02**** (+ (+ (* eyekh00 p02***) (* eyekh01 p12***)) (* eyekh02 p22***))]
-                          [p10**** (+ (+ (* eyekh10 p00***) (* eyekh11 p10***)) (* eyekh12 p20***))]
-                          [p11**** (+ (+ (* eyekh10 p01***) (* eyekh11 p11***)) (* eyekh12 p21***))]
-                          [p12**** (+ (+ (* eyekh10 p02***) (* eyekh11 p12***)) (* eyekh12 p22***))]
-                          [p20**** (+ (+ (* eyekh20 p00***) (* eyekh21 p10***)) (* eyekh22 p20***))]
-                          [p21**** (+ (+ (* eyekh20 p01***) (* eyekh21 p11***)) (* eyekh22 p21***))]
-                          [p22**** (+ (+ (* eyekh20 p02***) (* eyekh21 p12***)) (* eyekh22 p22***))])
-                      p00****))))))))
+;; From https://github.com/sandialabs/elaenia/blob/main/examples/05_kalman/05_gps/
+
+(FPCore build_Q (dt)
+  (array (array (* (* (* (* 0.25 dt) dt) dt) dt)
+                (* (* (* 0.5 dt) dt) dt)
+                (* (* 0.5 dt) dt))
+         (array (* (* (* 0.5 dt) dt) dt)
+                (* dt dt)
+                dt)
+         (array (* (* 0.5 dt) dt)
+                dt
+                1)))
+
+(FPCore build_P ()
+  (array (array 25  0 0)
+         (array  0 10 0)
+         (array  0  0 1)))
+
+(FPCore build_F (dt)
+  (array (array 1 dt (* (* 0.5 dt) dt))
+         (array 0  1 dt)
+         (array 0  0 1)))
+
+(FPCore axb_33 ((a 3 3) (b 3 3))
+  (array (array (+ (+ (* (ref a 0 0) (ref b 0 0))
+                      (* (ref a 0 1) (ref b 1 0)))
+                   (* (ref a 0 2) (ref b 2 0)))
+                (+ (+ (* (ref a 0 0) (ref b 0 1))
+                      (* (ref a 0 1) (ref b 1 1)))
+                   (* (ref a 0 2) (ref b 2 1)))
+                (+ (+ (* (ref a 0 0) (ref b 0 2))
+                      (* (ref a 0 1) (ref b 1 2)))
+                   (* (ref a 0 2) (ref b 2 2))))
+         (array (+ (+ (* (ref a 1 0) (ref b 0 0))
+                      (* (ref a 1 1) (ref b 1 0)))
+                   (* (ref a 1 2) (ref b 2 0)))
+                (+ (+ (* (ref a 1 0) (ref b 0 1))
+                      (* (ref a 1 1) (ref b 1 1)))
+                   (* (ref a 1 2) (ref b 2 1)))
+                (+ (+ (* (ref a 1 0) (ref b 0 2))
+                      (* (ref a 1 1) (ref b 1 2)))
+                   (* (ref a 1 2) (ref b 2 2))))
+         (array (+ (+ (* (ref a 2 0) (ref b 0 0))
+                      (* (ref a 2 1) (ref b 1 0)))
+                   (* (ref a 2 2) (ref b 2 0)))
+                (+ (+ (* (ref a 2 0) (ref b 0 1))
+                      (* (ref a 2 1) (ref b 1 1)))
+                   (* (ref a 2 2) (ref b 2 1)))
+                (+ (+ (* (ref a 2 0) (ref b 0 2))
+                      (* (ref a 2 1) (ref b 1 2)))
+                   (* (ref a 2 2) (ref b 2 2))))))
+
+(FPCore axbT_33 ((a 3 3) (b 3 3))
+  (array (array (+ (+ (* (ref a 0 0) (ref b 0 0))
+                      (* (ref a 0 1) (ref b 0 1)))
+                   (* (ref a 0 2) (ref b 0 2)))
+                (+ (+ (* (ref a 0 0) (ref b 1 0))
+                      (* (ref a 0 1) (ref b 1 1)))
+                   (* (ref a 0 2) (ref b 1 2)))
+                (+ (+ (* (ref a 0 0) (ref b 2 0))
+                      (* (ref a 0 1) (ref b 2 1)))
+                   (* (ref a 0 2) (ref b 2 2))))
+         (array (+ (+ (* (ref a 1 0) (ref b 0 0))
+                      (* (ref a 1 1) (ref b 0 1)))
+                   (* (ref a 1 2) (ref b 0 2)))
+                (+ (+ (* (ref a 1 0) (ref b 1 0))
+                      (* (ref a 1 1) (ref b 1 1)))
+                   (* (ref a 1 2) (ref b 1 2)))
+                (+ (+ (* (ref a 1 0) (ref b 2 0))
+                      (* (ref a 1 1) (ref b 2 1)))
+                   (* (ref a 1 2) (ref b 2 2))))
+         (array (+ (+ (* (ref a 2 0) (ref b 0 0))
+                      (* (ref a 2 1) (ref b 0 1)))
+                   (* (ref a 2 2) (ref b 0 2)))
+                (+ (+ (* (ref a 2 0) (ref b 1 0))
+                      (* (ref a 2 1) (ref b 1 1)))
+                   (* (ref a 2 2) (ref b 1 2)))
+                (+ (+ (* (ref a 2 0) (ref b 2 0))
+                      (* (ref a 2 1) (ref b 2 1)))
+                   (* (ref a 2 2) (ref b 2 2))))))
+
+(FPCore a_add_b_33 ((a 3 3) (b 3 3))
+  (array (array (+ (ref a 0 0) (ref b 0 0))
+                (+ (ref a 0 1) (ref b 0 1))
+                (+ (ref a 0 2) (ref b 0 2)))
+         (array (+ (ref a 1 0) (ref b 1 0))
+                (+ (ref a 1 1) (ref b 1 1))
+                (+ (ref a 1 2) (ref b 1 2)))
+         (array (+ (ref a 2 0) (ref b 2 0))
+                (+ (ref a 2 1) (ref b 2 1))
+                (+ (ref a 2 2) (ref b 2 2)))))
+
+(FPCore predict_P ((P 3 3) (F 3 3) (Q 3 3))
+   (let* ([P (axbT_33 P F)]
+          [P (axb_33 F P)]
+          [P (a_add_b_33 P Q)])
+     P))
+
+(FPCore predict_x ((x 3) dt)
+  (array (+ (+ (ref x 0) (ref x 1)) (* (* (* 0.5 dt) dt) (ref x 2)))
+         (+ (ref x 1) (ref x 2))
+         (ref x 2)))
+
+(FPCore update_P ((P 3 3) (K 3))
+  (let ([eyekh (array (array (- 1 (ref K 0)) 0 0)
+                      (array (- (ref K 1)) 1 0)
+                      (array (- (ref K 2)) 0 1))])
+    (axb_33 eyekh P)))
+
+(FPCore update_K ((K 3) (P 3 3) r)
+  (array (/ (ref (ref P 0) 0) (+ (ref (ref P 0) 0) r))
+         (/ (ref (ref P 1) 0) (+ (ref (ref P 0) 0) r))
+         (/ (ref (ref P 2) 0) (+ (ref (ref P 0) 0) r))))
+
+(FPCore update_x ((x 3) (K 3) y)
+  (array (+ (ref x 0) (* (ref K 0) y))
+         (+ (ref x 1) (* (ref K 1) y))
+         (+ (ref x 2) (* (ref K 2) y))))
+
+(FPCore main_body (m (x 3) (K 3) (P 3 3))
+  (let* ([x (predict_x x dt)]
+         [P (predict_P P F Q)]
+         [y (- m (ref x 0))]
+         [K (update_K K P r)]
+         [x (update_x x K y)]
+         [P (update_P P K)])
+    K))

--- a/bench/physics/kalman.fpcore
+++ b/bench/physics/kalman.fpcore
@@ -107,7 +107,7 @@
                       (array (- (ref K 2)) 0 1))])
     (axb_33 eyekh P)))
 
-(FPCore update_K ((K 3) (P 3 3) r)
+(FPCore update_K ((P 3 3) r)
   (array (/ (ref (ref P 0) 0) (+ (ref (ref P 0) 0) r))
          (/ (ref (ref P 1) 0) (+ (ref (ref P 0) 0) r))
          (/ (ref (ref P 2) 0) (+ (ref (ref P 0) 0) r))))
@@ -117,11 +117,28 @@
          (+ (ref x 1) (* (ref K 1) y))
          (+ (ref x 2) (* (ref K 2) y))))
 
-(FPCore main_body (m (x 3) (K 3) (P 3 3))
-  (let* ([x (predict_x x dt)]
+(FPCore (m dt (x 3) (P 3 3))
+  :name "Loop body, returning x"
+  (let* ([F (build_F dt)]
+         [Q (build_Q dt)]
+         [r 16]
+         [x (predict_x x dt)]
          [P (predict_P P F Q)]
          [y (- m (ref x 0))]
-         [K (update_K K P r)]
+         [K (update_K P r)]
          [x (update_x x K y)]
+         #;[P (update_P P K)])
+    x))
+
+(FPCore (#;m dt #;(x 3) (P 3 3))
+  :name "Loop body, returning P"
+  (let* ([F (build_F dt)]
+         [Q (build_Q dt)]
+         [r 16]
+         #;[x (predict_x x dt)]
+         [P (predict_P P F Q)]
+         #;[y (- m (ref x 0))]
+         [K (update_K P r)]
+         #;[x (update_x x K y)]
          [P (update_P P K)])
-    K))
+    P))

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -88,57 +88,12 @@
 
   ;; 2. Inserting expressions into the egglog program and getting a Listof (exprs . extract bindings)
 
-  ;; Overview of the new extraction method:
-  ;;
-  ;; The idea is to wrap the top-level `let` bindings inside a rule, and then
-  ;; execute that rule to perform the computation and store results using constructors.
-  ;;
-  ;; In the original design, we had a sequence of `let` bindings followed by a schedule run and
-  ;; then we perform an extraction of the required bindings.
-  ;;
-  ;; The new design introduces unextractable constructors to hold each intermediate result.
-  ;; These constructors are used in combination with a rule that performs all the bindings
-  ;; and assigns them via `set`
-  ;;
-  ;;   (constructor const1 () Expr :unextractable)
-  ;;   (constructor const2 () Expr :unextractable)
-  ;;   (constructor const3 () Expr :unextractable)
-  ;;   ...
-  ;;
-  ;;   (ruleset init)
-  ;;
-  ;;   (rule () (
-  ;;     (let a1 ...)
-  ;;     (union (const1) a1)
-  ;;
-  ;;     (let a2 ...)
-  ;;     (union (const2) a2)
-  ;;
-  ;;     (let b1 ...)
-  ;;     (union (const3) b1)
-  ;;   )
-  ;;   :ruleset init)
-  ;;
-  ;;   (run init 1)
-  ;;   (extract (const1))
-  ;;   (extract (const2))
-  ;;   (extract (const3))
-  ;;
-  ;;
-  ;; The idea behind this updated design is to prevent egglog from constantly rebuilding which
-  ;; it does after every top level command. Hence, we wrap the top level bindings into the actions
-  ;; of a rule and make them accessible through their unique constructor. Therefore, we must
-  ;; keep track of the mapping between each binding and its corresponding constructor.
-
   (define-values (all-bindings extract-bindings)
     (egglog-add-exprs insert-batch insert-brfs (egglog-runner-ctx runner) subproc))
 
-  (egglog-send subproc
-               `(ruleset run-extract-commands)
-               `(rule () (,@all-bindings) :ruleset run-extract-commands)
-               `(run-schedule (repeat 1 run-extract-commands)))
+  (apply egglog-send subproc all-bindings)
 
-  ;; 4. Running the schedule : having code inside to emulate egraph-run-rules
+  ;; 3. Running the schedule : having code inside to emulate egraph-run-rules
 
   (for ([step (in-list schedule)])
     (apply egglog-send subproc (egglog-step-commands step pform))
@@ -149,12 +104,8 @@
       ;; Run the rewrite ruleset interleaved with const-fold until the best iteration
       ['rewrite (egglog-unsound-detected-subprocess step subproc)]))
 
-  ;; 5. Extract using constructor names returned by egglog-add-exprs.
-  (define stdout-content
-    (egglog-multi-extract subproc
-                          `(multi-extract ,extract
-                                          ,@(for/list ([constructor-name extract-bindings])
-                                              `(,constructor-name)))))
+  ;; 4. Extract using binding names returned by egglog-add-exprs.
+  (define stdout-content (egglog-multi-extract subproc `(multi-extract ,extract ,@extract-bindings)))
 
   ;; Close everything subprocess related
   (egglog-subprocess-close subproc)
@@ -388,8 +339,8 @@
     (cond
       [(hash-has-key? vars x)
        (if spec?
-           (string->symbol (format "?s~a" (hash-ref vars x)))
-           (string->symbol (format "?t~a" (hash-ref vars x))))]
+           (string->symbol (format "$herbie_s_~a" (hash-ref vars x)))
+           (string->symbol (format "$herbie_t_~a" (hash-ref vars x))))]
       [else (vector-ref mappings x)]))
 
   ; node -> egglog node binding
@@ -397,12 +348,11 @@
   (define (insert-node! node n root?)
     (define binding
       (if root?
-          (string->symbol (format "?r~a" n))
-          (string->symbol (format "?b~a" n))))
+          (string->symbol (format "$herbie_r_~a" n))
+          (string->symbol (format "$herbie_b_~a" n))))
     (hash-set! bindings binding node)
     binding)
 
-  (define root-bindings '())
   ; Inserting nodes bottom-up
   (define root-mask (make-vector (batch-length batch) #f))
 
@@ -449,9 +399,7 @@
 
     (if node*
         (vector-set! mappings n (insert-node! node* n root?))
-        (hash-set! vars n node))
-    (when root?
-      (set! root-bindings (cons (vector-ref mappings n) root-bindings))))
+        (hash-set! vars n node)))
 
   ; Var-lowering-rules
   (for ([var (in-list (context-vars ctx))]
@@ -472,96 +420,40 @@
                         :ruleset
                         lift)))
 
-  (define all-bindings '())
-  (define binding->constructor (make-hash)) ; map from binding name to constructor name
+  (define all-bindings
+    (reap [sow]
+          ; Var-spec-bindings
+          (for ([var (in-list (context-vars ctx))])
+            (define binding-name (string->symbol (format "$herbie_s_~a" var)))
+            (sow `(let ,binding-name (Var ,(symbol->string var)))))
+          ; Var-typed-bindings
+          (for ([var (in-list (context-vars ctx))]
+                [repr (in-list (context-var-reprs ctx))])
+            (define binding-name (string->symbol (format "$herbie_t_~a" var)))
+            (sow `(let ,binding-name
+                    (,(typed-var-id (representation-name repr)) ,(symbol->string var)))))
+          ; Binding Exprs
+          (for ([root? (in-vector root-mask)]
+                [n (in-naturals)]
+                #:when (not (hash-has-key? vars n)))
 
-  (define constructor-num 1)
+            (define binding-name
+              (if root?
+                  (string->symbol (format "$herbie_r_~a" n))
+                  (string->symbol (format "$herbie_b_~a" n))))
 
-  ; ; Var-spec-bindings
-  (for ([var (in-list (context-vars ctx))])
-    ; Get the binding names for the program
-    (define binding-name (string->symbol (format "?s~a" var)))
-    (define constructor-name (string->symbol (format "const~a" constructor-num)))
-    (hash-set! binding->constructor binding-name constructor-name)
-
-    ; Define the actual binding
-    (define curr-var-spec-binding `(let ,binding-name (Var ,(symbol->string var))))
-
-    ; Send the constructor definition
-    (egglog-send subproc `(constructor ,constructor-name () M :unextractable))
-
-    ; Add the binding and constructor union to all-bindings for the future rule
-    (set! all-bindings (cons curr-var-spec-binding all-bindings))
-    (set! all-bindings (cons `(union (,constructor-name) ,binding-name) all-bindings))
-
-    (set! constructor-num (add1 constructor-num)))
-
-  ; Var-typed-bindings
-  (for ([var (in-list (context-vars ctx))]
-        [repr (in-list (context-var-reprs ctx))])
-    ; Get the binding names for the program
-    (define binding-name (string->symbol (format "?t~a" var)))
-    (define constructor-name (string->symbol (format "const~a" constructor-num)))
-    (hash-set! binding->constructor binding-name constructor-name)
-
-    ; Define the actual binding
-    (define curr-var-typed-binding
-      `(let ,binding-name (,(typed-var-id (representation-name repr)) ,(symbol->string var))))
-
-    ; Send the constructor definition
-    (egglog-send subproc `(constructor ,constructor-name () MTy :unextractable))
-
-    ; Add the binding and constructor union to all-bindings for the future rule
-    (set! all-bindings (cons curr-var-typed-binding all-bindings))
-    (set! all-bindings (cons `(union (,constructor-name) ,binding-name) all-bindings))
-
-    (set! constructor-num (add1 constructor-num)))
-
-  ; Binding Exprs
-  (for ([root? (in-vector root-mask)]
-        [n (in-naturals)]
-        #:when (not (hash-has-key? vars n)))
-
-    (define binding-name
-      (if root?
-          (string->symbol (format "?r~a" n))
-          (string->symbol (format "?b~a" n))))
-
-    (define constructor-name (string->symbol (format "const~a" constructor-num)))
-    (hash-set! binding->constructor binding-name constructor-name)
-
-    (define actual-binding (hash-ref bindings binding-name))
-
-    (define curr-datatype
-      (match actual-binding
-        [(cons 'do-lower _) 'MTy]
-        [(cons 'do-lift _) 'M]
-
-        ;; TODO : fix this way of getting spec or impl
-        [_ (if root? 'MTy 'M)]))
-
-    (define curr-binding-exprs `(let ,binding-name ,actual-binding))
-
-    (egglog-send subproc `(constructor ,constructor-name () ,curr-datatype :unextractable))
-
-    (set! all-bindings (cons curr-binding-exprs all-bindings))
-    (set! all-bindings (cons `(union (,constructor-name) ,binding-name) all-bindings))
-
-    (set! constructor-num (add1 constructor-num)))
+            (sow `(let ,binding-name ,(hash-ref bindings binding-name))))))
 
   (define curr-bindings
     (for/list ([brf brfs])
       (define root (batchref-idx brf))
-      (define curr-binding-name
-        (if (hash-has-key? vars root)
-            (if (spec? brf)
-                (string->symbol (format "?s~a" (hash-ref vars root)))
-                (string->symbol (format "?t~a" (hash-ref vars root))))
-            (string->symbol (format "?r~a" root))))
+      (if (hash-has-key? vars root)
+          (if (spec? brf)
+              (string->symbol (format "$herbie_s_~a" (hash-ref vars root)))
+              (string->symbol (format "$herbie_t_~a" (hash-ref vars root))))
+          (string->symbol (format "$herbie_r_~a" root)))))
 
-      (hash-ref binding->constructor curr-binding-name)))
-
-  (values (reverse all-bindings) curr-bindings))
+  (values all-bindings curr-bindings))
 
 (define (egglog-unsound-detected-subprocess tag subproc)
   (define node-limit (*node-limit*))

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -135,15 +135,17 @@
 
   ;; 4. Extract using constructor names returned by egglog-add-exprs.
   (define stdout-content
-    (egglog-multi-extract
-     subproc
-     `(multi-extract ,extract
-                     ,@(for/list ([binding (in-list extract-bindings)]
-                                  [repr (in-list reprs)])
-                         (match-define (cons constructor-name datatype) binding)
-                         (match datatype
-                           ['M `(do-lower (,constructor-name) ,(egglog-repr-token repr))]
-                           ['MTy `(,constructor-name)])))))
+    (if (null? extract-bindings)
+        '()
+        (egglog-multi-extract
+         subproc
+         `(multi-extract ,extract
+                         ,@(for/list ([binding (in-list extract-bindings)]
+                                      [repr (in-list reprs)])
+                             (match-define (cons constructor-name datatype) binding)
+                             (match datatype
+                               ['M `(do-lower (,constructor-name) ,(egglog-repr-token repr))]
+                               ['MTy `(,constructor-name)]))))))
 
   ;; Close everything subprocess related
   (egglog-subprocess-close subproc)

--- a/src/platforms/c.rkt
+++ b/src/platforms/c.rkt
@@ -29,6 +29,7 @@
 (define-representation <binary32> #:cost 32bit-move-cost)
 (define <array32> (make-array-representation #:elem <binary32> #:len 2))
 (define <array32r3> (make-array-representation #:elem <binary32> #:len 3))
+(define <array32r3r3> (make-array-representation #:elem <array32r3> #:len 3))
 
 (define-operation (if.f32 [c <bool>] [t <binary32>] [f <binary32>]) <binary32>
   #:spec (if c t f) #:impl if-impl
@@ -91,6 +92,7 @@
 
 (define-representation <array32> #:cost (* 2 32bit-move-cost))
 (define-representation <array32r3> #:cost (* 3 32bit-move-cost))
+(define-representation <array32r3r3> #:cost (* 3 3 32bit-move-cost))
 
 (define-operation (array.f32 [x <binary32>] [y <binary32>]) <array32>
   #:spec (array x y)
@@ -104,6 +106,12 @@
   #:fpcore (! :precision binary32 (array x y z))
   #:cost 0.375)
 
+(define-operation (array3x3.f32 [x <array32r3>] [y <array32r3>] [z <array32r3>]) <array32r3r3>
+  #:spec (array x y z)
+  #:impl (lambda (a b c) (vector a b c))
+  #:fpcore (array x y z)
+  #:cost 1.125)
+
 (define-operation (ref.f32 [arr <array32>] [idx <binary32>]) <binary32>
   #:spec (ref arr idx)
   #:impl (lambda (arr idx)
@@ -112,6 +120,13 @@
   #:cost 0.2)
 
 (define-operation (ref.r3.f32 [arr <array32r3>] [idx <binary32>]) <binary32>
+  #:spec (ref arr idx)
+  #:impl (lambda (arr idx)
+           (vector-ref arr (inexact->exact (round idx))))
+  #:fpcore (! :precision binary32 (ref arr idx))
+  #:cost 0.2)
+
+(define-operation (ref.r3r3.f32 [arr <array32r3r3>] [idx <binary32>]) <array32r3>
   #:spec (ref arr idx)
   #:impl (lambda (arr idx)
            (vector-ref arr (inexact->exact (round idx))))
@@ -147,6 +162,7 @@
 (define <array64> (make-array-representation #:elem <binary64> #:len 2))
 (define <array64r3> (make-array-representation #:elem <binary64> #:len 3))
 (define <array64r2> (make-array-representation #:elem <array64> #:len 2))
+(define <array64r3r3> (make-array-representation #:elem <array64r3> #:len 3))
 
 (define-operation (if.f64 [c <bool>] [t <binary64>] [f <binary64>]) <binary64>
   #:spec (if c t f) #:impl if-impl
@@ -209,6 +225,7 @@
 (define-representation <array64> #:cost (* 2 64bit-move-cost))
 (define-representation <array64r3> #:cost (* 3 64bit-move-cost))
 (define-representation <array64r2> #:cost (* 2 64bit-move-cost))
+(define-representation <array64r3r3> #:cost (* 3 3 64bit-move-cost))
 
 (define-operation (array.f64 [x <binary64>] [y <binary64>]) <array64>
   #:spec (array x y)
@@ -228,6 +245,12 @@
   #:fpcore (array x y)
   #:cost 0.25)
 
+(define-operation (array3x3.f64 [x <array64r3>] [y <array64r3>] [z <array64r3>]) <array64r3r3>
+  #:spec (array x y z)
+  #:impl (lambda (a b c) (vector a b c))
+  #:fpcore (array x y z)
+  #:cost 1.125)
+
 (define-operation (ref.f64 [arr <array64>] [idx <binary64>]) <binary64>
   #:spec (ref arr idx)
   #:impl (lambda (arr idx)
@@ -243,6 +266,13 @@
   #:cost 0.2)
 
 (define-operation (ref.r2.f64 [arr <array64r2>] [idx <binary64>]) <array64>
+  #:spec (ref arr idx)
+  #:impl (lambda (arr idx)
+           (vector-ref arr (inexact->exact (round idx))))
+  #:fpcore (! :precision binary64 (ref arr idx))
+  #:cost 0.2)
+
+(define-operation (ref.r3r3.f64 [arr <array64r3r3>] [idx <binary64>]) <array64r3>
   #:spec (ref arr idx)
   #:impl (lambda (arr idx)
            (vector-ref arr (inexact->exact (round idx))))

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -202,7 +202,7 @@
         body*
         targets
         (dict-ref prop-dict ':herbie-expected #t)
-        spec
+        (prog->spec spec)
         pre*
         (representation-name output-repr)
         (for/list ([var (in-list var-names)]

--- a/src/syntax/read.rkt
+++ b/src/syntax/read.rkt
@@ -193,7 +193,7 @@
   ;; Named fpcores become platform operators
   (when (and func-name (*register-named-fpcore-operators?*))
     (register-fpcore-operator! func-name (struct-copy context ctx [repr output-repr]) body* spec))
-  (check-unused-variables var-names body* pre*)
+  (check-unused-variables var-names pre* body* func-name)
   (check-weird-variables var-names)
 
   (test (~a name)
@@ -209,7 +209,7 @@
                    [repr (in-list var-reprs)])
           (cons var (representation-name repr)))))
 
-(define (check-unused-variables vars precondition expr)
+(define (check-unused-variables vars precondition expr identifier)
   ;; Fun story: you might want variables in the precondition that
   ;; don't appear in the `expr`, because that can allow you to do
   ;; non-uniform sampling. For example, if you have the precondition
@@ -218,11 +218,15 @@
   (define used (set-union (free-variables expr) (free-variables precondition)))
   (unless (set=? vars used)
     (define unused (set-subtract vars used))
-    (warn 'unused-variable
-          #:url "faq.html#unused-variable"
-          "unused ~a ~a"
-          (if (equal? (set-count unused) 1) "variable" "variables")
-          (string-join (map ~a unused) ", "))))
+    (define noun (if (equal? (set-count unused) 1) "variable" "variables"))
+    (define names (string-join (map ~a unused) ", "))
+    (if identifier
+        (raise-herbie-error "unused ~a ~a in named FPCore ~a"
+                            #:url "faq.html#unused-variable"
+                            noun
+                            names
+                            identifier)
+        (warn 'unused-variable #:url "faq.html#unused-variable" "unused ~a ~a" noun names))))
 
 (define (check-weird-variables vars)
   (for ([var (in-list vars)])
@@ -338,6 +342,9 @@
   (define port
     (open-input-string (string-append "(FPCore helper (x) (+ x 1))\n" "(FPCore (x) (helper x))\n")))
   (check-equal? (length (load-tests port)) 2)
+  (check-exn exn:fail:user:herbie?
+             (lambda () (load-tests (open-input-string "(FPCore helper (x y) x)"))))
+  (check-not-exn (lambda () (load-tests (open-input-string "(FPCore (x y) x)"))))
 
   ;; casting edge cases
   (check-equal? (fpcore->prog `(cast x) ctx) 'x)

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -144,6 +144,10 @@
                (list 'and out (list '!= term term2))
                (list '!= term term2))))
        (or out '(TRUE))]
+      ; expand multi-index array references
+      [`(ref ,arr ,idx ,idxs ...)
+       (for/fold ([out (loop arr env)]) ([idx (in-list (cons idx idxs))])
+         `(ref ,out ,(loop idx env)))]
       ; applications
       [`(,op ,args ...) `(,op ,@(map (curryr loop env) args))]
       ; constants

--- a/src/syntax/syntax-check.rkt
+++ b/src/syntax/syntax-check.rkt
@@ -66,9 +66,11 @@
          (error! stx "Array literal must have at least one element"))
        (for ([elem (in-list elems)])
          (loop elem vars))]
-      [#`(ref #,arr ,idx)
-       (unless (integer? idx)
-         (error! idx "Array index must be a literal integer, got ~a" idx))
+      [#`(ref #,arr #,idx #,idxs ...)
+       (for ([idx (in-list (cons idx idxs))])
+         (define raw (syntax-e idx))
+         (unless (integer? raw)
+           (error! idx "Array index must be a literal integer, got ~a" idx)))
        (loop arr vars)]
       [#`(cast #,arg) (loop arg vars)]
       [#`(cast #,args ...)
@@ -255,5 +257,6 @@
   (check-pred null? (get-errs #'(FPCore (x) (ref (array 1 2) 0))))
   (check-pred null? (get-errs #'(FPCore (x) (array 1 2 3))))
   (check-pred null? (get-errs #'(FPCore (x) (ref (array 1 2) 2))))
+  (check-pred null? (get-errs #'(FPCore (x) (ref (array (array 1 2 3)) 0 2))))
   (check-pred null? (get-errs #'(FPCore ((v 3)) v)))
   (check-pred null? (get-errs #'(FPCore ((v 2 2)) v))))

--- a/src/syntax/test-syntax.rkt
+++ b/src/syntax/test-syntax.rkt
@@ -2,6 +2,7 @@
 
 (require "syntax.rkt"
          "platform.rkt"
+         "sugar.rkt"
          "types.rkt")
 
 (module+ test
@@ -11,6 +12,8 @@
 
   (activate-platform! (*platform-name*))
   (define f64 (get-representation 'binary64))
+  (define f64x3 (get-representation '(array binary64 3)))
+  (define f64x3x3 (get-representation '(array (array binary64 3) 3)))
 
   (define sin-proc (impl-info 'sin.f64 'fl))
   (check-equal? (sin-proc 0.0) 0.0 "sin(0) = 0")
@@ -23,5 +26,8 @@
   (check-equal? (get-impl '+ '((:precision . binary64) (:description . "test")) (list f64 f64))
                 '+.f64)
   (check-equal? (get-impl 'sin '((:precision . binary64)) (list f64)) 'sin.f64)
+  (check-equal? (get-impl 'array '((:precision . binary64)) (list f64x3 f64x3 f64x3)) 'array3x3.f64)
+  (check-equal? (get-impl 'ref '((:precision . binary64)) (list f64x3x3 f64)) 'ref.r3r3.f64)
+  (check-equal? (fpcore->spec '(ref A 2 1)) '(ref (ref A 2) 1))
 
   (void))

--- a/src/syntax/type-check.rkt
+++ b/src/syntax/type-check.rkt
@@ -130,21 +130,21 @@
                    (repr-description first-type)
                    (repr-description t))))
        (array-of first-type (list (+ 1 (length rest-elems))))]
-      [#`(ref #,arr #,idx)
-       (define arr-type (loop arr prop-dict ctx))
-       (define raw (syntax-e idx))
-       (unless (integer? raw)
-         (error! idx "Array index must be a literal integer, got ~a" idx))
-       (match arr-type
-         [(? array-representation?)
-          (define len (array-representation-len arr-type))
-          (define elem (array-representation-elem arr-type))
-          (when (and (integer? raw) (or (< raw 0) (>= raw len)))
-            (error! idx "Array index ~a out of bounds for length ~a" raw len))
-          elem]
-         [_
-          (error! stx "ref expects an array, got ~a" (repr-description arr-type))
-          (get-representation (dict-ref prop-dict ':precision))])]
+      [#`(ref #,arr #,idx #,idxs ...)
+       (for/fold ([arr-type (loop arr prop-dict ctx)]) ([idx (in-list (cons idx idxs))])
+         (define raw (syntax-e idx))
+         (unless (integer? raw)
+           (error! idx "Array index must be a literal integer, got ~a" idx))
+         (match arr-type
+           [(? array-representation?)
+            (define len (array-representation-len arr-type))
+            (define elem (array-representation-elem arr-type))
+            (when (and (integer? raw) (or (< raw 0) (>= raw len)))
+              (error! idx "Array index ~a out of bounds for length ~a" raw len))
+            elem]
+           [_
+            (error! stx "ref expects an array, got ~a" (repr-description arr-type))
+            (get-representation (dict-ref prop-dict ':precision))]))]
       [#`(cast #,arg)
        (define irepr (loop arg prop-dict ctx))
        (define repr (get-representation (dict-ref prop-dict ':precision)))
@@ -252,12 +252,15 @@
     ;; Array-aware typing
     (define vec-type (array-of <b64> '(2)))
     (define vec3-type (array-of <b64> '(3)))
+    (define mat3-type (array-of <b64> '(3 3)))
     (check-types <b64> vec-type #'(array 1 2))
     (check-types <b64> vec3-type #'(array 1 2 3))
     (check-fails <b64> #'(array (array 1) (array 1 2)))
     (check-types <b64> <b64> #'(ref (array 5 6) 0))
     (check-types <b64> <b64> #'(ref A 2) #:env `((A . ,vec3-type)))
+    (check-types <b64> <b64> #'(ref A 2 1) #:env `((A . ,mat3-type)))
     (check-fails <b64> #'(ref A 3) #:env `((A . ,vec3-type)))
+    (check-fails <b64> #'(ref A 2 3) #:env `((A . ,mat3-type)))
     (check-fails <b64> #'(ref x 0) #:env `((x . ,<b64>))))
 
   (check-exn exn:fail?


### PR DESCRIPTION
The Kalman filter example was hand-transcribed by Artem and inlines all the matrix manipulations. This PR instead uses helper functions and array returns to make the code fairly readable.