### PR TITLE
Refactor egraph extraction to pass reprs explicitly

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1203,7 +1203,7 @@
 
 ;; Herbie's version of an egg runner.
 ;; Defines parameters for running rewrite rules with egg
-(struct egg-runner (batch reprs schedule ctx new-roots egg-graph)
+(struct egg-runner (batch schedule ctx new-roots egg-graph)
   #:transparent ; for equality
   #:methods gen:custom-write ; for abbreviated printing
   [(define (write-proc alt port mode)
@@ -1216,7 +1216,7 @@
 ;;  - `rewrite`: run rewrite rules up to node limit with backoff scheduler
 ;;  - `unsound`: run sound-removal rules for 1 iteration with simple scheduler
 ;;  - `lower`: run lowering rules for 1 iteration with simple scheduler
-(define (make-egraph batch brfs reprs schedule ctx)
+(define (make-egraph batch brfs schedule ctx)
   (define (oops! fmt . args)
     (apply error 'verify-schedule! fmt args))
   ; verify the schedule
@@ -1227,7 +1227,7 @@
   (define-values (root-ids egg-graph) (egraph-run-schedule batch brfs schedule ctx))
 
   ; make the runner
-  (egg-runner batch reprs schedule ctx root-ids egg-graph))
+  (egg-runner batch schedule ctx root-ids egg-graph))
 
 (module+ test
   (require "../syntax/load-platform.rkt")
@@ -1236,7 +1236,7 @@
     (define rebuild-ctx (context '(x y) <binary64> (list <binary64> <binary64>)))
     (define expr '(+ (/ 1 2) (* x y)))
     (define-values (batch brfs) (progs->batch (list expr)))
-    (define runner (make-egraph batch brfs (list (context-repr rebuild-ctx)) '() rebuild-ctx))
+    (define runner (make-egraph batch brfs '() rebuild-ctx))
     (define egg-graph (egg-runner-egg-graph runner))
     (define eclasses (u32vector->list (egraph_get_eclasses egg-graph)))
 
@@ -1286,7 +1286,7 @@
     (error 'egraph-prove "proof extraction failed between`~a` and `~a`" start end))
   proof)
 
-(define (egraph-best runner batch)
+(define (egraph-best runner batch reprs)
   (define ctx (egg-runner-ctx runner))
   (define root-ids (egg-runner-new-roots runner))
   (define egg-graph (egg-runner-egg-graph runner))
@@ -1296,7 +1296,6 @@
     [(egraph_is_unsound_detected egg-graph) (map (const empty) root-ids)]
     [else
      (define regraph (make-regraph egg-graph ctx))
-     (define reprs (egg-runner-reprs runner))
      (when (flag-set? 'dump 'egg)
        (regraph-dump regraph root-ids reprs))
 
@@ -1307,7 +1306,7 @@
                 [repr (in-list reprs)])
        (regraph-extract-best regraph extract-id id repr))]))
 
-(define (egraph-variations runner batch)
+(define (egraph-variations runner batch reprs)
   (define ctx (egg-runner-ctx runner))
   (define root-ids (egg-runner-new-roots runner))
   (define egg-graph (egg-runner-egg-graph runner))
@@ -1317,7 +1316,6 @@
     [(egraph_is_unsound_detected egg-graph) (map (const empty) root-ids)]
     [else
      (define regraph (make-regraph egg-graph ctx))
-     (define reprs (egg-runner-reprs runner))
      (when (flag-set? 'dump 'egg)
        (regraph-dump regraph root-ids reprs))
 
@@ -1331,8 +1329,9 @@
 (define (deduplicate-exprs exprs ctxs)
   (define ctx (contexts-union ctxs))
   (define-values (batch brfs) (progs->batch exprs))
-  (define runner (make-egraph batch brfs (map context-repr ctxs) '(lift rewrite lower) ctx))
-  (define batchrefss (egraph-best runner batch))
+  (define reprs (map context-repr ctxs))
+  (define runner (make-egraph batch brfs '(lift rewrite lower) ctx))
+  (define batchrefss (egraph-best runner batch reprs))
   (define batch-pull (batch-exprs batch))
   (for/list ([orig-expr (in-list exprs)]
              [refs (in-list batchrefss)])

--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -379,11 +379,13 @@
   (define ctx (context '(x eps) <binary64> (make-list 2 <binary64>)))
 
   (define reprs (make-list (length brfs) (context-repr ctx)))
+  (define spec-brfs (batch-to-spec! batch brfs))
 
   (define schedule '(lift rewrite lower))
 
   (when (find-executable-path "egglog")
-    (void (run-egglog (make-egglog-runner batch brfs reprs schedule ctx) batch #:extract 1000000))))
+    (void
+     (run-egglog (make-egglog-runner batch spec-brfs schedule ctx) batch reprs #:extract 1000000))))
 
 (module+ test
   (require rackunit)

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -69,7 +69,7 @@
 
 ;; Herbie's version of an egglog runner.
 ;; Defines parameters for running rewrite rules with egglog
-(struct egglog-runner (batch brfs reprs schedule ctx)
+(struct egglog-runner (batch brfs schedule ctx)
   #:transparent ; for equality
   #:methods gen:custom-write ; for abbreviated printing
   [(define (write-proc alt port mode)
@@ -82,7 +82,7 @@
 ;;  - `rewrite`: run rewrite rules up to node limit with backoff scheduler
 ;;  - `unsound`: run sound-removal rules for 1 iteration with simple scheduler
 ;;  - `lower`: run lowering rules for 1 iteration with simple scheduler
-(define (make-egglog-runner batch brfs reprs schedule ctx)
+(define (make-egglog-runner batch brfs schedule ctx)
   (define (oops! fmt . args)
     (apply error 'verify-schedule! fmt args))
   ; verify the schedule
@@ -91,10 +91,14 @@
       (oops! "unknown schedule step `~a`" step)))
 
   ; make the runner
-  (egglog-runner batch brfs reprs schedule ctx))
+  (egglog-runner batch brfs schedule ctx))
 
 ;; Runs egglog using an egglog runner by extracting multiple variants
-(define (run-egglog runner output-batch [label #f] #:extract extract) ; multi expression extraction
+(define (run-egglog runner
+                    output-batch
+                    reprs
+                    [label #f]
+                    #:extract extract) ; multi expression extraction
   (define insert-batch (egglog-runner-batch runner))
   (define insert-brfs (egglog-runner-brfs runner))
   (define schedule (egglog-runner-schedule runner))
@@ -173,8 +177,10 @@
   (define stdout-content
     (egglog-multi-extract subproc
                           `(multi-extract ,extract
-                                          ,@(for/list ([constructor-name extract-bindings])
-                                              `(,constructor-name)))))
+                                          ,@(for/list ([constructor-name (in-list extract-bindings)]
+                                                       [repr (in-list reprs)])
+                                              `(do-lower (,constructor-name)
+                                                         ,(egglog-repr-token repr))))))
 
   ;; Close everything subprocess related
   (egglog-subprocess-close subproc)
@@ -434,8 +440,7 @@
        (match node
          [(? literal?) #f] ;; If literal, not a spec
          [(? number?) #t] ;; If number, it's a spec
-         [(? symbol?)
-          #f] ;; If symbol, assume not a spec could be either (find way to distinguish) : PREPROCESS
+         [(? symbol?) #t]
          [(hole _ _) #f] ;; If hole, not a spec
          [(approx _ _) #f] ;; If approx, not a spec
          [`(if ,cond ,ift ,iff)
@@ -557,7 +562,7 @@
         [(cons 'do-lift _) 'M]
 
         ;; TODO : fix this way of getting spec or impl
-        [_ (if root? 'MTy 'M)]))
+        [_ (if (spec? (batchref batch n)) 'M 'MTy)]))
 
     (define curr-binding-exprs `(let ,binding-name ,actual-binding))
 

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -30,6 +30,8 @@
                               #;(exp ,exp-x ,log-x)
                               #;(log ,log-x ,exp-x))))
 
+(struct taylor-approx (spec repr impl-spec name var order prev) #:transparent)
+
 (define (taylor-alts altns global-batch spec-batch reducer)
   (define vars
     (for/list ([var (in-list (context-vars (*context*)))]
@@ -54,9 +56,7 @@
                 [altn (in-list altns)]
                 #:when (equal? (representation-type repr) 'real))
             (define genexpr0 (batch-add! global-batch 0))
-            (define gen0 (approx spec-brf (hole (representation-name repr) genexpr0)))
-            (define brf0 (batch-add! global-batch gen0))
-            (sow (alt brf0 `(taylor zero undef-var -1) (list altn))))
+            (sow (taylor-approx spec-brf repr genexpr0 'zero 'undef-var -1 altn)))
 
           ;; Taylor expansions
           ;; List<List<(cons offset coeffs)>>
@@ -76,43 +76,50 @@
                   #:when (set-member? fv var)) ;; check whether var exists in expr at all
               (for ([i (in-range (*taylor-order-limit*))])
                 ;; adding a new expansion to the global batch
-                (define gen (approx spec-brf (hole (representation-name repr) (copier (genexpr)))))
-                (define brf (batch-add! global-batch gen))
-                (sow (alt brf `(taylor ,name ,var ,i) (list altn)))))
+                (define genexpr-brf (copier (genexpr)))
+                (sow (taylor-approx spec-brf repr genexpr-brf name var i altn))))
             (set! idx (add1 idx))
             (timeline-stop!)))))
 
 (define (run-taylor altns global-batch spec-batch reducer)
   (timeline-event! 'series)
-  (define (key x)
-    (define expr (deref (alt-expr x)))
-    (if (approx? expr)
-        (approx-impl expr)
-        expr))
+  (define (taylor-key x)
+    (taylor-approx-impl-spec x))
+  (define (approx-key x)
+    (approx-impl (deref (alt-expr x))))
 
-  (define approxs (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key key))
-  (define approxs* (remove-duplicates (run-lowering approxs global-batch) #:key key))
+  (define approxs
+    (remove-duplicates (taylor-alts altns global-batch spec-batch reducer) #:key taylor-key))
+  (define approxs* (remove-duplicates (run-lowering approxs global-batch) #:key approx-key))
 
   (timeline-push! 'inputs (batch->jsexpr global-batch (map alt-expr altns)))
   (timeline-push! 'outputs (batch->jsexpr global-batch (map alt-expr approxs*)))
   (timeline-push! 'count (length altns) (length approxs*))
   approxs*)
 
-(define (run-lowering altns global-batch)
+(define (run-lowering taylors global-batch)
   (define schedule '(lower))
 
   ; run egg
-  (define brfs (map alt-expr altns))
-  (define reprs (map (batch-reprs global-batch (*context*)) brfs))
+  (define-values (specs impl-specs reprs names vars orders prevs)
+    (for/lists (specs impl-specs reprs names vars orders prevs)
+               ([taylor (in-list taylors)])
+               (values (taylor-approx-spec taylor)
+                       (taylor-approx-impl-spec taylor)
+                       (taylor-approx-repr taylor)
+                       (taylor-approx-name taylor)
+                       (taylor-approx-var taylor)
+                       (taylor-approx-order taylor)
+                       (taylor-approx-prev taylor))))
 
   (define runner
     (cond
       [(flag-set? 'generate 'egglog)
        (define batch* (batch-empty))
        (define copy-f (batch-copy-only! batch* global-batch))
-       (define brfs* (map copy-f brfs))
-       (make-egglog-runner batch* brfs* reprs schedule (*context*))]
-      [else (make-egraph global-batch brfs reprs schedule (*context*))]))
+       (define impl-specs* (map copy-f impl-specs))
+       (make-egglog-runner batch* impl-specs* reprs schedule (*context*))]
+      [else (make-egraph global-batch impl-specs reprs schedule (*context*))]))
 
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
@@ -122,9 +129,15 @@
   ; apply changelists
   (reap [sow]
         (for ([batchrefs (in-list batchrefss)]
-              [altn (in-list altns)])
+              [spec (in-list specs)]
+              [name (in-list names)]
+              [var (in-list vars)]
+              [order (in-list orders)]
+              [prev (in-list prevs)])
           (for ([batchref* (in-list batchrefs)])
-            (sow (alt batchref* (list 'rr runner #f) (list altn)))))))
+            (define brf (batch-add! global-batch (approx spec batchref*)))
+            (define taylor-altn (alt brf `(taylor ,name ,var ,order) (list prev)))
+            (sow (alt brf (list 'rr runner #f) (list taylor-altn)))))))
 
 (define (run-evaluate altns global-batch)
   (timeline-event! 'sample)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -118,13 +118,13 @@
        (define batch* (batch-empty))
        (define copy-f (batch-copy-only! batch* global-batch))
        (define impl-specs* (map copy-f impl-specs))
-       (make-egglog-runner batch* impl-specs* reprs schedule (*context*))]
-      [else (make-egraph global-batch impl-specs reprs schedule (*context*))]))
+       (make-egglog-runner batch* impl-specs* schedule (*context*))]
+      [else (make-egraph global-batch impl-specs schedule (*context*))]))
 
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
-        (run-egglog runner global-batch 'taylor #:extract 1)
-        (egraph-best runner global-batch)))
+        (run-egglog runner global-batch reprs 'taylor #:extract 1)
+        (egraph-best runner global-batch reprs)))
 
   ; apply changelists
   (reap [sow]
@@ -197,24 +197,19 @@
   (define brfs (map alt-expr altns))
   (define spec-brfs (batch-to-spec! global-batch brfs))
   (define reprs (map (batch-reprs global-batch (*context*)) brfs))
-  (define rr-brfs
-    (for/list ([spec-brf (in-list spec-brfs)]
-               [repr (in-list reprs)])
-      (batch-add! global-batch (hole (representation-name repr) spec-brf))))
-
   (define runner
     (cond
       [(flag-set? 'generate 'egglog)
        (define batch* (batch-empty))
        (define copy-f (batch-copy-only! batch* global-batch))
-       (define brfs* (map copy-f rr-brfs))
-       (make-egglog-runner batch* brfs* reprs schedule (*context*))]
-      [else (make-egraph global-batch rr-brfs reprs schedule (*context*))]))
+       (define brfs* (map copy-f spec-brfs))
+       (make-egglog-runner batch* brfs* schedule (*context*))]
+      [else (make-egraph global-batch spec-brfs schedule (*context*))]))
 
   (define batchrefss
     (if (flag-set? 'generate 'egglog)
-        (run-egglog runner global-batch 'rewrite #:extract 1000000) ; "infinity"
-        (egraph-variations runner global-batch)))
+        (run-egglog runner global-batch reprs 'rewrite #:extract 1000000) ; "infinity"
+        (egraph-variations runner global-batch reprs)))
 
   ; apply changelists
   (define rewritten

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -68,7 +68,7 @@
 
   ;; make egg runner
   (define-values (batch brfs) (progs->batch (cons spec (map cdr identities))))
-  (define runner (make-egraph batch brfs (make-list (length brfs) (context-repr ctx)) '(rewrite) ctx))
+  (define runner (make-egraph batch brfs '(rewrite) ctx))
 
   ;; collect equalities
   (for/list ([(ident spec*) (in-dict identities)]


### PR DESCRIPTION
This PR attempts to refactor the egraph code so that egraphs are always built from *spec*, not impl, terms. As part of this, I change the egg/egglog API so that reprs are passed at extraction, not construction, time. To be honest, the API is still bad and should be cleaned up, but that's not the highest priority.

The benefit of this is that it should make separate spec and impl batches pretty easy to implement.