### PR TITLE
Make batches carry around variable context

### DIFF
--- a/infra/analyze-rules.rkt
+++ b/infra/analyze-rules.rkt
@@ -33,7 +33,7 @@
   (for ([test (in-list tests)]
         [i (in-naturals)])
     (printf "Processing test ~a/~a: ~a\n" (+ i 1) (length tests) (test-name test))
-    (define-values (batch brfs) (progs->batch (list (test-input test))))
+    (define-values (batch brfs) (progs->batch (list (test-input test)) #:ctx (test-context test)))
 
     (for ([iter (in-range (*iters*))])
       (define-values (initial-size final-size sorted-results)

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -140,7 +140,7 @@
   (random) ;; Tick the random number generator, for backwards compatibility
   (define specification (test-spec test))
   (define precondition (test-pre test))
-  (define-values (batch brfs) (progs->batch (list specification)))
+  (define-values (batch brfs) (progs->batch (list specification) #:ctx (*context*)))
   (define sample
     (parameterize ([*num-points* (+ (*num-points*) (*reeval-pts*))])
       (sample-points precondition batch brfs (list (*context*)))))

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -98,8 +98,7 @@
 
 (define (get-cost test)
   (define cost-proc (platform-cost-proc (*active-platform*)))
-  (define output-repr (context-repr (*context*)))
-  (cost-proc (test-input test) output-repr))
+  (cost-proc (test-input test)))
 
 (define (get-errors test pcontext)
   (unless pcontext
@@ -247,8 +246,6 @@
      (define start (hash-ref backend 'start))
      (define targets (hash-ref backend 'target))
      (define end (hash-ref backend 'end))
-     (define expr-cost (platform-cost-proc (*active-platform*)))
-     (define repr (test-output-repr test))
 
      ; starting expr analysis
      (define start-expr (read (open-input-string (hash-ref start 'expr))))

--- a/src/api/server.rkt
+++ b/src/api/server.rkt
@@ -597,7 +597,7 @@
 (define (analysis->json analysis pcontext test errcache)
   (define repr (context-repr (test-context test)))
   (match-define (alt-analysis alt test-errors) analysis)
-  (define cost (alt-cost alt repr))
+  (define cost (alt-cost alt))
 
   (define history-json (render-json alt pcontext (test-context test) errcache))
 

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -30,19 +30,17 @@
 
 (define (alt-batch-costs batch)
   (define node-cost-proc (platform-node-cost-proc (*active-platform*)))
-  (define reprs (batch-reprs batch))
   (batch-recurse batch
                  (λ (brf recurse)
                    (define node (deref brf))
-                   (define repr (reprs brf))
                    (match node
-                     [(? literal?) ((node-cost-proc node repr))]
-                     [(? symbol?) ((node-cost-proc node repr))]
+                     [(? literal?) ((node-cost-proc node))]
+                     [(? symbol?) ((node-cost-proc node))]
                      [(? number?) 0] ; specs
                      [(approx _ impl) (recurse impl)]
                      [(list (? (negate impl-exists?) impl) args ...) 0] ; specs
                      [(list impl args ...)
-                      (define cost-proc (node-cost-proc node repr))
+                      (define cost-proc (node-cost-proc node))
                       (apply cost-proc (map recurse args))]))))
 
 (define (make-alt-table batch pcontext initial-alt ctx)

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -206,11 +206,11 @@
 
 (define (atab-add-altn atab altn errs cost)
   (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
-  (define brf (alt-expr altn))
-  (define max-valid-bits (representation-total-bits ((batch-reprs (batchref-batch brf)) brf)))
   ;; Check  whether altn is already inserted into atab
   (match (hash-has-key? alt->point-idxs altn)
     [#f
+     (define brf (alt-expr altn))
+     (define max-valid-bits (representation-total-bits (batch-repr-of brf)))
      (define point-idx->alts*
        (for/vector #:length (vector-length point-idx->alts)
                    ([pcurve (in-vector point-idx->alts)]

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -18,19 +18,19 @@
           (atab-all-alts (alt-table? . -> . (listof alt?)))
           (atab-not-done-alts (alt-table? . -> . (listof alt?)))
           (atab-eval-altns (alt-table? batch? (listof alt?) context? . -> . (values any/c any/c)))
-          (atab-add-altns (alt-table? (listof alt?) any/c any/c context? . -> . alt-table?))
+          (atab-add-altns (alt-table? (listof alt?) any/c any/c . -> . alt-table?))
           (atab-set-picked (alt-table? (listof alt?) . -> . alt-table?))
           (atab-completed? (alt-table? . -> . boolean?))
           (atab-min-errors (alt-table? . -> . flvector?))
-          (alt-batch-costs (batch? context? . -> . (batchref? . -> . real?)))))
+          (alt-batch-costs (batch? . -> . (batchref? . -> . real?)))))
 
 ;; Public API
 
 (struct alt-table (point-idx->alts alt->point-idxs alt->done? alt->cost pcontext all) #:prefab)
 
-(define (alt-batch-costs batch ctx)
+(define (alt-batch-costs batch)
   (define node-cost-proc (platform-node-cost-proc (*active-platform*)))
-  (define reprs (batch-reprs batch ctx))
+  (define reprs (batch-reprs batch))
   (batch-recurse batch
                  (λ (brf recurse)
                    (define node (deref brf))
@@ -46,7 +46,7 @@
                       (apply cost-proc (map recurse args))]))))
 
 (define (make-alt-table batch pcontext initial-alt ctx)
-  (define cost ((alt-batch-costs batch ctx) (alt-expr initial-alt)))
+  (define cost ((alt-batch-costs batch) (alt-expr initial-alt)))
   (define errs (batchref-errors (alt-expr initial-alt) pcontext ctx))
   (alt-table (for/vector #:length (pcontext-length pcontext)
                          ([err (in-flvector errs)])
@@ -178,16 +178,16 @@
 (define (atab-eval-altns atab batch altns ctx)
   (define brfs (map alt-expr altns))
   (define errss (batch-errors batch brfs (alt-table-pcontext atab) ctx))
-  (define costs (map (alt-batch-costs batch ctx) brfs))
+  (define costs (map (alt-batch-costs batch) brfs))
   (values errss costs))
 
-(define (atab-add-altns atab altns errss costs ctx)
+(define (atab-add-altns atab altns errss costs)
   (define atab*
     (for/fold ([atab atab])
               ([altn (in-list altns)]
                [errs (in-list errss)]
                [cost (in-list costs)])
-      (atab-add-altn atab altn errs cost ctx)))
+      (atab-add-altn atab altn errs cost)))
   (define atab**
     (struct-copy alt-table atab* [alt->point-idxs (invert-index (alt-table-point-idx->alts atab*))]))
   (define atab*** (atab-prune atab**))
@@ -206,10 +206,10 @@
       (hash-update! alt->points* alt (λ (v) (cons idx v)) '())))
   (make-immutable-hasheq (hash->list alt->points*)))
 
-(define (atab-add-altn atab altn errs cost ctx)
+(define (atab-add-altn atab altn errs cost)
   (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
   (define brf (alt-expr altn))
-  (define max-valid-bits (representation-total-bits ((batch-reprs (batchref-batch brf) ctx) brf)))
+  (define max-valid-bits (representation-total-bits ((batch-reprs (batchref-batch brf)) brf)))
   ;; Check  whether altn is already inserted into atab
   (match (hash-has-key? alt->point-idxs altn)
     [#f

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -208,7 +208,8 @@
 
 (define (atab-add-altn atab altn errs cost ctx)
   (match-define (alt-table point-idx->alts alt->point-idxs alt->done? alt->cost pcontext _) atab)
-  (define max-valid-bits (representation-total-bits (context-repr ctx)))
+  (define brf (alt-expr altn))
+  (define max-valid-bits (representation-total-bits ((batch-reprs (batchref-batch brf) ctx) brf)))
   ;; Check  whether altn is already inserted into atab
   (match (hash-has-key? alt->point-idxs altn)
     [#f

--- a/src/core/alternative.rkt
+++ b/src/core/alternative.rkt
@@ -20,9 +20,9 @@
 (define (make-alt expr)
   (alt expr 'start '()))
 
-(define (alt-cost altn repr)
+(define (alt-cost altn)
   (define expr-cost (platform-cost-proc (*active-platform*)))
-  (expr-cost (alt-expr altn) repr))
+  (expr-cost (alt-expr altn)))
 
 (define (alt-map f altn)
   (f (struct-copy alt altn [prevs (map (curry alt-map f) (alt-prevs altn))])))

--- a/src/core/batch-reduce.rkt
+++ b/src/core/batch-reduce.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
-(require "../syntax/batch.rkt"
+(require "../syntax/types.rkt"
+         "../syntax/batch.rkt"
          "../utils/common.rkt"
          "programs.rkt")
 
@@ -336,7 +337,7 @@
 
 (module+ test
   (require rackunit)
-  (define batch (batch-empty))
+  (define batch (batch-empty (context '() #f '())))
   (define evaluator (batch-eval-application batch))
   (define (evaluator-results expr)
     (evaluator (batch-add! batch expr)))

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -189,6 +189,7 @@
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
   (define spec-brfs (batch-to-spec! batch (list start-prog)))
   (define start-real-compiler (make-real-compiler batch spec-brfs (list ctx*)))
+  (define repr-of* (batch-reprs batch ctx*))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))
@@ -197,7 +198,7 @@
     (define brf1 (list-ref progs (si-cidx si1)))
     (define brf2 (list-ref progs (si-cidx si2)))
     (define eval-errors (compile-batch batch (list brf1 brf2) ctx*))
-    (define score-ulps (repr-ulps (context-repr ctx*)))
+    (define score-ulps (repr-ulps (repr-of* brf1)))
     (define (pred v)
       (define pctx
         (parameterize ([*num-points* (*binary-search-test-points*)])
@@ -224,14 +225,14 @@
   (define num-alts (length alts))
   (define num-points (pcontext-length pcontext))
   (define bexpr (sp-bexpr (car splitpoints)))
-  (define ctx* (struct-copy context ctx [repr (repr-of bexpr ctx)]))
+  (define repr (repr-of bexpr ctx))
+  (define ctx* (struct-copy context ctx [repr repr]))
   (define prog (compile-prog bexpr ctx*))
   (define masks (build-vector num-alts (λ (_) (make-vector num-points #f))))
   (for ([(pt _) (in-pcontext pcontext)]
         [idx (in-naturals)])
     (define val (prog pt))
     (for/first ([right (in-list splitpoints)]
-                #:when (or (equal? (sp-point right) +nan.0)
-                           (<=/total val (sp-point right) (context-repr ctx*))))
+                #:when (or (equal? (sp-point right) +nan.0) (<=/total val (sp-point right) repr)))
       (vector-set! (vector-ref masks (sp-cidx right)) idx #t)))
   masks)

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -27,7 +27,7 @@
 (module+ test
   (require rackunit))
 
-(define (finish-combine-alts batch alts brf splitindices splitpoints ctx)
+(define (finish-combine-alts batch alts brf splitindices splitpoints)
   (define splitpoints* (append splitpoints (list (sp (si-cidx (last splitindices)) brf +nan.0))))
   (define reprs (batch-reprs batch))
   (define brf*
@@ -48,14 +48,14 @@
 
 (define (combine-alts batch best-option ctx)
   (match-define (option splitindices alts pts brf) best-option)
-  (define splitpoints (sindices->spoints/left batch pts brf splitindices ctx))
-  (finish-combine-alts batch alts brf splitindices splitpoints ctx))
+  (define splitpoints (sindices->spoints/left batch pts brf splitindices))
+  (finish-combine-alts batch alts brf splitindices splitpoints))
 
 (define (combine-alts/binary batch best-option start-prog ctx pcontext)
   (match-define (option splitindices alts pts brf) best-option)
   (define splitpoints
     (sindices->spoints/binary batch pts brf alts splitindices start-prog ctx pcontext))
-  (finish-combine-alts batch alts brf splitindices splitpoints ctx))
+  (finish-combine-alts batch alts brf splitindices splitpoints))
 
 (define (remove-unused-alts alts splitpoints)
   (for/fold ([alts* '()]
@@ -137,10 +137,10 @@
 ;; float form always come from the range [f(idx1), f(idx2)). If the
 ;; float form of a split is f(idx2), or entirely outside that range,
 ;; problems may arise.
-(define/contract (sindices->spoints/left batch points brf sindices ctx)
+(define/contract (sindices->spoints/left batch points brf sindices)
   (-> batch? (listof vector?) batchref? (listof si?) context? (listof sp?))
   (define repr ((batch-reprs batch) brf))
-  (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf) ctx)))
+  (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf))))
 
   (define (left-point p1 p2)
     (define left ((representation-repr->bf repr) p1))
@@ -178,7 +178,7 @@
       (listof sp?))
   (define repr ((batch-reprs batch) brf))
   (define ulps (repr-ulps repr))
-  (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf) ctx)))
+  (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf))))
   (define brf-node (deref brf))
   (define var
     (if (symbol? brf-node)
@@ -205,7 +205,7 @@
   (define (find-split si1 si2 p1 p2)
     (define brf1 (list-ref progs (si-cidx si1)))
     (define brf2 (list-ref progs (si-cidx si2)))
-    (define eval-errors (compile-batch batch* (list brf1 brf2) ctx*))
+    (define eval-errors (compile-batch batch* (list brf1 brf2)))
     (define score-ulps (repr-ulps (repr-of* brf1)))
     (define (pred v)
       (define pctx

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -46,7 +46,7 @@
   (define-values (alts* splitpoints**) (remove-unused-alts alts splitpoints*))
   (alt brf* (list 'regimes splitpoints**) alts*))
 
-(define (combine-alts batch best-option ctx)
+(define (combine-alts batch best-option)
   (match-define (option splitindices alts pts brf) best-option)
   (define splitpoints (sindices->spoints/left batch pts brf splitindices))
   (finish-combine-alts batch alts brf splitindices splitpoints))
@@ -138,7 +138,7 @@
 ;; float form of a split is f(idx2), or entirely outside that range,
 ;; problems may arise.
 (define/contract (sindices->spoints/left batch points brf sindices)
-  (-> batch? (listof vector?) batchref? (listof si?) context? (listof sp?))
+  (-> batch? (listof vector?) batchref? (listof si?) (listof sp?))
   (define repr ((batch-reprs batch) brf))
   (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf))))
 

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -29,11 +29,10 @@
 
 (define (finish-combine-alts batch alts brf splitindices splitpoints)
   (define splitpoints* (append splitpoints (list (sp (si-cidx (last splitindices)) brf +nan.0))))
-  (define reprs (batch-reprs batch))
   (define brf*
     (for/fold ([brf (alt-expr (list-ref alts (sp-cidx (last splitpoints*))))])
               ([splitpoint (cdr (reverse splitpoints*))])
-      (define repr (reprs (sp-bexpr splitpoint)))
+      (define repr (batch-repr-of (sp-bexpr splitpoint)))
       (define if-impl (get-fpcore-impl 'if '() (list (get-representation 'bool) repr repr)))
       (define <=-impl (get-fpcore-impl '<= '() (list repr repr)))
       (define lit-brf
@@ -139,7 +138,7 @@
 ;; problems may arise.
 (define/contract (sindices->spoints/left batch points brf sindices)
   (-> batch? (listof vector?) batchref? (listof si?) (listof sp?))
-  (define repr ((batch-reprs batch) brf))
+  (define repr (batch-repr-of brf))
   (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf))))
 
   (define (left-point p1 p2)
@@ -176,7 +175,7 @@
       context?
       pcontext?
       (listof sp?))
-  (define repr ((batch-reprs batch) brf))
+  (define repr (batch-repr-of brf))
   (define ulps (repr-ulps repr))
   (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf))))
   (define brf-node (deref brf))
@@ -197,7 +196,6 @@
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
   (define spec-brfs (batch-to-spec! batch* (list start-prog-sub)))
   (define start-real-compiler (make-real-compiler batch* spec-brfs (list ctx*)))
-  (define repr-of* (batch-reprs batch*))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))
@@ -206,7 +204,7 @@
     (define brf1 (list-ref progs (si-cidx si1)))
     (define brf2 (list-ref progs (si-cidx si2)))
     (define eval-errors (compile-batch batch* (list brf1 brf2)))
-    (define score-ulps (repr-ulps (repr-of* brf1)))
+    (define score-ulps (repr-ulps (batch-repr-of brf1)))
     (define (pred v)
       (define pctx
         (parameterize ([*num-points* (*binary-search-test-points*)])

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -29,7 +29,7 @@
 
 (define (finish-combine-alts batch alts brf splitindices splitpoints ctx)
   (define splitpoints* (append splitpoints (list (sp (si-cidx (last splitindices)) brf +nan.0))))
-  (define reprs (batch-reprs batch ctx))
+  (define reprs (batch-reprs batch))
   (define brf*
     (for/fold ([brf (alt-expr (list-ref alts (sp-cidx (last splitpoints*))))])
               ([splitpoint (cdr (reverse splitpoints*))])
@@ -92,18 +92,24 @@
         (timeline-push! 'stop "predicate-same" 1)
         (values p1 p2)])]))
 
-(define (extract-subexpression batch brf var pattern-brf ctx)
-  (define var-brf (batch-add! batch var))
-  (if (= (batchref-idx pattern-brf) (batchref-idx var-brf))
-      brf
-      (let ()
-        (define free-vars (batch-free-vars batch))
-        (define body-brf (batch-replace-subexpr batch brf pattern-brf var-brf))
-        (define vars* (set-subtract (list->set (context-vars ctx)) (free-vars pattern-brf)))
-        (and (subset? (free-vars body-brf) (set-add vars* var)) body-brf))))
+(define (extract-subexpression batch brf pattern-brf batch* var-brf)
+  (define pattern-idx (batchref-idx pattern-brf))
+  (define var (deref var-brf))
+  (define free-vars (batch-free-vars batch))
+  (define vars* (set-subtract (list->set (batch-vars batch)) (free-vars pattern-brf)))
+  (define copy
+    (batch-recurse
+     batch
+     (λ (brf recurse)
+       (cond
+         [(= (batchref-idx brf) pattern-idx) var-brf]
+         [else (batch-push! batch* (expr-recurse (deref brf) (compose batchref-idx recurse)))]))))
+  (define body-brf (copy brf))
+  (define free-vars* (batch-free-vars batch*))
+  (and (subset? (free-vars* body-brf) (set-add vars* var)) body-brf))
 
-(define (deterministic-branch-var ctx)
-  (define used-vars (list->set (context-vars ctx)))
+(define (deterministic-branch-var batch)
+  (define used-vars (list->set (batch-vars batch)))
   (let loop ([n 0])
     (define var (string->symbol (format "branch-~a" n)))
     (if (set-member? used-vars var)
@@ -133,7 +139,7 @@
 ;; problems may arise.
 (define/contract (sindices->spoints/left batch points brf sindices ctx)
   (-> batch? (listof vector?) batchref? (listof si?) context? (listof sp?))
-  (define repr ((batch-reprs batch ctx) brf))
+  (define repr ((batch-reprs batch) brf))
   (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf) ctx)))
 
   (define (left-point p1 p2)
@@ -170,26 +176,28 @@
       context?
       pcontext?
       (listof sp?))
-  (define repr ((batch-reprs batch ctx) brf))
+  (define repr ((batch-reprs batch) brf))
   (define ulps (repr-ulps repr))
   (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf) ctx)))
   (define brf-node (deref brf))
   (define var
     (if (symbol? brf-node)
         brf-node
-        (deterministic-branch-var ctx)))
+        (deterministic-branch-var batch)))
   (define ctx* (context-extend ctx var repr))
+  (define batch* (batch-empty ctx*))
+  (define var-brf (batch-add! batch* var))
   (define progs
     (for/list ([alt (in-list alts)])
-      (extract-subexpression batch (alt-expr alt) var brf ctx)))
-  (define start-prog-sub (extract-subexpression batch start-prog var brf ctx))
+      (extract-subexpression batch (alt-expr alt) brf batch* var-brf)))
+  (define start-prog-sub (extract-subexpression batch start-prog brf batch* var-brf))
   (unless (and start-prog-sub (andmap identity progs))
     (raise-user-error
      'sindices->spoints/binary
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
-  (define spec-brfs (batch-to-spec! batch (list start-prog)))
-  (define start-real-compiler (make-real-compiler batch spec-brfs (list ctx*)))
-  (define repr-of* (batch-reprs batch ctx*))
+  (define spec-brfs (batch-to-spec! batch* (list start-prog-sub)))
+  (define start-real-compiler (make-real-compiler batch* spec-brfs (list ctx*)))
+  (define repr-of* (batch-reprs batch*))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))
@@ -197,7 +205,7 @@
   (define (find-split si1 si2 p1 p2)
     (define brf1 (list-ref progs (si-cidx si1)))
     (define brf2 (list-ref progs (si-cidx si2)))
-    (define eval-errors (compile-batch batch (list brf1 brf2) ctx*))
+    (define eval-errors (compile-batch batch* (list brf1 brf2) ctx*))
     (define score-ulps (repr-ulps (repr-of* brf1)))
     (define (pred v)
       (define pctx

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -77,7 +77,7 @@
   (define-values (batch brfs) (progs->batch exprs #:ctx ctx))
   (compile-batch batch brfs ctx))
 
-(define (compile-batch batch brfs ctx)
+(define (compile-batch batch brfs)
   (define vars (batch-vars batch))
   (define args (make-vector (length vars)))
   (define vregs (make-vector (batch-length batch)))

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -75,7 +75,7 @@
 ;; Translates a Herbie IR into a vector of thunks.
 (define (compile-progs exprs ctx)
   (define-values (batch brfs) (progs->batch exprs #:ctx ctx))
-  (compile-batch batch brfs ctx))
+  (compile-batch batch brfs))
 
 (define (compile-batch batch brfs)
   (define vars (batch-vars batch))

--- a/src/core/compiler.rkt
+++ b/src/core/compiler.rkt
@@ -74,12 +74,11 @@
 ;; returning representation values.
 ;; Translates a Herbie IR into a vector of thunks.
 (define (compile-progs exprs ctx)
-  (define vars (context-vars ctx))
-  (define-values (batch brfs) (progs->batch exprs #:vars vars))
+  (define-values (batch brfs) (progs->batch exprs #:ctx ctx))
   (compile-batch batch brfs ctx))
 
 (define (compile-batch batch brfs ctx)
-  (define vars (context-vars ctx))
+  (define vars (batch-vars batch))
   (define args (make-vector (length vars)))
   (define vregs (make-vector (batch-length batch)))
   (define-values (thunks roots) (batch-for-compiler batch brfs vars args vregs))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1033,8 +1033,7 @@
      (define ctx (regraph-ctx regraph))
      (define node-cost-proc (platform-node-cost-proc (*active-platform*)))
      (match node
-       ; numbers (repr is unused)
-       [(? number? n) ((node-cost-proc (literal n type) type))]
+       [(? number? n) ((node-cost-proc (literal n type)))]
        ; variables
        [(? symbol?) 0]
        ; approx node
@@ -1046,7 +1045,7 @@
                     (fraction-with-odd-denominator? n))
            +inf.0]
           [_
-           (define cost-proc (node-cost-proc node type))
+           (define cost-proc (node-cost-proc node))
            (apply cost-proc (map rec args))])])]
     [else (default-egg-cost-proc regraph cache node type rec)]))
 

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -85,7 +85,6 @@
       [(list op ids ...) (egraph_add_node ptr (~s op) (list->u32vec ids))]
       [(? (disjoin symbol? number?) x) (egraph_add_node ptr (~s x) 0-vec)]))
 
-  (define reprs (batch-reprs batch))
   (define add-to-egraph
     (batch-recurse
      batch
@@ -1328,7 +1327,7 @@
 (define (deduplicate-exprs exprs ctxs)
   (define ctx (contexts-union ctxs))
   (define-values (batch brfs) (progs->batch exprs #:ctx ctx))
-  (define reprs (map (batch-reprs batch) brfs))
+  (define reprs (map batch-repr-of brfs))
   (define runner (make-egraph batch brfs '(lift rewrite lower) ctx))
   (define batchrefss (egraph-best runner batch reprs))
   (define batch-pull (batch-exprs batch))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -85,7 +85,7 @@
       [(list op ids ...) (egraph_add_node ptr (~s op) (list->u32vec ids))]
       [(? (disjoin symbol? number?) x) (egraph_add_node ptr (~s x) 0-vec)]))
 
-  (define reprs (batch-reprs batch ctx))
+  (define reprs (batch-reprs batch))
   (define add-to-egraph
     (batch-recurse
      batch
@@ -140,7 +140,7 @@
   eclass)
 
 (define (egraph-expr-equal? ptr expr goal ctx)
-  (define-values (batch brfs) (progs->batch (list expr goal)))
+  (define-values (batch brfs) (progs->batch (list expr goal) #:ctx ctx))
   (match-define (list id1 id2) (egraph-add-exprs ptr batch brfs ctx))
   (= id1 id2))
 
@@ -1235,7 +1235,7 @@
     (activate-platform! "c")
     (define rebuild-ctx (context '(x y) <binary64> (list <binary64> <binary64>)))
     (define expr '(+ (/ 1 2) (* x y)))
-    (define-values (batch brfs) (progs->batch (list expr)))
+    (define-values (batch brfs) (progs->batch (list expr) #:ctx rebuild-ctx))
     (define runner (make-egraph batch brfs '() rebuild-ctx))
     (define egg-graph (egg-runner-egg-graph runner))
     (define eclasses (u32vector->list (egraph_get_eclasses egg-graph)))
@@ -1328,8 +1328,8 @@
 
 (define (deduplicate-exprs exprs ctxs)
   (define ctx (contexts-union ctxs))
-  (define-values (batch brfs) (progs->batch exprs))
-  (define reprs (map (batch-reprs batch ctx) brfs))
+  (define-values (batch brfs) (progs->batch exprs #:ctx ctx))
+  (define reprs (map (batch-reprs batch) brfs))
   (define runner (make-egraph batch brfs '(lift rewrite lower) ctx))
   (define batchrefss (egraph-best runner batch reprs))
   (define batch-pull (batch-exprs batch))

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -1329,7 +1329,7 @@
 (define (deduplicate-exprs exprs ctxs)
   (define ctx (contexts-union ctxs))
   (define-values (batch brfs) (progs->batch exprs))
-  (define reprs (map context-repr ctxs))
+  (define reprs (map (batch-reprs batch ctx) brfs))
   (define runner (make-egraph batch brfs '(lift rewrite lower) ctx))
   (define batchrefss (egraph-best runner batch reprs))
   (define batch-pull (batch-exprs batch))

--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -318,6 +318,7 @@
 (module+ test
   (require rackunit
            "egglog-herbie.rkt"
+           "programs.rkt"
            "../syntax/types.rkt"
            "../syntax/batch.rkt"
            "rules.rkt"
@@ -378,7 +379,7 @@
 
   (define ctx (context '(x eps) <binary64> (make-list 2 <binary64>)))
 
-  (define reprs (make-list (length brfs) (context-repr ctx)))
+  (define reprs (map (batch-reprs batch ctx) brfs))
   (define spec-brfs (batch-to-spec! batch brfs))
 
   (define schedule '(lift rewrite lower))

--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -377,8 +377,8 @@
       #s(approx (+ x 1) #s(hole binary64 (* x (+ 1 (/ 1 x)))))
       #s(approx (sin x) #s(hole binary64 (sin x)))
       #s(approx (- (sin (+ x 1)) (sin x)) #s(hole binary64 (- (sin (- 1 (* -1 x))) (sin x))))
-      #s(approx (sin (+ x 1)) #s(hole binary64 (sin (- 1 (* -1 x)))))))
-    #:ctx ctx)
+      #s(approx (sin (+ x 1)) #s(hole binary64 (sin (- 1 (* -1 x))))))
+     #:ctx ctx))
 
   (define reprs (map (batch-reprs batch) brfs))
   (define spec-brfs (batch-to-spec! batch brfs))

--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -327,6 +327,7 @@
            "../syntax/float.rkt"
            "../syntax/load-platform.rkt")
   (activate-platform! "c")
+  (define ctx (context '(x eps) <binary64> (make-list 2 <binary64>)))
 
   (define-values (batch brfs)
     (progs->batch (list '(-.f64 (sin.f64 (+.f64 x eps)) (sin.f64 x))
@@ -334,7 +335,8 @@
                         '(+.f64 x eps)
                         'x
                         'eps
-                        '(sin.f64 x))))
+                        '(sin.f64 x))
+                  #:ctx ctx))
 
   (define-values (batch2 brfs2)
     (progs->batch
@@ -375,11 +377,10 @@
       #s(approx (+ x 1) #s(hole binary64 (* x (+ 1 (/ 1 x)))))
       #s(approx (sin x) #s(hole binary64 (sin x)))
       #s(approx (- (sin (+ x 1)) (sin x)) #s(hole binary64 (- (sin (- 1 (* -1 x))) (sin x))))
-      #s(approx (sin (+ x 1)) #s(hole binary64 (sin (- 1 (* -1 x))))))))
+      #s(approx (sin (+ x 1)) #s(hole binary64 (sin (- 1 (* -1 x)))))))
+    #:ctx ctx)
 
-  (define ctx (context '(x eps) <binary64> (make-list 2 <binary64>)))
-
-  (define reprs (map (batch-reprs batch ctx) brfs))
+  (define reprs (map (batch-reprs batch) brfs))
   (define spec-brfs (batch-to-spec! batch brfs))
 
   (define schedule '(lift rewrite lower))

--- a/src/core/egglog-herbie-tests.rkt
+++ b/src/core/egglog-herbie-tests.rkt
@@ -380,7 +380,7 @@
       #s(approx (sin (+ x 1)) #s(hole binary64 (sin (- 1 (* -1 x))))))
      #:ctx ctx))
 
-  (define reprs (map (batch-reprs batch) brfs))
+  (define reprs (map batch-repr-of brfs))
   (define spec-brfs (batch-to-spec! batch brfs))
 
   (define schedule '(lift rewrite lower))

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -154,8 +154,7 @@
   ;; of a rule and make them accessible through their unique constructor. Therefore, we must
   ;; keep track of the mapping between each binding and its corresponding constructor.
 
-  (define-values (all-bindings extract-bindings)
-    (egglog-add-exprs insert-batch insert-brfs (egglog-runner-ctx runner) subproc))
+  (define-values (all-bindings extract-bindings) (egglog-add-exprs insert-batch insert-brfs subproc))
 
   (egglog-send subproc
                `(ruleset run-extract-commands)
@@ -405,7 +404,7 @@
               :ruleset
               ,tag)))
 
-(define (egglog-add-exprs batch brfs ctx subproc)
+(define (egglog-add-exprs batch brfs subproc)
   (define mappings (build-vector (batch-length batch) values))
   (define bindings (make-hash))
   (define vars (make-hash))
@@ -478,8 +477,8 @@
       (set! root-bindings (cons (vector-ref mappings n) root-bindings))))
 
   ; Var-lowering-rules
-  (for ([var (in-list (context-vars ctx))]
-        [repr (in-list (context-var-reprs ctx))])
+  (for ([var (in-list (batch-vars batch))]
+        [repr (in-list (batch-var-reprs batch))])
     (egglog-send subproc
                  `(rule ((= e (Var ,(symbol->string var))))
                         ((union (do-lower e ,(egglog-repr-token repr))
@@ -488,8 +487,8 @@
                         lower)))
 
   ; Var-lifting-rules
-  (for ([var (in-list (context-vars ctx))]
-        [repr (in-list (context-var-reprs ctx))])
+  (for ([var (in-list (batch-vars batch))]
+        [repr (in-list (batch-var-reprs batch))])
     (egglog-send subproc
                  `(rule ((= e (,(typed-var-id (representation-name repr)) ,(symbol->string var))))
                         ((union (do-lift e) (Var ,(symbol->string var))))
@@ -502,7 +501,7 @@
   (define constructor-num 1)
 
   ; ; Var-spec-bindings
-  (for ([var (in-list (context-vars ctx))])
+  (for ([var (in-list (batch-vars batch))])
     ; Get the binding names for the program
     (define binding-name (string->symbol (format "?s~a" var)))
     (define constructor-name (string->symbol (format "const~a" constructor-num)))
@@ -521,8 +520,8 @@
     (set! constructor-num (add1 constructor-num)))
 
   ; Var-typed-bindings
-  (for ([var (in-list (context-vars ctx))]
-        [repr (in-list (context-var-reprs ctx))])
+  (for ([var (in-list (batch-vars batch))]
+        [repr (in-list (batch-var-reprs batch))])
     ; Get the binding names for the program
     (define binding-name (string->symbol (format "?t~a" var)))
     (define constructor-name (string->symbol (format "const~a" constructor-num)))

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -75,7 +75,7 @@
   (define repr-hash
     (make-immutable-hash (map (lambda (e ctx) (cons e (context-repr ctx))) subexprs ctxs)))
 
-  (define-values (batch brfs) (progs->batch spec-list))
+  (define-values (batch brfs) (progs->batch spec-list #:ctx ctx))
   (define subexprs-fn
     (parameterize ([*max-mpfr-prec* 128])
       (eval-progs-real batch brfs ctxs)))

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -70,10 +70,10 @@
                [repr (in-list reprs-list)])
       (struct-copy context ctx [repr repr])))
 
-  (define-values (expr-batch brfs) (progs->batch exprs-list))
+  (define-values (expr-batch brfs) (progs->batch exprs-list #:ctx ctx))
   (define roots (list->vector (map batchref-idx brfs)))
 
-  (define-values (spec-batch spec-brfs) (progs->batch (map prog->spec exprs-list)))
+  (define-values (spec-batch spec-brfs) (progs->batch (map prog->spec exprs-list) #:ctx ctx))
   (define subexprs-fn (eval-progs-real spec-batch spec-brfs ctx-list))
 
   (define errs (make-matrix roots pcontext))
@@ -124,7 +124,7 @@
     (for/list ([subexpr (in-list exprs-list)]
                [repr (in-list reprs-list)])
       (struct-copy context ctx [repr repr])))
-  (define-values (spec-batch spec-brfs) (progs->batch spec-list))
+  (define-values (spec-batch spec-brfs) (progs->batch spec-list #:ctx ctx))
   (define subexprs-fn (eval-progs-real spec-batch spec-brfs ctx-list))
 
   ;; And the absolute difference between the two
@@ -144,10 +144,10 @@
         ['bool 0] ; We can't subtract booleans so ignore them
         ['real `(fabs (- ,spec ,var))]
         [_ 0])))
-  (define-values (compare-batch compare-brfs) (progs->batch compare-specs))
+  (define-values (compare-batch compare-brfs) (progs->batch compare-specs #:ctx delta-ctx))
   (define delta-fn (eval-progs-real compare-batch compare-brfs (map (const delta-ctx) compare-specs)))
 
-  (define-values (expr-batch brfs) (progs->batch exprs-list))
+  (define-values (expr-batch brfs) (progs->batch exprs-list #:ctx ctx))
   (define roots (list->vector (map batchref-idx brfs)))
 
   (define ulp-errs (make-matrix roots pcontext))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -319,11 +319,10 @@
 
 (define (sort-alts alts [errss (exprs-errors (map alt-expr alts) (*pcontext*) (*context*))])
   ;; sort everything by error + cost
-  (define repr (context-repr (*context*)))
   (define alts-to-be-sorted (map cons alts errss))
   (sort alts-to-be-sorted
         (lambda (x y)
           (or (< (errors-score (cdr x)) (errors-score (cdr y))) ; sort by error
               (and (equal? (errors-score (cdr x))
                            (errors-score (cdr y))) ; if error is equal sort by cost
-                   (< (alt-cost (car x) repr) (alt-cost (car y) repr)))))))
+                   (< (alt-cost (car x)) (alt-cost (car y))))))))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -256,7 +256,7 @@
        (timeline-push! 'taylor-count (~a transform) order nvars 1 (if kept? 1 0))]
       [#f (void)]))
 
-  (define repr ((batch-reprs (*global-batch*)) (*start-brf*)))
+  (define repr (batch-repr-of (*start-brf*)))
   (timeline-push! 'min-error
                   (errors-score (atab-min-errors (^table^)))
                   (format "~a" (representation-name repr)))
@@ -277,7 +277,7 @@
 
 (define (make-regime! batch alts start-prog)
   (define ctx (*context*))
-  (define repr ((batch-reprs batch) start-prog))
+  (define repr (batch-repr-of start-prog))
   (define alt-costs (alt-batch-costs batch))
 
   (cond

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -54,8 +54,8 @@
   (define pcontext* (preprocess-pcontext context pcontext preprocessing))
   (*pcontext* pcontext*)
 
-  (parameterize ([*global-batch* (batch-empty)])
-    (define global-spec-batch (batch-empty))
+  (parameterize ([*global-batch* (batch-empty context)])
+    (define global-spec-batch (batch-empty context))
     (define spec-reducer (batch-reduce global-spec-batch))
 
     (*preprocessing* preprocessing)
@@ -144,7 +144,7 @@
   (define (group-equivalent-alts alts)
     (define fn (compile-batch (*global-batch*) (map alt-expr alts) (*context*)))
     (define signatures (make-vector (length alts) '()))
-    (define batch-cost (alt-batch-costs (*global-batch*) (*context*)))
+    (define batch-cost (alt-batch-costs (*global-batch*)))
 
     (for ([pt (in-vector (pcontext-points (*pcontext*)))])
       (define outs (fn pt))
@@ -227,7 +227,7 @@
 
   (define-values (errss costs) (atab-eval-altns (^table^) (*global-batch*) patched (*context*)))
   (timeline-event! 'prune)
-  (^table^ (atab-add-altns (^table^) patched errss costs (*context*)))
+  (^table^ (atab-add-altns (^table^) patched errss costs))
   (define final-fresh-set (list->seteq (atab-not-done-alts (^table^))))
   (define final-active-set (list->seteq (atab-active-alts (^table^))))
   (define final-done-set (set-subtract final-active-set final-fresh-set))
@@ -256,7 +256,7 @@
        (timeline-push! 'taylor-count (~a transform) order nvars 1 (if kept? 1 0))]
       [#f (void)]))
 
-  (define repr ((batch-reprs (*global-batch*) (*context*)) (*start-brf*)))
+  (define repr ((batch-reprs (*global-batch*)) (*start-brf*)))
   (timeline-push! 'min-error
                   (errors-score (atab-min-errors (^table^)))
                   (format "~a" (representation-name repr)))
@@ -277,14 +277,14 @@
 
 (define (make-regime! batch alts start-prog)
   (define ctx (*context*))
-  (define repr ((batch-reprs batch ctx) start-prog))
-  (define alt-costs (alt-batch-costs batch ctx))
+  (define repr ((batch-reprs batch) start-prog))
+  (define alt-costs (alt-batch-costs batch))
 
   (cond
     [(and (flag-set? 'reduce 'regimes)
           (> (length alts) 1)
           (equal? (representation-type repr) 'real)
-          (not (null? (context-vars ctx)))
+          (not (null? (batch-vars batch)))
           (get-fpcore-impl 'if '() (list <bool> repr repr))
           (get-fpcore-impl '<= '() (list repr repr)))
      (define opts
@@ -299,9 +299,9 @@
        (define use-binary?
          (and (flag-set? 'reduce 'binary-search)
               (> (length splitindices) 1)
-              (critical-subexpression? batch start-prog brf (context-vars ctx))
+              (critical-subexpression? batch start-prog brf)
               (for/and ([alt (in-list opt-alts)])
-                (critical-subexpression? batch (alt-expr alt) brf (context-vars ctx)))))
+                (critical-subexpression? batch (alt-expr alt) brf))))
        (cond
          [(= (length splitindices) 1) (list-ref opt-alts (si-cidx (first splitindices)))]
          [use-binary? (combine-alts/binary batch opt start-prog ctx (*pcontext*))]

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -256,7 +256,7 @@
        (timeline-push! 'taylor-count (~a transform) order nvars 1 (if kept? 1 0))]
       [#f (void)]))
 
-  (define repr (context-repr (*context*)))
+  (define repr ((batch-reprs (*global-batch*) (*context*)) (*start-brf*)))
   (timeline-push! 'min-error
                   (errors-score (atab-min-errors (^table^)))
                   (format "~a" (representation-name repr)))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -142,7 +142,7 @@
   (timeline-event! 'reconstruct)
 
   (define (group-equivalent-alts alts)
-    (define fn (compile-batch (*global-batch*) (map alt-expr alts) (*context*)))
+    (define fn (compile-batch (*global-batch*) (map alt-expr alts)))
     (define signatures (make-vector (length alts) '()))
     (define batch-cost (alt-batch-costs (*global-batch*)))
 
@@ -305,7 +305,7 @@
        (cond
          [(= (length splitindices) 1) (list-ref opt-alts (si-cidx (first splitindices)))]
          [use-binary? (combine-alts/binary batch opt start-prog ctx (*pcontext*))]
-         [else (combine-alts batch opt ctx)]))]
+         [else (combine-alts batch opt)]))]
     [else
      (define scores (batch-score-alts alts))
      (list (cdr (argmin car (map (λ (a s) (cons s a)) alts scores))))]))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -39,7 +39,7 @@
                #:when (equal? (representation-type repr) 'real))
       var))
   (define brfs (map alt-expr altns))
-  (define reprs (map (batch-reprs global-batch) brfs))
+  (define reprs (map batch-repr-of brfs))
   ;; Specs
   (define spec-brfs (batch-to-spec! global-batch brfs)) ;; These specs will go into (approx spec impl)
   (define free-vars (map (batch-free-vars global-batch) spec-brfs))
@@ -145,19 +145,18 @@
   (define all-brfs (map alt-expr altns))
   (define spec-brfs (batch-to-spec! global-batch all-brfs))
   (define free-vars (batch-free-vars global-batch))
-  (define repr-of (batch-reprs global-batch))
   (define real-pairs
     (for/list ([altn (in-list altns)]
                [spec-brf (in-list spec-brfs)]
                #:when (set-empty? (free-vars spec-brf))
                #:unless (literal? (deref (alt-expr altn)))
-               #:when (equal? (representation-type (repr-of (alt-expr altn))) 'real))
+               #:when (equal? (representation-type (batch-repr-of (alt-expr altn))) 'real))
       (cons altn spec-brf)))
   (define real-altns (map car real-pairs))
   (define real-spec-brfs (map cdr real-pairs))
 
   (define brfs (map alt-expr real-altns))
-  (define reprs (map repr-of brfs))
+  (define reprs (map batch-repr-of brfs))
   (define contexts
     (for/list ([repr (in-list reprs)])
       (context '() repr '())))
@@ -196,7 +195,7 @@
 
   (define brfs (map alt-expr altns))
   (define spec-brfs (batch-to-spec! global-batch brfs))
-  (define reprs (map (batch-reprs global-batch) brfs))
+  (define reprs (map batch-repr-of brfs))
   (define runner
     (cond
       [(flag-set? 'generate 'egglog)

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -170,9 +170,8 @@
     (for/list ([pt (in-list (if (equal? status 'valid)
                                 pts
                                 '()))]
-               [ctx (in-list contexts)]
+               [repr (in-list reprs)]
                #:when (equal? status 'valid))
-      (define repr (context-repr ctx))
       (literal (repr->real pt repr) (representation-name repr))))
 
   (define final-altns

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -34,11 +34,12 @@
 
 (define (taylor-alts altns global-batch spec-batch reducer)
   (define vars
-    (for/list ([var (in-list (context-vars (*context*)))]
-               #:when (equal? (representation-type (context-lookup (*context*) var)) 'real))
+    (for/list ([var (in-list (batch-vars global-batch))]
+               [repr (in-list (batch-var-reprs global-batch))]
+               #:when (equal? (representation-type repr) 'real))
       var))
   (define brfs (map alt-expr altns))
-  (define reprs (map (batch-reprs global-batch (*context*)) brfs))
+  (define reprs (map (batch-reprs global-batch) brfs))
   ;; Specs
   (define spec-brfs (batch-to-spec! global-batch brfs)) ;; These specs will go into (approx spec impl)
   (define free-vars (map (batch-free-vars global-batch) spec-brfs))
@@ -115,7 +116,7 @@
   (define runner
     (cond
       [(flag-set? 'generate 'egglog)
-       (define batch* (batch-empty))
+       (define batch* (batch-empty (*context*)))
        (define copy-f (batch-copy-only! batch* global-batch))
        (define impl-specs* (map copy-f impl-specs))
        (make-egglog-runner batch* impl-specs* schedule (*context*))]
@@ -144,7 +145,7 @@
   (define all-brfs (map alt-expr altns))
   (define spec-brfs (batch-to-spec! global-batch all-brfs))
   (define free-vars (batch-free-vars global-batch))
-  (define repr-of (batch-reprs global-batch (*context*)))
+  (define repr-of (batch-reprs global-batch))
   (define real-pairs
     (for/list ([altn (in-list altns)]
                [spec-brf (in-list spec-brfs)]
@@ -195,11 +196,11 @@
 
   (define brfs (map alt-expr altns))
   (define spec-brfs (batch-to-spec! global-batch brfs))
-  (define reprs (map (batch-reprs global-batch (*context*)) brfs))
+  (define reprs (map (batch-reprs global-batch) brfs))
   (define runner
     (cond
       [(flag-set? 'generate 'egglog)
-       (define batch* (batch-empty))
+       (define batch* (batch-empty (*context*)))
        (define copy-f (batch-copy-only! batch* global-batch))
        (define brfs* (map copy-f spec-brfs))
        (make-egglog-runner batch* brfs* schedule (*context*))]

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -70,15 +70,14 @@
 (define (exprs-errors exprs pcontext ctx)
   (define fn (compile-progs exprs ctx))
   (define num-exprs (length exprs))
-  (generate-errors fn pcontext ctx num-exprs))
+  (generate-errors fn pcontext (context-repr ctx) num-exprs))
 
 (define (batch-errors batch brfs pcontext ctx)
   (define fn (compile-batch batch brfs ctx))
   (define num-exprs (length brfs))
-  (generate-errors fn pcontext ctx num-exprs))
+  (generate-errors fn pcontext (context-repr ctx) num-exprs))
 
-(define (generate-errors fn pcontext ctx num-exprs)
-  (define repr (context-repr ctx))
+(define (generate-errors fn pcontext repr num-exprs)
   (define ulps (repr-ulps repr))
   (define max-ulps (+ 1 (expt 2 (representation-total-bits repr))))
   (define invalid-bits (real->double-flonum (representation-total-bits repr)))

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -73,7 +73,7 @@
   (generate-errors fn pcontext (context-repr ctx) num-exprs))
 
 (define (batch-errors batch brfs pcontext ctx)
-  (define fn (compile-batch batch brfs ctx))
+  (define fn (compile-batch batch brfs))
   (define num-exprs (length brfs))
   (generate-errors fn pcontext (context-repr ctx) num-exprs))
 

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -66,7 +66,7 @@
             (make-sort-identities spec ctx)))
 
   ;; make egg runner
-  (define-values (batch brfs) (progs->batch (cons spec (map cdr identities))))
+  (define-values (batch brfs) (progs->batch (cons spec (map cdr identities)) #:ctx ctx))
   (define runner (make-egraph batch brfs '(rewrite) ctx))
 
   ;; collect equalities

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -41,9 +41,10 @@
 ;; The odd identities: f(x) = -f(-x)
 ;; Requires `neg` and `fabs` operator implementations.
 (define (make-odd-identities spec ctx)
+  (define output-repr (context-repr ctx))
   (for/list ([var (in-list (context-vars ctx))]
              [repr (in-list (context-var-reprs ctx))]
-             #:when (and (has-fabs-impl? repr) (has-copysign-impl? (context-repr ctx))))
+             #:when (and (has-fabs-impl? repr) (has-copysign-impl? output-repr)))
     (cons `(negabs ,var) (replace-expression `(neg ,spec) var `(neg ,var)))))
 
 ;; Sort identities: f(a, b) = f(b, a)
@@ -97,7 +98,6 @@
 
 (define (instruction->operator context instruction)
   (define variables (context-vars context))
-  (define sort* (curryr sort (curryr </total (context-repr context))))
   (match instruction
     [(list 'sort a b)
      (define indices (indexes-where variables (curry set-member? (list a b))))

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -14,7 +14,7 @@
          impl-prog?
          node-is-impl?
          repr-of
-         batch-reprs
+         batch-repr-of
          get-locations
          free-variables
          replace-expression
@@ -42,17 +42,16 @@
     [(hole precision spec) (get-representation precision)]
     [(list op args ...) (impl-info op 'otype)]))
 
-(define (batch-reprs batch)
+(define (batch-repr-of brf)
+  (define batch (batchref-batch brf))
   (define var-reprs (map cons (batch-vars batch) (batch-var-reprs batch)))
-  (batch-recurse batch
-                 (lambda (brf recurse)
-                   (define node (deref brf))
-                   (match node
-                     [(literal val precision) (get-representation precision)]
-                     [(? symbol?) (dict-ref var-reprs node)]
-                     [(approx _ impl) (recurse impl)]
-                     [(hole precision spec) (get-representation precision)]
-                     [(list op args ...) (impl-info op 'otype)]))))
+  (let loop ([brf brf])
+    (match (deref brf)
+      [(literal val precision) (get-representation precision)]
+      [(? symbol? node) (dict-ref var-reprs node)]
+      [(approx _ impl) (loop impl)]
+      [(hole precision spec) (get-representation precision)]
+      [(list op args ...) (impl-info op 'otype)])))
 
 (define (all-subexpressions expr #:reverse? [reverse? #f])
   (define subexprs

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -42,13 +42,14 @@
     [(hole precision spec) (get-representation precision)]
     [(list op args ...) (impl-info op 'otype)]))
 
-(define (batch-reprs batch ctx)
+(define (batch-reprs batch)
+  (define var-reprs (map cons (batch-vars batch) (batch-var-reprs batch)))
   (batch-recurse batch
                  (lambda (brf recurse)
                    (define node (deref brf))
                    (match node
                      [(literal val precision) (get-representation precision)]
-                     [(? symbol?) (context-lookup ctx node)]
+                     [(? symbol?) (dict-ref var-reprs node)]
                      [(approx _ impl) (recurse impl)]
                      [(hole precision spec) (get-representation precision)]
                      [(list op args ...) (impl-info op 'otype)]))))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -59,7 +59,7 @@
                 (critical-subexpressions batch start-prog)
                 (map (curry batch-add! batch) (batch-vars batch)))))
 
-  (define brf-vals (brf-values* batch branch-brfs ctx pcontext))
+  (define brf-vals (brf-values* batch branch-brfs pcontext))
   (define pts-vec (pcontext-points pcontext))
 
   ;; For timeline
@@ -160,9 +160,9 @@
                 (min best-err (flvector-ref err-col point-idx))))
      num-points))
 
-(define (brf-values* batch brfs ctx pcontext)
+(define (brf-values* batch brfs pcontext)
   (define count (length brfs))
-  (define fn (compile-batch batch brfs ctx))
+  (define fn (compile-batch batch brfs))
   (define num-points (pcontext-length pcontext))
   (define vals (build-vector count (lambda (_) (make-vector num-points))))
   (for ([pt (in-vector (pcontext-points pcontext))]
@@ -210,7 +210,7 @@
   (define (test-regimes expr goal)
     (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
     (define brf (car brfs))
-    (define brf-vals (car (brf-values* batch (list brf) ctx pctx)))
+    (define brf-vals (car (brf-values* batch (list brf) pctx)))
     (define reprs (batch-reprs batch))
     (check
      (lambda (x y) (equal? (map si-cidx (option-split-indices x)) y))
@@ -221,7 +221,7 @@
   (define (test-regimes/prefixes expr goals)
     (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
     (define brf (car brfs))
-    (define brf-vals (car (brf-values* batch (list brf) ctx pctx)))
+    (define brf-vals (car (brf-values* batch (list brf) pctx)))
     (define reprs (batch-reprs batch))
     (define options
       (map pareto-point-data

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -31,8 +31,12 @@
            "../syntax/sugar.rkt")
 
   (define (check-critical expr subexpr)
-    (define-values (batch brfs) (progs->batch (list expr)))
-    (critical-subexpression? batch (first brfs) (batch-add! batch subexpr) (free-variables expr))))
+    (define ctx
+      (context (free-variables expr)
+               <binary64>
+               (make-list (length (free-variables expr)) <binary64>)))
+    (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
+    (critical-subexpression? batch (first brfs) (batch-add! batch subexpr))))
 
 (struct option (split-indices alts pts expr)
   #:transparent
@@ -46,14 +50,14 @@
   (define alts-vec (list->vector sorted))
   (define alt-count (vector-length alts-vec))
   (define err-cols (batch-errors batch (map alt-expr sorted) pcontext ctx))
-  (define reprs (batch-reprs batch ctx))
+  (define reprs (batch-reprs batch))
   (define (real-brf? brf)
     (equal? (representation-type (reprs brf)) 'real))
   (define branch-brfs
     (filter real-brf?
             (if (flag-set? 'reduce 'branch-expressions)
-                (critical-subexpressions batch start-prog (context-vars ctx))
-                (map (curry batch-add! batch) (context-vars ctx)))))
+                (critical-subexpressions batch start-prog)
+                (map (curry batch-add! batch) (batch-vars batch)))))
 
   (define brf-vals (brf-values* batch branch-brfs ctx pcontext))
   (define pts-vec (pcontext-points pcontext))
@@ -101,11 +105,11 @@
                     (baseline-errors-score err-cols (pareto-point-cost ppt)))
     opt))
 
-(define (critical-subexpression? batch root-brf sub-brf vars)
-  (set-member? (critical-subexpressions batch root-brf vars) sub-brf))
+(define (critical-subexpression? batch root-brf sub-brf)
+  (set-member? (critical-subexpressions batch root-brf) sub-brf))
 
-(define (critical-subexpressions batch root-brf vars)
-  (define var-brfs (map (curry batch-add! batch) vars))
+(define (critical-subexpressions batch root-brf)
+  (define var-brfs (map (curry batch-add! batch) (batch-vars batch)))
   (define dom-parent (build-dominator-tree batch root-brf))
   (reap [sow]
         (define seen-brfs (mutable-set root-brf))
@@ -204,10 +208,10 @@
   (define pts-vec (pcontext-points pctx))
 
   (define (test-regimes expr goal)
-    (define-values (batch brfs) (progs->batch (list expr)))
+    (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
     (define brf (car brfs))
     (define brf-vals (car (brf-values* batch (list brf) ctx pctx)))
-    (define reprs (batch-reprs batch ctx))
+    (define reprs (batch-reprs batch))
     (check
      (lambda (x y) (equal? (map si-cidx (option-split-indices x)) y))
      (pareto-point-data
@@ -215,10 +219,10 @@
      goal))
 
   (define (test-regimes/prefixes expr goals)
-    (define-values (batch brfs) (progs->batch (list expr)))
+    (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
     (define brf (car brfs))
     (define brf-vals (car (brf-values* batch (list brf) ctx pctx)))
-    (define reprs (batch-reprs batch ctx))
+    (define reprs (batch-reprs batch))
     (define options
       (map pareto-point-data
            (reverse
@@ -249,11 +253,9 @@
 
   (let ()
     (define xy-ctx (context '(x y) <binary64> (list <binary64> <binary64>)))
-    (define-values (batch brfs) (progs->batch (list 'x)))
-    (check-true
-     (critical-subexpression? batch (first brfs) (batch-add! batch 'x) (context-vars xy-ctx)))
-    (check-false
-     (critical-subexpression? batch (first brfs) (batch-add! batch 'y) (context-vars xy-ctx))))
+    (define-values (batch brfs) (progs->batch (list 'x) #:ctx xy-ctx))
+    (check-true (critical-subexpression? batch (first brfs) (batch-add! batch 'x)))
+    (check-false (critical-subexpression? batch (first brfs) (batch-add! batch 'y))))
 
   (let ()
     (define vec2-ctx
@@ -264,9 +266,8 @@
     (define dot-product
       '(+.f64 (*.f64 (ref.f64 a #s(literal 0 binary64)) (ref.f64 b #s(literal 0 binary64)))
               (*.f64 (ref.f64 a #s(literal 1 binary64)) (ref.f64 b #s(literal 1 binary64)))))
-    (define-values (batch brfs) (progs->batch (list dot-product)))
-    (check-true (set-member? (critical-subexpressions batch (first brfs) (context-vars vec2-ctx))
-                             (first brfs)))))
+    (define-values (batch brfs) (progs->batch (list dot-product) #:ctx vec2-ctx))
+    (check-true (set-member? (critical-subexpressions batch (first brfs)) (first brfs)))))
 
 (define (valid-splitindices? can-split? split-indices)
   (and (for/and ([pidx (map si-pidx (drop-right split-indices 1))])

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -50,9 +50,8 @@
   (define alts-vec (list->vector sorted))
   (define alt-count (vector-length alts-vec))
   (define err-cols (batch-errors batch (map alt-expr sorted) pcontext ctx))
-  (define reprs (batch-reprs batch))
   (define (real-brf? brf)
-    (equal? (representation-type (reprs brf)) 'real))
+    (equal? (representation-type (batch-repr-of brf)) 'real))
   (define branch-brfs
     (filter real-brf?
             (if (flag-set? 'reduce 'branch-expressions)
@@ -72,7 +71,7 @@
     (for/list ([brf (in-list branch-brfs)]
                [brf-vals-vec (in-list brf-vals)])
       (define timeline-stop! (timeline-start! 'times (batch->jsexpr batch (list brf))))
-      (define repr (reprs brf))
+      (define repr (batch-repr-of brf))
       (define curve (branch-options batch alts-vec err-cols pts-vec brf brf-vals-vec repr))
       (define last-point (last curve))
       (timeline-stop!)
@@ -211,22 +210,26 @@
     (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
     (define brf (car brfs))
     (define brf-vals (car (brf-values* batch (list brf) pctx)))
-    (define reprs (batch-reprs batch))
     (check
      (lambda (x y) (equal? (map si-cidx (option-split-indices x)) y))
      (pareto-point-data
-      (first (branch-options batch (list->vector alts) err-cols pts-vec brf brf-vals (reprs brf))))
+      (first
+       (branch-options batch (list->vector alts) err-cols pts-vec brf brf-vals (batch-repr-of brf))))
      goal))
 
   (define (test-regimes/prefixes expr goals)
     (define-values (batch brfs) (progs->batch (list expr) #:ctx ctx))
     (define brf (car brfs))
     (define brf-vals (car (brf-values* batch (list brf) pctx)))
-    (define reprs (batch-reprs batch))
     (define options
       (map pareto-point-data
-           (reverse
-            (branch-options batch (list->vector alts) err-cols pts-vec brf brf-vals (reprs brf)))))
+           (reverse (branch-options batch
+                                    (list->vector alts)
+                                    err-cols
+                                    pts-vec
+                                    brf
+                                    brf-vals
+                                    (batch-repr-of brf)))))
     (for ([goal (in-list goals)]
           [opt (in-list options)])
       (check (lambda (x y) (equal? (map si-cidx (option-split-indices x)) y)) opt goal)))

--- a/src/core/taylor.rkt
+++ b/src/core/taylor.rkt
@@ -4,6 +4,7 @@
 (require "../utils/common.rkt"
          "../utils/dvector.rkt"
          "../syntax/syntax.rkt"
+         "../syntax/types.rkt"
          "../syntax/batch.rkt"
          "programs.rkt")
 
@@ -88,9 +89,10 @@
 ; Tests for expand-taylor
 (module+ test
   (require rackunit)
+  (define taylor-test-ctx (context '(x) <binary64> (list <binary64>)))
 
   (define (test-expand-taylor expr)
-    (define-values (batch brfs) (progs->batch (list expr)))
+    (define-values (batch brfs) (progs->batch (list expr) #:ctx taylor-test-ctx))
     (define brf* ((expand-taylor! batch) (car brfs)))
     ((batch-exprs batch) brf*))
 
@@ -589,7 +591,7 @@
 
 (module+ test
   (require rackunit)
-  (define-values (batch brfs) (progs->batch (list '(pow x 1.0))))
+  (define-values (batch brfs) (progs->batch (list '(pow x 1.0)) #:ctx taylor-test-ctx))
   (parameterize ([reduce (batch-reduce batch)]
                  [add (λ (x) (batch-add! batch x))])
     (define brfs* (map (expand-taylor! batch) brfs))
@@ -599,7 +601,7 @@
 (module+ test
   (require "batch-reduce.rkt")
   (define (coeffs expr #:n [n 7])
-    (define-values (batch brfs) (progs->batch (list expr)))
+    (define-values (batch brfs) (progs->batch (list expr) #:ctx taylor-test-ctx))
     (parameterize ([reduce (batch-reduce batch)]
                    [add (λ (x) (batch-add! batch x))])
       (define brfs* (map (expand-taylor! batch) brfs))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -35,7 +35,7 @@
 (define (check-rule test-rule)
   (match-define (rule name p1 p2 _) test-rule)
   (define ctx (env->ctx p1 p2))
-  (define ulps (repr-ulps (context-repr ctx)))
+  (define ulps (repr-ulps double-repr))
 
   (define-values (batch brfs) (progs->batch (list p1 (drop-sound p2))))
   (match-define (list pts exs1 exs2)

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -37,7 +37,7 @@
   (define ctx (env->ctx p1 p2))
   (define ulps (repr-ulps double-repr))
 
-  (define-values (batch brfs) (progs->batch (list p1 (drop-sound p2))))
+  (define-values (batch brfs) (progs->batch (list p1 (drop-sound p2)) #:ctx ctx))
   (match-define (list pts exs1 exs2)
     (parameterize ([*num-points* (num-test-points)]
                    [*max-find-range-depth* 0])

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -49,11 +49,6 @@
         [_ (void)]))
     (k 'Goal #f step)))
 
-(define (altn-errors altn pcontext ctx errcache mask)
-  (define repr (context-repr ctx))
-  (define err (errors-score-masked (hash-ref errcache (alt-expr altn)) mask))
-  (format-accuracy err repr #:unit "%"))
-
 (define (mixed->fpcore expr ctx)
   (define expr*
     (let loop ([expr expr])
@@ -126,10 +121,10 @@
   (make-vector (pcontext-length pcontext) #f))
 
 ;; HTML renderer for derivations
-(define (render-history json ctx)
+(define (render-history json repr)
   (define err
     (match (hash-ref json 'error)
-      [(? number? n) (format-accuracy n (context-repr ctx) #:unit "%")]
+      [(? number? n) (format-accuracy n repr #:unit "%")]
       [other other]))
   (define prog (read (open-input-string (hash-ref json 'program))))
   (match (hash-ref json 'type)
@@ -137,7 +132,7 @@
      (list `(li (p "Initial program " (span ((class "error")) ,err))
                 (div ((class "math")) "\\[" ,(fpcore->tex prog) "\\]")))]
 
-    ["add-preprocessing" `(,@(render-history (hash-ref json 'prev) ctx) (li "Add Preprocessing"))]
+    ["add-preprocessing" `(,@(render-history (hash-ref json 'prev) repr) (li "Add Preprocessing"))]
 
     ["regimes"
      (define prevs (hash-ref json 'prevs))
@@ -146,28 +141,28 @@
                     (for/list ([entry (in-list prevs)]
                                [condition (in-list (hash-ref json 'conditions))])
                       `((h2 (code "if " (span ((class "condition")) ,(string-join condition " or "))))
-                        (ol ,@(render-history entry ctx))))))
+                        (ol ,@(render-history entry repr))))))
        (li ((class "event")) "Recombined " ,(~a (length prevs)) " regimes into one program."))]
 
     ["taylor"
      (define-values (prev pt var order)
        (apply values (map (curry hash-ref json) '(prev pt var order))))
-     `(,@(render-history prev ctx)
+     `(,@(render-history prev repr)
        (li (p "Taylor expanded in " ,var " around " ,pt " to order " ,(~a order))
            (div ((class "math")) "\\[\\leadsto " ,(fpcore->tex prog) "\\]")))]
 
     ["evaluate"
      (define prev (hash-ref json 'prev))
-     `(,@(render-history prev ctx)
+     `(,@(render-history prev repr)
        (li (p "Evaluated real constant" (span ((class "error")) ,err))
            (div ((class "math")) "\\[\\leadsto " ,(fpcore->tex prog) "\\]")))]
 
     ["rr"
      (define-values (prev proof) (apply values (map (curry hash-ref json) '(prev proof))))
-     `(,@(render-history prev ctx)
+     `(,@(render-history prev repr)
        (li ,(if (eq? proof (json-null))
                 ""
-                (render-proof proof ctx)))
+                (render-proof proof repr)))
        (li (p "Applied rewrites" (span ((class "error")) ,err))
            (div ((class "math")) "\\[\\leadsto " ,(fpcore->tex prog) "\\]")))]))
 
@@ -179,7 +174,7 @@
                   err))
   (errors-score (if (zero? mask-count) errs masked-errs)))
 
-(define (render-proof proof-json ctx)
+(define (render-proof proof-json repr)
   `(div ((class "proof"))
         (details
          (summary "Step-by-step derivation")
@@ -197,7 +192,7 @@
                      `(li (p (code ([title ,dir]) ,rule)
                              (span ((class "error"))
                                    ,(if (number? err)
-                                        (format-accuracy err (context-repr ctx) #:unit "%")
+                                        (format-accuracy err repr #:unit "%")
                                         err)))
                           (div ((class "math")) "\\[\\leadsto " ,(fpcore->tex prog) "\\]"))))))))
 

--- a/src/reports/make-graph.rkt
+++ b/src/reports/make-graph.rkt
@@ -163,7 +163,7 @@
                ,dropdown
                ,(render-help "report.html#alternatives"))
            ,body
-           (details (summary "Derivation") (ol ((class "history")) ,@(render-history history ctx)))))
+           (details (summary "Derivation") (ol ((class "history")) ,@(render-history history repr)))))
      ,@(for/list ([i (in-naturals 1)]
                   [target (in-list targets)])
          (define target-error (hash-ref target 'errors))

--- a/src/syntax/batch.rkt
+++ b/src/syntax/batch.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
 (require "syntax.rkt"
+         "types.rkt"
          "../utils/common.rkt"
          "../utils/dvector.rkt")
 
@@ -27,14 +28,15 @@
          deref) ; Batchref -> Expr
 
 ;; Batches store these recursive structures, flattened
-(struct batch ([nodes #:mutable] [index #:mutable]))
+(struct batch ([nodes #:mutable] [index #:mutable] vars var-reprs))
 
 (struct batchref (batch idx) #:transparent)
 
 ;; --------------------------------- CORE BATCH FUNCTION ------------------------------------
 
-(define (batch-empty)
-  (batch (make-dvector) (make-hash)))
+(define (batch-empty ctx)
+  (match-define (context vars _ var-reprs) ctx)
+  (batch (make-dvector) (make-hash) vars var-reprs))
 
 (define (in-batch batch [start 0] [end #f] [step 1])
   (in-dvector (batch-nodes batch) start end step))
@@ -76,9 +78,9 @@
   (match-define (batchref b idx) x)
   (expr-recurse (dvector-ref (batch-nodes b) idx) (lambda (ref) (batchref b ref))))
 
-(define (progs->batch exprs #:vars [vars '()])
-  (define out (batch-empty))
-  (for ([var (in-list vars)])
+(define (progs->batch exprs #:ctx ctx)
+  (define out (batch-empty ctx))
+  (for ([var (in-list (context-vars ctx))])
     (batch-push! out var))
   (define brfs
     (for/list ([expr (in-list exprs)])
@@ -160,7 +162,7 @@
 ;; Returns: (hash 'nodes [...] 'roots [idx1 idx2 ...])
 ;; Nodes are: atoms (symbols->strings, numbers) or [op-string idx1 idx2 ...]
 (define (batch->jsexpr b brfs)
-  (define batch* (batch-empty))
+  (define batch* (batch-empty (context (batch-vars b) #f (batch-var-reprs b))))
   (define copy-f (batch-copy-only! batch* b))
   (define brfs* (map copy-f brfs))
   (define nodes
@@ -244,8 +246,9 @@
 ; Tests for progs->batch and batch-exprs
 (module+ test
   (require rackunit)
+  (define test-empty-ctx (context '() #f '()))
   (define (test-munge-unmunge expr)
-    (define-values (batch brfs) (progs->batch (list expr)))
+    (define-values (batch brfs) (progs->batch (list expr) #:ctx test-empty-ctx))
     (check-equal? (list expr) (map (batch-exprs batch) brfs)))
 
   (define (f64 x)
@@ -265,9 +268,9 @@
 (module+ test
   (require rackunit)
   (define (zombie-test #:nodes nodes #:roots roots)
-    (define in-batch (batch nodes (make-hash)))
+    (define in-batch (batch nodes (make-hash) '() '()))
     (define brfs (map (curry batchref in-batch) roots))
-    (define out-batch (batch-empty))
+    (define out-batch (batch-empty test-empty-ctx))
     (define copy-f (batch-copy-only! out-batch in-batch))
     (define brfs* (map copy-f brfs))
     (check-equal? (map (batch-exprs out-batch) brfs*) (map (batch-exprs in-batch) brfs))
@@ -297,7 +300,7 @@
 (module+ test
   (require rackunit)
   (define (test-json-tostring expr expected)
-    (define-values (batch brfs) (progs->batch (list expr)))
+    (define-values (batch brfs) (progs->batch (list expr) #:ctx test-empty-ctx))
     (define jsexpr (batch->jsexpr batch brfs))
     (define str (jsexpr->batch-exprs jsexpr))
     (check-equal? str expected))

--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -33,7 +33,7 @@
                   (hash-clear! cache))))
 
 (define-generator ((from-rival #:cache? [cache? #t]) spec ctx)
-  (define-values (batch brfs) (progs->batch (list spec)))
+  (define-values (batch brfs) (progs->batch (list spec) #:ctx ctx))
   (define compiler (make-real-compiler batch brfs (list ctx)))
   (define fail ((representation-bf->repr (context-repr ctx)) +nan.bf))
   (define (compute . pt)

--- a/src/syntax/platform-state.rkt
+++ b/src/syntax/platform-state.rkt
@@ -46,7 +46,7 @@
      (define fl-proc
        (procedure-reduce-arity (lambda args (core-proc (list->vector args)))
                                (length (context-vars ctx))))
-     (define cost ((platform-cost-proc (*active-platform*)) body* output-repr))
+     (define cost ((platform-cost-proc (*active-platform*)) body*))
      (define fpcore-expr (cons name (context-vars ctx)))
      (define impl
        (create-operator-impl! name

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -169,9 +169,9 @@
 
 ; Cost model of a single node by a platform.
 ; Returns a procedure that must be called with the costs of the children.
-(define ((platform-node-cost-proc platform) expr repr)
+(define ((platform-node-cost-proc platform) expr)
   (match expr
-    [(? literal?) (lambda () (platform-repr-cost platform repr))]
+    [(literal _ precision) (lambda () (platform-repr-cost platform (get-representation precision)))]
     [(? symbol?) (lambda () 0)]
     [(list impl args ...)
      (define impl-cost (impl-info impl 'cost))
@@ -184,17 +184,15 @@
 ; Cost model parameterized by a platform.
 (define (platform-cost-proc platform)
   (define node-cost-proc (platform-node-cost-proc platform))
-  (λ (expr repr)
-    (let loop ([expr expr]
-               [repr repr])
+  (λ (expr)
+    (let loop ([expr expr])
       (match expr
-        [(? literal?) ((node-cost-proc expr repr))]
-        [(? symbol?) ((node-cost-proc expr repr))]
-        [(approx _ impl) (loop impl repr)]
+        [(? literal?) ((node-cost-proc expr))]
+        [(? symbol?) ((node-cost-proc expr))]
+        [(approx _ impl) (loop impl)]
         [(list impl args ...)
-         (define cost-proc (node-cost-proc expr repr))
-         (define itypes (impl-info impl 'itype))
-         (apply cost-proc (map loop args itypes))]))))
+         (define cost-proc (node-cost-proc expr))
+         (apply cost-proc (map loop args))]))))
 
 ;; Extracts the `fpcore` field of an operator implementation
 ;; as a property dictionary and operation.


### PR DESCRIPTION
This PR adds `vars` and `var-reprs` to the `batch` object. This make the `batch` object typed on its own and avoids a lot of cases where you have to keep track of the context and batch together. Long term I think the goal is to kill of contexts entirely, but this PR doesn't fully do that.

As part of this I replaced `batch-reprs` by `batch-repr-of` which is recursive and non-cached. That makes it a bit easier to use.