### PR TITLE
Include all alts in results.json

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -269,6 +269,7 @@
      (define end-exprs
        (for/list ([end-analysis (in-list end)])
          (read (open-input-string (hash-ref end-analysis 'expr)))))
+     (define end-expr-strings (map (curryr hash-ref 'expr) end))
      (define end-scores
        (for/list ([end-analysis (in-list end)])
          (errors-score (list->flvector (hash-ref end-analysis 'errors)))))
@@ -279,8 +280,11 @@
        (/ (round (* x 1000)) 1000.0))
      (define cost&accuracy
        (list (list (round3 start-cost) (round3 start-score))
-             (list (round3 (car end-costs)) (round3 (car end-scores)))
-             (map (λ (c s) (list (round3 c) (round3 s))) (cdr end-costs) (cdr end-scores))))
+             (list (round3 (car end-costs)) (round3 (car end-scores)) (car end-expr-strings))
+             (map (λ (c s expr) (list (round3 c) (round3 s) expr))
+                  (cdr end-costs)
+                  (cdr end-scores)
+                  (cdr end-expr-strings))))
 
      (define fuzz 0.1)
      (define end-score (car end-scores))


### PR DESCRIPTION
This PR adds the expr for the alt into the cost-accuracy field of results.json. 