### PR TITLE
Remove `ctx` argument from `batch-errors`

### DIFF
--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -13,7 +13,7 @@
          "programs.rkt")
 
 (provide (contract-out
-          (make-alt-table (batch? pcontext? alt? any/c . -> . alt-table?))
+          (make-alt-table (batch? pcontext? alt? . -> . alt-table?))
           (atab-active-alts (alt-table? . -> . (listof alt?)))
           (atab-all-alts (alt-table? . -> . (listof alt?)))
           (atab-not-done-alts (alt-table? . -> . (listof alt?)))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -17,7 +17,7 @@
           (atab-active-alts (alt-table? . -> . (listof alt?)))
           (atab-all-alts (alt-table? . -> . (listof alt?)))
           (atab-not-done-alts (alt-table? . -> . (listof alt?)))
-          (atab-eval-altns (alt-table? batch? (listof alt?) context? . -> . (values any/c any/c)))
+          (atab-eval-altns (alt-table? batch? (listof alt?) . -> . (values any/c any/c)))
           (atab-add-altns (alt-table? (listof alt?) any/c any/c . -> . alt-table?))
           (atab-set-picked (alt-table? (listof alt?) . -> . alt-table?))
           (atab-completed? (alt-table? . -> . boolean?))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -43,9 +43,9 @@
                       (define cost-proc (node-cost-proc node))
                       (apply cost-proc (map recurse args))]))))
 
-(define (make-alt-table batch pcontext initial-alt ctx)
+(define (make-alt-table batch pcontext initial-alt)
   (define cost ((alt-batch-costs batch) (alt-expr initial-alt)))
-  (define errs (batchref-errors (alt-expr initial-alt) pcontext ctx))
+  (define errs (batchref-errors (alt-expr initial-alt) pcontext))
   (alt-table (for/vector #:length (pcontext-length pcontext)
                          ([err (in-flvector errs)])
                (list (pareto-point cost err (list initial-alt))))
@@ -173,9 +173,9 @@
                [alt->done? (hash-remove* alt->done? altns)]
                [alt->cost (hash-remove* alt->cost altns)]))
 
-(define (atab-eval-altns atab batch altns ctx)
+(define (atab-eval-altns atab batch altns)
   (define brfs (map alt-expr altns))
-  (define errss (batch-errors batch brfs (alt-table-pcontext atab) ctx))
+  (define errss (batch-errors batch brfs (alt-table-pcontext atab)))
   (define costs (map (alt-batch-costs batch) brfs))
   (values errss costs))
 

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -12,17 +12,16 @@
          "points.rkt"
          "programs.rkt")
 
-(provide (contract-out
-          (make-alt-table (batch? pcontext? alt? . -> . alt-table?))
-          (atab-active-alts (alt-table? . -> . (listof alt?)))
-          (atab-all-alts (alt-table? . -> . (listof alt?)))
-          (atab-not-done-alts (alt-table? . -> . (listof alt?)))
-          (atab-eval-altns (alt-table? batch? (listof alt?) . -> . (values any/c any/c)))
-          (atab-add-altns (alt-table? (listof alt?) any/c any/c . -> . alt-table?))
-          (atab-set-picked (alt-table? (listof alt?) . -> . alt-table?))
-          (atab-completed? (alt-table? . -> . boolean?))
-          (atab-min-errors (alt-table? . -> . flvector?))
-          (alt-batch-costs (batch? . -> . (batchref? . -> . real?)))))
+(provide (contract-out (make-alt-table (batch? pcontext? alt? . -> . alt-table?))
+                       (atab-active-alts (alt-table? . -> . (listof alt?)))
+                       (atab-all-alts (alt-table? . -> . (listof alt?)))
+                       (atab-not-done-alts (alt-table? . -> . (listof alt?)))
+                       (atab-eval-altns (alt-table? batch? (listof alt?) . -> . (values any/c any/c)))
+                       (atab-add-altns (alt-table? (listof alt?) any/c any/c . -> . alt-table?))
+                       (atab-set-picked (alt-table? (listof alt?) . -> . alt-table?))
+                       (atab-completed? (alt-table? . -> . boolean?))
+                       (atab-min-errors (alt-table? . -> . flvector?))
+                       (alt-batch-costs (batch? . -> . (batchref? . -> . real?)))))
 
 ;; Public API
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -62,7 +62,7 @@
     (define initial-brf (batch-add! (*global-batch*) initial))
     (*start-brf* initial-brf)
     (define start-alt (alt initial-brf 'start '()))
-    (^table^ (make-alt-table (*global-batch*) pcontext start-alt context))
+    (^table^ (make-alt-table (*global-batch*) pcontext start-alt))
 
     (for ([_ (in-range (*num-iterations*))]
           #:break (atab-completed? (^table^)))
@@ -104,7 +104,7 @@
                              (writeln (exprs (alt-expr altn)) out)))))
 
 (define (batch-score-alts altns)
-  (map errors-score (batch-errors (*global-batch*) (map alt-expr altns) (*pcontext*) (*context*))))
+  (map errors-score (batch-errors (*global-batch*) (map alt-expr altns) (*pcontext*))))
 
 (define (timeline-push-alts! next-alts)
   (define pending-alts (atab-not-done-alts (^table^)))
@@ -225,7 +225,7 @@
   (define orig-fresh-alts (atab-not-done-alts (^table^)))
   (define orig-done-alts (set-subtract orig-all-alts (atab-not-done-alts (^table^))))
 
-  (define-values (errss costs) (atab-eval-altns (^table^) (*global-batch*) patched (*context*)))
+  (define-values (errss costs) (atab-eval-altns (^table^) (*global-batch*) patched))
   (timeline-event! 'prune)
   (^table^ (atab-add-altns (^table^) patched errss costs))
   (define final-fresh-set (list->seteq (atab-not-done-alts (^table^))))
@@ -276,7 +276,6 @@
   (void))
 
 (define (make-regime! batch alts start-prog)
-  (define ctx (*context*))
   (define repr (batch-repr-of start-prog))
   (define alt-costs (alt-batch-costs batch))
 
@@ -291,7 +290,6 @@
        (pareto-regimes batch
                        (sort alts < #:key (compose alt-costs alt-expr))
                        start-prog
-                       ctx
                        (*pcontext*)))
      (for/list ([opt (in-list opts)])
        (match-define (option splitindices opt-alts _ brf) opt)
@@ -304,7 +302,7 @@
                 (critical-subexpression? batch (alt-expr alt) brf))))
        (cond
          [(= (length splitindices) 1) (list-ref opt-alts (si-cidx (first splitindices)))]
-         [use-binary? (combine-alts/binary batch opt start-prog ctx (*pcontext*))]
+         [use-binary? (combine-alts/binary batch opt start-prog (*context*) (*pcontext*))]
          [else (combine-alts batch opt)]))]
     [else
      (define scores (batch-score-alts alts))

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -4,6 +4,7 @@
          "../syntax/float.rkt"
          "../syntax/types.rkt"
          "../syntax/batch.rkt"
+         "programs.rkt"
          "compiler.rkt")
 
 (provide in-pcontext

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -64,18 +64,18 @@
 (define (errors expr pcontext ctx)
   (first (exprs-errors (list expr) pcontext ctx)))
 
-(define (batchref-errors brf pcontext ctx)
-  (first (batch-errors (batchref-batch brf) (list brf) pcontext ctx)))
+(define (batchref-errors brf pcontext)
+  (first (batch-errors (batchref-batch brf) (list brf) pcontext)))
 
 (define (exprs-errors exprs pcontext ctx)
   (define fn (compile-progs exprs ctx))
   (define num-exprs (length exprs))
   (generate-errors fn pcontext (context-repr ctx) num-exprs))
 
-(define (batch-errors batch brfs pcontext ctx)
+(define (batch-errors batch brfs pcontext)
   (define fn (compile-batch batch brfs))
   (define num-exprs (length brfs))
-  (generate-errors fn pcontext (context-repr ctx) num-exprs))
+  (generate-errors fn pcontext (batch-repr-of (first brfs)) num-exprs))
 
 (define (generate-errors fn pcontext repr num-exprs)
   (define ulps (repr-ulps repr))

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -45,11 +45,11 @@
      (fprintf port "#<option ~a>" (option-split-indices opt)))])
 
 ;; CONSIDER: move start-prog and the "branch-brfs" computation into caller.
-(define (pareto-regimes batch sorted start-prog ctx pcontext)
+(define (pareto-regimes batch sorted start-prog pcontext)
   (timeline-event! 'regimes)
   (define alts-vec (list->vector sorted))
   (define alt-count (vector-length alts-vec))
-  (define err-cols (batch-errors batch (map alt-expr sorted) pcontext ctx))
+  (define err-cols (batch-errors batch (map alt-expr sorted) pcontext))
   (define (real-brf? brf)
     (equal? (representation-type (batch-repr-of brf)) 'real))
   (define branch-brfs


### PR DESCRIPTION
This is a small PR replacing a context argument with the batch-stored var reprs, but it allows us to simplify a number of function signatures.