### PR TITLE
Preprocess on batches

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -23,6 +23,7 @@
 (provide (struct-out egg-runner)
          make-egraph
          egraph-equal?
+         egraph-roots-equal?
          egraph-prove
          egraph-best
          egraph-variations
@@ -1268,6 +1269,10 @@
   (define ctx (egg-runner-ctx runner))
   (define egg-graph (egg-runner-egg-graph runner))
   (egraph-expr-equal? egg-graph start end ctx))
+
+(define (egraph-roots-equal? runner idx1 idx2)
+  (define root-ids (egg-runner-new-roots runner))
+  (= (list-ref root-ids idx1) (list-ref root-ids idx2)))
 
 (define (egraph-prove runner start-brf end-brf)
   (define ctx (egg-runner-ctx runner))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -45,21 +45,22 @@
 ;; - Final steps: regimes, derivations, and remove preprocessing
 
 (define (run-improve! initial specification context pcontext)
-  (timeline-event! 'preprocess)
-  (define preprocessing
-    (if (flag-set? 'setup 'preprocess)
-        (find-preprocessing specification context)
-        '()))
-  (timeline-push! 'symmetry (map ~a preprocessing))
-  (define pcontext* (preprocess-pcontext context pcontext preprocessing))
-  (*pcontext* pcontext*)
-
   (parameterize ([*global-batch* (batch-empty context)])
     (define global-spec-batch (batch-empty context))
+    (define initial-brf (batch-add! (*global-batch*) initial))
+    (define specification-brf (batch-add! global-spec-batch specification))
+    (timeline-event! 'preprocess)
+    (define preprocessing
+      (if (flag-set? 'setup 'preprocess)
+          (find-preprocessing global-spec-batch specification-brf context)
+          '()))
+    (timeline-push! 'symmetry (map ~a preprocessing))
+    (define pcontext* (preprocess-pcontext context pcontext preprocessing))
+    (*pcontext* pcontext*)
+
     (define spec-reducer (batch-reduce global-spec-batch))
 
     (*preprocessing* preprocessing)
-    (define initial-brf (batch-add! (*global-batch*) initial))
     (*start-brf* initial-brf)
     (define start-alt (alt initial-brf 'start '()))
     (^table^ (make-alt-table (*global-batch*) pcontext start-alt context))

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -30,50 +30,70 @@
   (and (get-fpcore-impl '* (repr->prop repr) (list repr repr))
        (get-fpcore-impl 'copysign (repr->prop repr) (list repr repr))))
 
+(define (batch-replace-vars! batch replacements)
+  (batch-recurse
+   batch
+   (lambda (brf recurse)
+     (dict-ref replacements
+               brf
+               (lambda ()
+                 (batch-push! batch (expr-recurse (deref brf) (compose batchref-idx recurse))))))))
+
 ;; The even identities: f(x) = f(-x)
 ;; Requires `neg` and `fabs` operator implementations.
-(define (make-even-identities spec ctx)
-  (for/list ([var (in-list (context-vars ctx))]
-             [repr (in-list (context-var-reprs ctx))]
+(define (make-even-identities batch spec-brf)
+  (for/list ([var (in-list (batch-vars batch))]
+             [repr (in-list (batch-var-reprs batch))]
              #:when (has-fabs-impl? repr))
-    (cons `(abs ,var) (replace-expression spec var `(neg ,var)))))
+    (define var-brf (batch-add! batch var))
+    (define neg-var-brf (batch-add! batch `(neg ,var-brf)))
+    (define replace-neg ((batch-replace-vars! batch `((,var-brf . ,neg-var-brf))) spec-brf))
+    (cons `(abs ,var) replace-neg)))
 
 ;; The odd identities: f(x) = -f(-x)
 ;; Requires `neg` and `fabs` operator implementations.
-(define (make-odd-identities spec ctx)
-  (define output-repr (context-repr ctx))
-  (for/list ([var (in-list (context-vars ctx))]
-             [repr (in-list (context-var-reprs ctx))]
+(define (make-odd-identities batch spec-brf)
+  (define output-repr (batch-repr-of spec-brf))
+  (for/list ([var (in-list (batch-vars batch))]
+             [repr (in-list (batch-var-reprs batch))]
              #:when (and (has-fabs-impl? repr) (has-copysign-impl? output-repr)))
-    (cons `(negabs ,var) (replace-expression `(neg ,spec) var `(neg ,var)))))
+    (define neg-spec-brf (batch-add! batch `(neg ,spec-brf)))
+    (define var-brf (batch-add! batch var))
+    (define neg-var-brf (batch-add! batch `(neg ,var-brf)))
+    (define replace-neg ((batch-replace-vars! batch `((,var-brf . ,neg-var-brf))) neg-spec-brf))
+    (cons `(negabs ,var) replace-neg)))
 
 ;; Sort identities: f(a, b) = f(b, a)
-(define (make-sort-identities spec ctx)
-  (define pairs (combinations (context-vars ctx) 2))
+(define (make-sort-identities batch spec-brf)
+  (define pairs (combinations (batch-vars batch) 2))
+  (define reprs (map cons (batch-vars batch) (batch-var-reprs batch)))
   (for/list ([pair (in-list pairs)]
              ;; Can only sort same-repr variables
-             #:when (equal? (context-lookup ctx (first pair)) (context-lookup ctx (second pair)))
-             #:when (has-fmin-fmax-impl? (context-lookup ctx (first pair))))
+             #:when (equal? (dict-ref reprs (first pair)) (dict-ref reprs (second pair)))
+             #:when (has-fmin-fmax-impl? (dict-ref reprs (first pair))))
     (match-define (list a b) pair)
-    (cons `(sort ,a ,b) (replace-vars `((,a . ,b) (,b . ,a)) spec))))
+    (define a-brf (batch-add! batch a))
+    (define b-brf (batch-add! batch b))
+    (define sorted-spec-brf
+      ((batch-replace-vars! batch `((,a-brf . ,b-brf) (,b-brf . ,a-brf))) spec-brf))
+    (cons `(sort ,a ,b) sorted-spec-brf)))
 
 ;; See https://pavpanchekha.com/blog/symmetric-expressions.html
 (define (find-preprocessing batch spec-brf ctx)
-  (define spec ((batch-exprs batch) spec-brf))
-
   ;; identities
   (define identities
-    (append (make-even-identities spec ctx)
-            (make-odd-identities spec ctx)
-            (make-sort-identities spec ctx)))
+    (append (make-even-identities batch spec-brf)
+            (make-odd-identities batch spec-brf)
+            (make-sort-identities batch spec-brf)))
 
   ;; make egg runner
-  (define brfs (cons spec-brf (map (compose (curry batch-add! batch) cdr) identities)))
+  (define brfs (cons spec-brf (map cdr identities)))
   (define runner (make-egraph batch brfs '(rewrite) ctx))
 
   ;; collect equalities
-  (for/list ([(ident spec*) (in-dict identities)]
-             #:when (egraph-equal? runner spec spec*))
+  (for/list ([(ident _) (in-dict identities)]
+             [idx (in-naturals 1)]
+             #:when (egraph-roots-equal? runner 0 idx))
     ident))
 
 (define (preprocess-pcontext context pcontext preprocessing)

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -41,7 +41,7 @@
 
 ;; The even identities: f(x) = f(-x)
 ;; Requires `neg` and `fabs` operator implementations.
-(define (make-even-identities batch spec-brf)
+(define (make-even-identities batch spec-brf output-repr)
   (for/list ([var (in-list (batch-vars batch))]
              [repr (in-list (batch-var-reprs batch))]
              #:when (has-fabs-impl? repr))
@@ -52,8 +52,7 @@
 
 ;; The odd identities: f(x) = -f(-x)
 ;; Requires `neg` and `fabs` operator implementations.
-(define (make-odd-identities batch spec-brf)
-  (define output-repr (batch-repr-of spec-brf))
+(define (make-odd-identities batch spec-brf output-repr)
   (for/list ([var (in-list (batch-vars batch))]
              [repr (in-list (batch-var-reprs batch))]
              #:when (and (has-fabs-impl? repr) (has-copysign-impl? output-repr)))
@@ -64,7 +63,7 @@
     (cons `(negabs ,var) replace-neg)))
 
 ;; Sort identities: f(a, b) = f(b, a)
-(define (make-sort-identities batch spec-brf)
+(define (make-sort-identities batch spec-brf output-repr)
   (define pairs (combinations (batch-vars batch) 2))
   (define reprs (map cons (batch-vars batch) (batch-var-reprs batch)))
   (for/list ([pair (in-list pairs)]
@@ -80,11 +79,13 @@
 
 ;; See https://pavpanchekha.com/blog/symmetric-expressions.html
 (define (find-preprocessing batch spec-brf ctx)
+  (define repr (context-repr ctx))
+
   ;; identities
   (define identities
-    (append (make-even-identities batch spec-brf)
-            (make-odd-identities batch spec-brf)
-            (make-sort-identities batch spec-brf)))
+    (append (make-even-identities batch spec-brf repr)
+            (make-odd-identities batch spec-brf repr)
+            (make-sort-identities batch spec-brf repr)))
 
   ;; make egg runner
   (define brfs (cons spec-brf (map cdr identities)))

--- a/src/core/preprocess.rkt
+++ b/src/core/preprocess.rkt
@@ -58,7 +58,9 @@
     (cons `(sort ,a ,b) (replace-vars `((,a . ,b) (,b . ,a)) spec))))
 
 ;; See https://pavpanchekha.com/blog/symmetric-expressions.html
-(define (find-preprocessing spec ctx)
+(define (find-preprocessing batch spec-brf ctx)
+  (define spec ((batch-exprs batch) spec-brf))
+
   ;; identities
   (define identities
     (append (make-even-identities spec ctx)
@@ -66,7 +68,7 @@
             (make-sort-identities spec ctx)))
 
   ;; make egg runner
-  (define-values (batch brfs) (progs->batch (cons spec (map cdr identities)) #:ctx ctx))
+  (define brfs (cons spec-brf (map (compose (curry batch-add! batch) cdr) identities)))
   (define runner (make-egraph batch brfs '(rewrite) ctx))
 
   ;; collect equalities


### PR DESCRIPTION
The preprocessing step, which operates on specs, currently represents those specs as expression trees and uses expression functions on them. This PR batchifies preprocessing, so that it operates entirely on batches instead.