### PR TITLE
Don't sort alts on test points

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -89,9 +89,8 @@
   ;; compute error/cost for output expression
   ;; and sort alternatives by accuracy + cost on testing subset
   (define test-errs (exprs-errors (map alt-expr alternatives) test-pcontext (*context*)))
-  (define sorted-end-exprs (sort-alts alternatives test-errs))
-  (define end-exprs (map (compose alt-expr car) sorted-end-exprs))
-  (define end-errs (map cdr sorted-end-exprs))
+  (define end-exprs (map (compose alt-expr car) alternatives))
+  (define end-errs (map cdr alternatives))
   (define end-data (map alt-analysis alternatives end-errs))
 
   (improve-result test-pcontext start-alt-data target-alt-data end-data))

--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -88,9 +88,8 @@
 
   ;; compute error/cost for output expression
   ;; and sort alternatives by accuracy + cost on testing subset
-  (define test-errs (exprs-errors (map alt-expr alternatives) test-pcontext (*context*)))
-  (define end-exprs (map (compose alt-expr car) alternatives))
-  (define end-errs (map cdr alternatives))
+  (define end-errs (exprs-errors (map alt-expr alternatives) test-pcontext (*context*)))
+  (define end-exprs (map alt-expr alternatives))
   (define end-data (map alt-analysis alternatives end-errs))
 
   (improve-result test-pcontext start-alt-data target-alt-data end-data))

--- a/src/core/alt-table.rkt
+++ b/src/core/alt-table.rkt
@@ -45,7 +45,7 @@
 
 (define (make-alt-table batch pcontext initial-alt ctx)
   (define cost ((alt-batch-costs batch) (alt-expr initial-alt)))
-  (define errs (batchref-errors (alt-expr initial-alt) pcontext ctx))
+  (define errs (first (batch-errors batch (list (alt-expr initial-alt)) pcontext ctx)))
   (alt-table (for/vector #:length (pcontext-length pcontext)
                          ([err (in-flvector errs)])
                (list (pareto-point cost err (list initial-alt))))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -80,8 +80,8 @@
   (define joined-alts (make-regime! (*global-batch*) all-alts (*start-brf*)))
   (define annotated-alts (add-derivations! joined-alts))
   (define scores (batch-errors (*global-batch*) (map alt-expr annotated-alts) (*pcontext*)))
-  (define sorted-alts (map car (sort-alts annotated-alts scores)))
-  (define unbatched-alts (unbatchify-alts (*global-batch*) annotated-alts))
+  (define sorted-alts (map car (sort-alts (*global-batch*) annotated-alts scores)))
+  (define unbatched-alts (unbatchify-alts (*global-batch*) sorted-alts))
   (timeline-push! 'stop (if (atab-completed? (^table^)) "done" "fuel") 1)
   unbatched-alts)
 
@@ -317,12 +317,13 @@
      (add-derivations alts)]
     [else alts]))
 
-(define (sort-alts alts errss)
+(define (sort-alts batch alts errss)
   ;; sort everything by error + cost
+  (define alt-costs (alt-batch-costs batch))
   (define alts-to-be-sorted (map cons alts errss))
   (sort alts-to-be-sorted
         (lambda (x y)
           (or (< (errors-score (cdr x)) (errors-score (cdr y))) ; sort by error
               (and (equal? (errors-score (cdr x))
                            (errors-score (cdr y))) ; if error is equal sort by cost
-                   (< (alt-cost (car x)) (alt-cost (car y))))))))
+                   (< (alt-costs (alt-expr (car x))) (alt-costs (alt-expr (car y)))))))))

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -19,8 +19,7 @@
          "regimes.rkt"
          "batch-reduce.rkt")
 
-(provide run-improve!
-         sort-alts)
+(provide run-improve!)
 
 ;; The Herbie main loop goes through a simple iterative process:
 ;;

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -79,10 +79,11 @@
   (define all-alts (atab-all-alts (^table^)))
   (define joined-alts (make-regime! (*global-batch*) all-alts (*start-brf*)))
   (define annotated-alts (add-derivations! joined-alts))
+  (define scores (batch-errors (*global-batch*) (map alt-expr annotated-alts) (*pcontext*)))
+  (define sorted-alts (map car (sort-alts annotated-alts scores)))
   (define unbatched-alts (unbatchify-alts (*global-batch*) annotated-alts))
-
   (timeline-push! 'stop (if (atab-completed? (^table^)) "done" "fuel") 1)
-  (map car (sort-alts unbatched-alts)))
+  unbatched-alts)
 
 ;; The rest of the file is various helper / glue functions used by
 ;; Herbie. These often wrap other Herbie components, but add logging
@@ -137,6 +138,7 @@
           (list (alt _ `(taylor ,prev-start-expr ,transform ,var ,order) prevs)))
      (car (alt-prevs altn))]
     [_ #f]))
+
 ;; Converts a patch to full alt with valid history
 (define (reconstruct! starting-alts new-alts)
   (timeline-event! 'reconstruct)
@@ -317,7 +319,7 @@
      (add-derivations alts)]
     [else alts]))
 
-(define (sort-alts alts [errss (exprs-errors (map alt-expr alts) (*pcontext*) (*context*))])
+(define (sort-alts alts errss)
   ;; sort everything by error + cost
   (define alts-to-be-sorted (map cons alts errss))
   (sort alts-to-be-sorted

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -104,7 +104,7 @@
                              (writeln (exprs (alt-expr altn)) out)))))
 
 (define (batch-score-alts altns)
-  (map errors-score (batch-errors (*global-batch*) (map alt-expr altns) (*pcontext*) (*context*))))
+  (map errors-score (batch-errors (*global-batch*) (map alt-expr altns) (*pcontext*))))
 
 (define (timeline-push-alts! next-alts)
   (define pending-alts (atab-not-done-alts (^table^)))

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -64,9 +64,6 @@
 (define (errors expr pcontext ctx)
   (first (exprs-errors (list expr) pcontext ctx)))
 
-(define (batchref-errors brf pcontext ctx)
-  (first (batch-errors (batchref-batch brf) (list brf) pcontext ctx)))
-
 (define (exprs-errors exprs pcontext ctx)
   (define fn (compile-progs exprs ctx))
   (define num-exprs (length exprs))

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -55,9 +55,6 @@
 ;; Herbie's standard error measure is the average bits of error across
 ;; all points in a pcontext.
 
-(define (average . s)
-  (/ (apply + s) (length s)))
-
 (define (errors-score e)
   (/ (flvector-sum e) (flvector-length e)))
 

--- a/src/core/points.rkt
+++ b/src/core/points.rkt
@@ -14,7 +14,6 @@
          split-pcontext
          pcontext-length
          errors
-         batchref-errors
          batch-errors
          exprs-errors
          errors-score)


### PR DESCRIPTION
Herbie seems to currently sort outputs based on training accuracy, but then re-sort based on test accuracy. I guess we shouldn't sort on test accuracy; if we do it wrong we should just cop to it. For some reason we do it wrong anyway? Anyway, one less thing to export.