### PR TITLE
Fix dominator-based regimes code

### DIFF
--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -145,7 +145,7 @@
     (define idx2 (batchref-idx brf2))
     (cond
       [(= idx1 idx2) brf1]
-      [(< idx1 idx2) (loop (dom-parent brf1) brf2)]
+      [(> idx1 idx2) (loop (dom-parent brf1) brf2)]
       [else (loop brf1 (dom-parent brf2))])))
 
 (define (baseline-errors-score err-cols count)
@@ -259,6 +259,11 @@
     (define-values (batch brfs) (progs->batch (list 'x) #:ctx xy-ctx))
     (check-true (critical-subexpression? batch (first brfs) (batch-add! batch 'x)))
     (check-false (critical-subexpression? batch (first brfs) (batch-add! batch 'y))))
+
+  (let ()
+    (define xyz-ctx (context '(x y z) <binary64> (list <binary64> <binary64> <binary64>)))
+    (define-values (batch brfs) (progs->batch (list '(* (+ x y) (/ x z))) #:ctx xyz-ctx))
+    (check-false (critical-subexpression? batch (first brfs) (batch-add! batch '(+ x y)))))
 
   (let ()
     (define vec2-ctx

--- a/src/core/regimes.rkt
+++ b/src/core/regimes.rkt
@@ -109,7 +109,16 @@
 
 (define (critical-subexpressions batch root-brf)
   (define var-brfs (map (curry batch-add! batch) (batch-vars batch)))
+  (define free-vars (batch-free-vars batch))
   (define dom-parent (build-dominator-tree batch root-brf))
+  (define (dominates? parent-brf child-brf)
+    (cond
+      [(equal? parent-brf child-brf) #t]
+      [(equal? child-brf root-brf) #f]
+      [else (dominates? parent-brf (dom-parent child-brf))]))
+  (define (extractable? brf)
+    (for/and ([var (in-set (free-vars brf))])
+      (dominates? brf (batch-add! batch var))))
   (reap [sow]
         (define seen-brfs (mutable-set root-brf))
         (sow root-brf)
@@ -118,7 +127,8 @@
             (let loop ([brf brf])
               (unless (set-member? seen-brfs brf)
                 (set-add! seen-brfs brf)
-                (sow brf)
+                (when (extractable? brf)
+                  (sow brf))
                 (loop (dom-parent brf))))))))
 
 (define (build-dominator-tree batch root-brf)
@@ -145,7 +155,7 @@
     (define idx2 (batchref-idx brf2))
     (cond
       [(= idx1 idx2) brf1]
-      [(> idx1 idx2) (loop (dom-parent brf1) brf2)]
+      [(< idx1 idx2) (loop (dom-parent brf1) brf2)]
       [else (loop brf1 (dom-parent brf2))])))
 
 (define (baseline-errors-score err-cols count)


### PR DESCRIPTION
Turns out #1570 was wrong. The reason is kind of simple once you think about it, but I guess it shows the risk of clever algorithms. Basically, we construct the dominator tree, and now we look at expressions that dominate a variable. But an expression might dominate _one_ variable but not _another_ variable that it uses; the example Codex came up with was that `x + y` dominates `y` but not `x` in `(x + y) / (x + z)`. So what we need to do is, for every expression that dominates one variable, compute its free variables and see if it dominates all other free variables in that expression.

This fixes an unlikely crash.