### PR TITLE
Remove dead `hole` term from Herbie

### DIFF
--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -97,7 +97,6 @@
          [(literal v _) (insert-node! v)]
          [(? number?) (insert-node! node)]
          [(? symbol?) (insert-node! (var->egg-var node ctx))]
-         [(hole prec spec) (recurse spec)] ; "hole" terms currently disappear
          [(approx spec impl) (insert-node! (list '$approx (recurse spec) (recurse impl)))]
          [(list op (app recurse args) ...) (insert-node! (cons op args))]))))
 
@@ -198,7 +197,6 @@
       [(? literal?) (literal-value expr)]
       [(? symbol? x) (var->egg-var x ctx)]
       [(approx spec impl) (list '$approx (loop spec) (loop impl))]
-      [(hole precision spec) (loop spec)]
       [(list op args ...) (cons op (map loop args))])))
 
 (define (flatten-let expr)

--- a/src/core/egglog-herbie.rkt
+++ b/src/core/egglog-herbie.rkt
@@ -446,7 +446,6 @@
          [(? literal?) #f] ;; If literal, not a spec
          [(? number?) #t] ;; If number, it's a spec
          [(? symbol?) #t]
-         [(hole _ _) #f] ;; If hole, not a spec
          [(approx _ _) #f] ;; If approx, not a spec
          [`(if ,cond ,ift ,iff)
           (recurse cond)] ;; If the condition or any branch is a spec, then this is a spec
@@ -472,9 +471,7 @@
                           (id->e2))
                       impl)
            ,@(for/list ([arg (in-list args)])
-               (remap arg (spec? (batchref batch n)))))]
-
-        [(hole ty spec) `(do-lower ,(remap spec #t) ,(egglog-repr-token ty))]))
+               (remap arg (spec? (batchref batch n)))))]))
 
     (if node*
         (vector-set! mappings n (insert-node! node* n root?))

--- a/src/core/programs.rkt
+++ b/src/core/programs.rkt
@@ -39,7 +39,6 @@
     [(literal val precision) (get-representation precision)]
     [(? symbol?) (context-lookup ctx expr)]
     [(approx _ impl) (repr-of impl ctx)]
-    [(hole precision spec) (get-representation precision)]
     [(list op args ...) (impl-info op 'otype)]))
 
 (define (batch-repr-of brf)
@@ -50,7 +49,6 @@
       [(literal val precision) (get-representation precision)]
       [(? symbol? node) (dict-ref var-reprs node)]
       [(approx _ impl) (loop impl)]
-      [(hole precision spec) (get-representation precision)]
       [(list op args ...) (impl-info op 'otype)])))
 
 (define (all-subexpressions expr #:reverse? [reverse? #f])
@@ -127,13 +125,6 @@
          cmp-spec)]
     [((? approx?) _) 1]
     [(_ (? approx?)) -1]
-    [((? hole?) (? hole?))
-     (define cmp-spec (expr-cmp (hole-spec a) (hole-spec b)))
-     (if (zero? cmp-spec)
-         (expr-cmp (hole-precision a) (hole-precision b))
-         cmp-spec)]
-    [((? hole?) _) 1]
-    [(_ (? hole?)) -1]
     [((? symbol?) (? symbol?))
      (cond
        [(symbol<? a b) -1]

--- a/src/reports/history.rkt
+++ b/src/reports/history.rkt
@@ -44,7 +44,6 @@
         [(approx spec impl)
          (loop spec)
          (loop impl)]
-        [(hole prec spec) (loop spec)]
         [(list op args ...) (for-each loop args)]
         [_ (void)]))
     (k 'Goal #f step)))
@@ -57,7 +56,6 @@
         [(? number?) expr]
         [(? literal?) (literal-value expr)]
         [(approx _ impl) (loop impl)]
-        [(hole precision spec) (loop spec)]
         [`(if ,cond ,ift ,iff)
          `(if ,(loop cond)
               ,(loop ift)

--- a/src/syntax/batch.rkt
+++ b/src/syntax/batch.rkt
@@ -45,7 +45,6 @@
 (define (expr-recurse expr f)
   (match expr
     [(approx spec impl) (approx (f spec) (f impl))]
-    [(hole precision spec) (hole precision (f spec))]
     [(list op) (list op)]
     [(list op arg1) (list op (f arg1))]
     [(list op arg1 arg2) (list op (f arg1) (f arg2))]
@@ -171,7 +170,6 @@
         [(? symbol?) (~a node)]
         [(? number?) (~a node)]
         [(approx spec impl) (list "approx" spec impl)]
-        [(hole precision spec) (list "hole" (~a precision) spec)]
         [(list op args ...) (cons (~a op) args)]
         [_ (~a node)])))
   (hash 'nodes nodes 'roots (map batchref-idx brfs*)))

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -118,7 +118,6 @@
                        [(? literal?) (batch-push! batch (literal-value node))]
                        [(? number?) brf]
                        [(? symbol?) brf]
-                       [(hole _ spec) (recurse spec)]
                        [(approx spec _) (recurse spec)]
                        [(list (? impl-exists? impl) args ...)
                         (define vars (impl-info impl 'vars))

--- a/src/syntax/sugar.rkt
+++ b/src/syntax/sugar.rkt
@@ -74,7 +74,6 @@
     [(literal _ precision) (get-representation precision)]
     [(? symbol?) (context-lookup ctx expr)]
     [(approx _ impl) (repr-of impl ctx)]
-    [(hole precision _) (get-representation precision)]
     [(list op _ ...) (impl-info op 'otype)]))
 
 (define (replace-vars dict expr)
@@ -294,7 +293,6 @@
       [(? number?) expr]
       [(? symbol?) expr]
       [(approx _ impl) (munge impl)]
-      [(hole _ spec) (munge spec)]
       [(list (? impl-exists? impl) args ...)
        (define args* (map munge args))
        (define vars (impl-info impl 'vars))

--- a/src/syntax/syntax.rkt
+++ b/src/syntax/syntax.rkt
@@ -11,7 +11,6 @@
 
 (provide (struct-out literal)
          (struct-out approx)
-         (struct-out hole)
          operator-exists?
          operator-info
          all-operators ; return a list of operators names
@@ -76,6 +75,3 @@
 ;; An approximation of a specification by
 ;; a floating-point expression.
 (struct approx (spec impl) #:prefab)
-
-;; An unknown floating-point expression that implements a given spec
-(struct hole (precision spec) #:prefab)


### PR DESCRIPTION
This PR removes `hole` terms from the IR. It was always a bit of a weird term, and now we don't use it, so removing it is a small simplification.