### PR TITLE
Pass output representations into Rival compiler boundaries

### DIFF
--- a/src/api/sandbox.rkt
+++ b/src/api/sandbox.rkt
@@ -140,7 +140,7 @@
   (define-values (batch brfs) (progs->batch (list specification) #:ctx (*context*)))
   (define sample
     (parameterize ([*num-points* (+ (*num-points*) (*reeval-pts*))])
-      (sample-points precondition batch brfs (list (*context*)))))
+      (sample-points precondition batch brfs (list (context-repr (*context*))))))
   (apply mk-pcontext sample))
 
 ;;

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -194,7 +194,7 @@
     (raise-user-error
      'sindices->spoints/binary
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
-  (define spec-brfs (batch-to-spec! batch* (list start-prog-sub)))
+  (define spec-brfs (batch-to-spec! batch* batch* (list start-prog-sub)))
   (define start-real-compiler (make-real-compiler batch* spec-brfs (list ctx*)))
 
   (define (prepend-macro v)

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -195,7 +195,7 @@
      'sindices->spoints/binary
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
   (define spec-brfs (batch-to-spec! batch* (list start-prog-sub)))
-  (define start-real-compiler (make-real-compiler batch* spec-brfs (list ctx*)))
+  (define start-real-compiler (make-real-compiler batch* spec-brfs (list (context-repr ctx*))))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))

--- a/src/core/bsearch.rkt
+++ b/src/core/bsearch.rkt
@@ -50,10 +50,9 @@
   (define splitpoints (sindices->spoints/left batch pts brf splitindices))
   (finish-combine-alts batch alts brf splitindices splitpoints))
 
-(define (combine-alts/binary batch best-option start-prog ctx pcontext)
+(define (combine-alts/binary batch best-option start-prog pcontext)
   (match-define (option splitindices alts pts brf) best-option)
-  (define splitpoints
-    (sindices->spoints/binary batch pts brf alts splitindices start-prog ctx pcontext))
+  (define splitpoints (sindices->spoints/binary batch pts brf alts splitindices start-prog pcontext))
   (finish-combine-alts batch alts brf splitindices splitpoints))
 
 (define (remove-unused-alts alts splitpoints)
@@ -165,16 +164,8 @@
     (timeline-push! 'method "left-value")
     (sp (si-cidx si1) brf split-at)))
 
-(define/contract (sindices->spoints/binary batch points brf alts sindices start-prog ctx pcontext)
-  (-> batch?
-      (listof vector?)
-      batchref?
-      (listof alt?)
-      (listof si?)
-      any/c
-      context?
-      pcontext?
-      (listof sp?))
+(define/contract (sindices->spoints/binary batch points brf alts sindices start-prog pcontext)
+  (-> batch? (listof vector?) batchref? (listof alt?) (listof si?) any/c pcontext? (listof sp?))
   (define repr (batch-repr-of brf))
   (define ulps (repr-ulps repr))
   (define eval-expr (compose (curryr vector-ref 0) (compile-batch batch (list brf))))
@@ -183,9 +174,7 @@
     (if (symbol? brf-node)
         brf-node
         (deterministic-branch-var batch)))
-  (define ctx* (context-extend ctx var repr))
-  (define batch* (batch-empty ctx*))
-  (define var-brf (batch-add! batch* var))
+  (define-values (batch* var-brf) (batch-empty-extend batch var repr))
   (define progs
     (for/list ([alt (in-list alts)])
       (extract-subexpression batch (alt-expr alt) brf batch* var-brf)))
@@ -195,7 +184,7 @@
      'sindices->spoints/binary
      "mainloop called binary splitpoint search without extractable critical subexpressions"))
   (define spec-brfs (batch-to-spec! batch* (list start-prog-sub)))
-  (define start-real-compiler (make-real-compiler batch* spec-brfs (list (context-repr ctx*))))
+  (define start-real-compiler (make-real-compiler batch* spec-brfs (list repr)))
 
   (define (prepend-macro v)
     (prepend-argument start-real-compiler v pcontext))

--- a/src/core/derivations.rkt
+++ b/src/core/derivations.rkt
@@ -26,7 +26,7 @@
     [(alt expr (list 'rr start-brf end-brf (? egg-runner? runner) #f) `(,prev))
      (define batch (egg-runner-batch runner))
      (define-values (proof-start proof-end)
-       (apply values (batch-to-spec! batch (list start-brf end-brf))))
+       (apply values (batch-to-spec! batch batch (list start-brf end-brf))))
      (define proof
        (and (not (flag-set? 'generate 'egglog)) (egraph-prove runner proof-start proof-end)))
      (define proof* (canonicalize-proof batch (alt-expr altn) proof start-brf))

--- a/src/core/explain.rkt
+++ b/src/core/explain.rkt
@@ -68,17 +68,14 @@
 (define (compile-expr expr ctx)
   (define subexprs (all-subexpressions expr #:reverse? #t))
   (define spec-list (map prog->spec subexprs))
-  (define ctxs
-    (for/list ([subexpr (in-list subexprs)])
-      (struct-copy context ctx [repr (repr-of subexpr ctx)])))
+  (define reprs (map (curryr repr-of ctx) subexprs))
 
-  (define repr-hash
-    (make-immutable-hash (map (lambda (e ctx) (cons e (context-repr ctx))) subexprs ctxs)))
+  (define repr-hash (make-immutable-hash (map cons subexprs reprs)))
 
   (define-values (batch brfs) (progs->batch spec-list #:ctx ctx))
   (define subexprs-fn
     (parameterize ([*max-mpfr-prec* 128])
-      (eval-progs-real batch brfs ctxs)))
+      (eval-progs-real batch brfs reprs)))
   (values subexprs repr-hash subexprs-fn))
 
 (define (predict-errors ctx pctx subexprs-list repr-hash subexprs-fn)

--- a/src/core/localize.rkt
+++ b/src/core/localize.rkt
@@ -24,11 +24,11 @@
          eval-progs-real
          local-error-as-tree)
 
-(define (eval-progs-real batch brfs ctxs)
-  (define compiler (make-real-compiler batch brfs ctxs))
+(define (eval-progs-real batch brfs reprs)
+  (define compiler (make-real-compiler batch brfs reprs))
   (define bad-pt
-    (for/list ([ctx* (in-list ctxs)])
-      ((representation-bf->repr (context-repr ctx*)) +nan.bf)))
+    (for/list ([repr (in-list reprs)])
+      ((representation-bf->repr repr) +nan.bf)))
   (define (<eval-prog-real> pt)
     (define-values (_ exs) (real-apply compiler pt))
     (or exs bad-pt))
@@ -65,16 +65,11 @@
   (define exprs-list (append* subexprss)) ; unroll subexprss
   (define reprs-list (map (curryr repr-of ctx) exprs-list))
   (define ulps-list (map repr-ulps reprs-list))
-  (define ctx-list
-    (for/list ([subexpr (in-list exprs-list)]
-               [repr (in-list reprs-list)])
-      (struct-copy context ctx [repr repr])))
-
   (define-values (expr-batch brfs) (progs->batch exprs-list #:ctx ctx))
   (define roots (list->vector (map batchref-idx brfs)))
 
   (define-values (spec-batch spec-brfs) (progs->batch (map prog->spec exprs-list) #:ctx ctx))
-  (define subexprs-fn (eval-progs-real spec-batch spec-brfs ctx-list))
+  (define subexprs-fn (eval-progs-real spec-batch spec-brfs reprs-list))
 
   (define errs (make-matrix roots pcontext))
 
@@ -120,12 +115,8 @@
   (define spec-list (map prog->spec exprs-list))
   (define reprs-list (map (curryr repr-of ctx) exprs-list))
   (define ulps-list (map repr-ulps reprs-list))
-  (define ctx-list
-    (for/list ([subexpr (in-list exprs-list)]
-               [repr (in-list reprs-list)])
-      (struct-copy context ctx [repr repr])))
   (define-values (spec-batch spec-brfs) (progs->batch spec-list #:ctx ctx))
-  (define subexprs-fn (eval-progs-real spec-batch spec-brfs ctx-list))
+  (define subexprs-fn (eval-progs-real spec-batch spec-brfs reprs-list))
 
   ;; And the absolute difference between the two
   (define exact-var-names
@@ -133,7 +124,7 @@
       (gensym 'exact)))
   (define delta-ctx
     (context (append (context-vars ctx) exact-var-names)
-             (get-representation 'binary64)
+             <binary64>
              (append (context-var-reprs ctx) reprs-list)))
   (define compare-specs
     (for/list ([spec (in-list spec-list)]
@@ -145,7 +136,8 @@
         ['real `(fabs (- ,spec ,var))]
         [_ 0])))
   (define-values (compare-batch compare-brfs) (progs->batch compare-specs #:ctx delta-ctx))
-  (define delta-fn (eval-progs-real compare-batch compare-brfs (map (const delta-ctx) compare-specs)))
+  (define delta-fn
+    (eval-progs-real compare-batch compare-brfs (map (const <binary64>) compare-specs)))
 
   (define-values (expr-batch brfs) (progs->batch exprs-list #:ctx ctx))
   (define roots (list->vector (map batchref-idx brfs)))
@@ -155,8 +147,6 @@
   (define approx-out (make-matrix roots pcontext))
   (define true-error-out (make-matrix roots pcontext))
 
-  (define spec-vec (list->vector spec-list))
-  (define ctx-vec (list->vector ctx-list))
   (for ([(pt ex) (in-pcontext pcontext)]
         [pt-idx (in-naturals)])
 

--- a/src/core/mainloop.rkt
+++ b/src/core/mainloop.rkt
@@ -304,7 +304,7 @@
                 (critical-subexpression? batch (alt-expr alt) brf))))
        (cond
          [(= (length splitindices) 1) (list-ref opt-alts (si-cidx (first splitindices)))]
-         [use-binary? (combine-alts/binary batch opt start-prog (*context*) (*pcontext*))]
+         [use-binary? (combine-alts/binary batch opt start-prog (*pcontext*))]
          [else (combine-alts batch opt)]))]
     [else
      (define scores (batch-score-alts alts))

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -41,7 +41,8 @@
   (define brfs (map alt-expr altns))
   (define reprs (map batch-repr-of brfs))
   ;; Specs
-  (define spec-brfs (batch-to-spec! global-batch brfs)) ;; These specs will go into (approx spec impl)
+  (define spec-brfs
+    (batch-to-spec! global-batch global-batch brfs)) ;; These specs will go into (approx spec impl)
   (define free-vars (map (batch-free-vars global-batch) spec-brfs))
   (define spec-brfs*
     (map (batch-copy-only! spec-batch global-batch)
@@ -143,7 +144,7 @@
 (define (run-evaluate altns global-batch)
   (timeline-event! 'sample)
   (define all-brfs (map alt-expr altns))
-  (define spec-brfs (batch-to-spec! global-batch all-brfs))
+  (define spec-brfs (batch-to-spec! global-batch global-batch all-brfs))
   (define free-vars (batch-free-vars global-batch))
   (define real-pairs
     (for/list ([altn (in-list altns)]
@@ -194,7 +195,7 @@
   (define schedule '(rewrite unsound lower))
 
   (define brfs (map alt-expr altns))
-  (define spec-brfs (batch-to-spec! global-batch brfs))
+  (define spec-brfs (batch-to-spec! global-batch global-batch brfs))
   (define reprs (map batch-repr-of brfs))
   (define runner
     (cond

--- a/src/core/patch.rkt
+++ b/src/core/patch.rkt
@@ -157,14 +157,11 @@
 
   (define brfs (map alt-expr real-altns))
   (define reprs (map batch-repr-of brfs))
-  (define contexts
-    (for/list ([repr (in-list reprs)])
-      (context '() repr '())))
 
   (define-values (status pts)
     (if (null? real-spec-brfs)
         (values 'invalid #f)
-        (let ([real-compiler (make-real-compiler global-batch real-spec-brfs contexts)])
+        (let ([real-compiler (make-real-compiler global-batch real-spec-brfs reprs)])
           (real-apply real-compiler (vector)))))
   (define literals
     (for/list ([pt (in-list (if (equal? status 'valid)

--- a/src/core/sampling.rkt
+++ b/src/core/sampling.rkt
@@ -180,9 +180,9 @@
   (for/fold ([t1 (hash-remove (hash-remove t1 'unknown) 'valid)]) ([(k v) (in-hash t2)])
     (hash-set t1 k (+ (hash-ref t1 k 0) (* (/ v t2-total) t1-base)))))
 
-(define (sample-points pre batch brfs ctxs)
+(define (sample-points pre batch brfs reprs)
   (timeline-event! 'analyze)
-  (define compiler (make-real-compiler batch brfs ctxs #:pre pre))
+  (define compiler (make-real-compiler batch brfs reprs #:pre pre))
   (define-values (sampler table) (make-sampler compiler))
   (timeline-event! 'sample)
   (define-values (results table2) (batch-prepare-points compiler sampler))

--- a/src/core/test-rules.rkt
+++ b/src/core/test-rules.rkt
@@ -41,7 +41,7 @@
   (match-define (list pts exs1 exs2)
     (parameterize ([*num-points* (num-test-points)]
                    [*max-find-range-depth* 0])
-      (sample-points '(TRUE) batch brfs (list ctx ctx))))
+      (sample-points '(TRUE) batch brfs (make-list 2 double-repr))))
 
   (for ([pt (in-list pts)]
         [v1 (in-list exs1)]

--- a/src/syntax/batch.rkt
+++ b/src/syntax/batch.rkt
@@ -11,6 +11,7 @@
          expr-recurse-impl
          (struct-out batch)
          batch-empty ; Batch
+         batch-empty-extend
          batch-push!
          batch-add! ; Batch -> (or Expr Batchref Expr<Batchref>) -> Batchref
          batch-copy-only!
@@ -37,6 +38,11 @@
 (define (batch-empty ctx)
   (match-define (context vars _ var-reprs) ctx)
   (batch (make-dvector) (make-hash) vars var-reprs))
+
+(define (batch-empty-extend b var repr)
+  (define out
+    (batch (make-dvector) (make-hash) (cons var (batch-vars b)) (cons repr (batch-var-reprs b))))
+  (values out (batch-push! out var)))
 
 (define (in-batch batch [start 0] [end #f] [step 1])
   (in-dvector (batch-nodes batch) start end step))

--- a/src/syntax/generators.rkt
+++ b/src/syntax/generators.rkt
@@ -34,7 +34,7 @@
 
 (define-generator ((from-rival #:cache? [cache? #t]) spec ctx)
   (define-values (batch brfs) (progs->batch (list spec) #:ctx ctx))
-  (define compiler (make-real-compiler batch brfs (list ctx)))
+  (define compiler (make-real-compiler batch brfs (list (context-repr ctx))))
   (define fail ((representation-bf->repr (context-repr ctx)) +nan.bf))
   (define (compute . pt)
     (define-values (_ exs) (real-apply compiler (list->vector pt)))

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -109,25 +109,66 @@
      (define env (map cons vars (map prog->spec args)))
      (pattern-substitute spec env)]))
 
-(define (batch-to-spec! batch brfs)
+(define (batch-to-spec! in-batch out-batch brfs)
+  (define (check-output-spec! spec)
+    (unless (equal? (batchref-batch spec) out-batch)
+      (error 'batch-to-spec! "spec reference does not belong to the output batch"))
+    spec)
   (define lower
-    (batch-recurse batch
-                   (lambda (brf recurse)
-                     (define node (deref brf))
-                     (match node
-                       [(? literal?) (batch-push! batch (literal-value node))]
-                       [(? number?) brf]
-                       [(? symbol?) brf]
-                       [(hole _ spec) (recurse spec)]
-                       [(approx spec _) (recurse spec)]
-                       [(list (? impl-exists? impl) args ...)
-                        (define vars (impl-info impl 'vars))
-                        (define spec (impl-info impl 'spec))
-                        (define env (map cons vars (map recurse args)))
-                        (batch-add! batch (pattern-substitute spec env))]
-                       [(list op args ...)
-                        (batch-push! batch (cons op (map (compose batchref-idx recurse) args)))]))))
+    (batch-recurse
+     in-batch
+     (lambda (brf recurse)
+       (define node (deref brf))
+       (match node
+         [(? literal?) (batch-add! out-batch (literal-value node))]
+         [(? number?) (error 'batch-to-spec! "unexpected spec node in input batch: ~a" node)]
+         [(? symbol?) (batch-add! out-batch node)]
+         [(hole _ spec) (check-output-spec! spec)]
+         [(approx spec _) (check-output-spec! spec)]
+         [(list (? impl-exists? impl) args ...)
+          (define vars (impl-info impl 'vars))
+          (define spec (impl-info impl 'spec))
+          (define env (map cons vars (map recurse args)))
+          (batch-add! out-batch (pattern-substitute spec env))]
+         [(list op args ...)
+          (error 'batch-to-spec! "unexpected spec node in input batch: ~a" node)]))))
   (map lower brfs))
+
+(module+ test
+  (require rackunit)
+
+  (define test-empty-ctx (context '() #f '()))
+
+  (let* ([in-batch (batch-empty test-empty-ctx)]
+         [out-batch (batch-empty test-empty-ctx)]
+         [x (batch-add! in-batch 'x)]
+         [x* (first (batch-to-spec! in-batch out-batch (list x)))])
+    (check-equal? (batchref-batch x*) out-batch)
+    (check-equal? (deref x*) 'x))
+
+  (let* ([batch (batch-empty test-empty-ctx)]
+         [spec (batch-add! batch 'x)]
+         [impl (batch-add! batch (literal 1 'binary64))]
+         [approx-brf (batch-add! batch (approx spec impl))]
+         [hole-brf (batch-add! batch (hole 'binary64 spec))])
+    (check-equal? (batch-to-spec! batch batch (list approx-brf hole-brf)) (list spec spec)))
+
+  (let* ([in-batch (batch-empty test-empty-ctx)]
+         [out-batch (batch-empty test-empty-ctx)]
+         [spec (batch-add! in-batch 'x)]
+         [impl (batch-add! in-batch (literal 1 'binary64))]
+         [approx-brf (batch-add! in-batch (approx spec impl))]
+         [hole-brf (batch-add! in-batch (hole 'binary64 spec))])
+    (check-exn #rx"output batch" (λ () (batch-to-spec! in-batch out-batch (list approx-brf))))
+    (check-exn #rx"output batch" (λ () (batch-to-spec! in-batch out-batch (list hole-brf)))))
+
+  (let* ([in-batch (batch-empty test-empty-ctx)]
+         [out-batch (batch-empty test-empty-ctx)]
+         [num (batch-add! in-batch 1)]
+         [expr (batch-add! in-batch `(+ ,num ,num))])
+    (parameterize ([*active-platform* (make-empty-platform)])
+      (check-exn #rx"unexpected spec node" (λ () (batch-to-spec! in-batch out-batch (list num))))
+      (check-exn #rx"unexpected spec node" (λ () (batch-to-spec! in-batch out-batch (list expr)))))))
 
 ;; Expression predicates ;;
 

--- a/src/syntax/platform.rkt
+++ b/src/syntax/platform.rkt
@@ -148,18 +148,15 @@
   (let* ([batch (batch-empty test-empty-ctx)]
          [spec (batch-add! batch 'x)]
          [impl (batch-add! batch (literal 1 'binary64))]
-         [approx-brf (batch-add! batch (approx spec impl))]
-         [hole-brf (batch-add! batch (hole 'binary64 spec))])
-    (check-equal? (batch-to-spec! batch batch (list approx-brf hole-brf)) (list spec spec)))
+         [approx-brf (batch-add! batch (approx spec impl))])
+    (check-equal? (batch-to-spec! batch batch (list approx-brf)) (list spec)))
 
   (let* ([in-batch (batch-empty test-empty-ctx)]
          [out-batch (batch-empty test-empty-ctx)]
          [spec (batch-add! in-batch 'x)]
          [impl (batch-add! in-batch (literal 1 'binary64))]
-         [approx-brf (batch-add! in-batch (approx spec impl))]
-         [hole-brf (batch-add! in-batch (hole 'binary64 spec))])
-    (check-exn #rx"output batch" (λ () (batch-to-spec! in-batch out-batch (list approx-brf))))
-    (check-exn #rx"output batch" (λ () (batch-to-spec! in-batch out-batch (list hole-brf)))))
+         [approx-brf (batch-add! in-batch (approx spec impl))])
+    (check-exn #rx"output batch" (λ () (batch-to-spec! in-batch out-batch (list approx-brf)))))
 
   (let* ([in-batch (batch-empty test-empty-ctx)]
          [out-batch (batch-empty test-empty-ctx)]

--- a/src/syntax/rival.rkt
+++ b/src/syntax/rival.rkt
@@ -118,25 +118,16 @@
          ival-hi
          (contract-out
           [make-real-compiler
-           (->i
-            ([batch batch?]
-             [brfs (listof batchref?)]
-             [ctxs (brfs) (and/c unified-contexts? (lambda (ctxs) (= (length brfs) (length ctxs))))])
-            (#:pre [pre any/c])
-            [c real-compiler?])]
+           (->i ([batch batch?] [brfs (listof batchref?)]
+                                [reprs
+                                 (brfs)
+                                 (and/c (listof representation?)
+                                        (lambda (reprs) (= (length brfs) (length reprs))))])
+                (#:pre [pre any/c])
+                [c real-compiler?])]
           [real-apply (->* (real-compiler? vector?) (any/c) (values symbol? any/c))]
           [real-compiler-clear! (-> real-compiler? void?)]
           [real-compiler-analyze (->* (real-compiler? (vectorof ival?)) (any/c) (listof any/c))]))
-
-(define (unified-contexts? ctxs)
-  (cond
-    [((non-empty-listof context?) ctxs)
-     (define ctx0 (car ctxs))
-     (for/and ([ctx (in-list (cdr ctxs))])
-       (and (equal? (context-vars ctx0) (context-vars ctx))
-            (for/and ([var (in-list (context-vars ctx0))])
-              (equal? (context-lookup ctx0 var) (context-lookup ctx var)))))]
-    [else #f]))
 
 (define (expr-size expr)
   (if (list? expr)
@@ -148,15 +139,18 @@
         (pre vars var-reprs exprs reprs machine dump-file assemble-point assemble-output))
 
 ;; Creates a Rival machine.
-(define (make-real-compiler batch brfs ctxs #:pre [pre '(TRUE)])
+(define (make-real-compiler batch brfs output-reprs #:pre [pre '(TRUE)])
   (define specs (map (batch-exprs batch) brfs))
-  (define-values (specs* ctxs* pre* assemble-point assemble-output reprs)
+  (define ctxs
+    (for/list ([repr (in-list output-reprs)])
+      (context (batch-vars batch) repr (batch-var-reprs batch))))
+  (define-values (specs* ctxs* pre* assemble-point assemble-output flattened-reprs)
     (flatten-arrays-for-rival specs ctxs pre))
   (define vars (context-vars (first ctxs*)))
 
   ; create the machine
   (define exprs (cons `(assert ,pre*) specs*))
-  (define discs (make-discretizations reprs))
+  (define discs (make-discretizations flattened-reprs))
   (define machine (rival-compile exprs vars discs))
   (timeline-push! 'compiler
                   (apply + 1 (expr-size pre*) (map expr-size specs*))
@@ -186,7 +180,7 @@
                  (list->vector vars)
                  (list->vector (context-var-reprs (first ctxs*)))
                  specs*
-                 (list->vector reprs)
+                 (list->vector flattened-reprs)
                  machine
                  dump-file
                  assemble-point


### PR DESCRIPTION
This PR modifies the Rival APIs to use the batch vars and var reprs instead of separate contexts. This simplifies a number of APIs, which is good, and also moves toward a vision of stand-alone batches. (Internally, Rival is still using contexts for various reasons.)

We're still using contexts redundantly with batches in the egraph API but otherwise we're basically there.