### PR TITLE
Remove dead egg-herbie FFI exports

### DIFF
--- a/egg-herbie/Cargo.lock
+++ b/egg-herbie/Cargo.lock
@@ -75,7 +75,6 @@ version = "0.3.0"
 dependencies = [
  "egg",
  "env_logger",
- "indexmap",
  "libc",
  "log",
  "num-bigint",

--- a/egg-herbie/Cargo.toml
+++ b/egg-herbie/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 egg = { git = "https://github.com/egraphs-good/egg.git", rev = "6f2ac1ee72d0ec6b51d12c9ca59e94ada6615e87" }
 
 log = "0.4"
-indexmap = "1"
 libc = "0.2.125"
 
 num-bigint = "0.4.3"

--- a/egg-herbie/main.rkt
+++ b/egg-herbie/main.rkt
@@ -7,21 +7,16 @@
 
 (provide egraph_create
          egraph_destroy
-         egraph_add_expr
          egraph_add_root
          egraph_add_node
          egraph_run
          egraph_copy
          egraph_get_stop_reason
          egraph_find
-         egraph_serialize
          egraph_get_eclasses
          egraph_get_eclass
-         egraph_get_simplest
-         egraph_get_variants
          egraph_get_cost
          egraph_is_unsound_detected
-         egraph_get_times_applied
          egraph_get_proof
          (struct-out iteration-data)
          (struct-out FFIRule)
@@ -110,14 +105,6 @@
               (lambda (x) (and x (string->_rust/string (~a x))))
               (lambda (x) (and x (first (_rust/string->data x))))))
 
-;; FFI type that converts Rust-allocated C-style strings
-;; to multiple Racket datum via reapeated use of `read`,
-;; automatically freeing the Rust-side allocation.
-(define _rust/data
-  (make-ctype _pointer
-              (lambda (_) (error '_rust/data "cannot be used as an input type"))
-              (lambda (x) (and x (_rust/string->data x)))))
-
 ; Egraph iteration data
 ; Not managed by Racket GC.
 ; Must call `destroy_egraphiters` to free.
@@ -168,10 +155,6 @@
 ;; Copies an e-graph instance.
 (define-eggmath egraph_copy (_fun _egraph-pointer -> _egraph-pointer))
 
-;; Adds an expression to the e-graph.
-;; egraph -> expr -> id
-(define-eggmath egraph_add_expr (_fun _egraph-pointer _rust/datum -> _uint))
-
 (define-eggmath egraph_add_root (_fun _egraph-pointer _uint -> _void))
 
 ; egraph -> string -> ids -> bool -> id
@@ -213,9 +196,6 @@
 
 ;; gets the stop reason as an integer
 (define-eggmath egraph_get_stop_reason (_fun _egraph-pointer -> _stop_reason))
-
-;; egraph -> string
-(define-eggmath egraph_serialize (_fun _egraph-pointer -> _rust/datum))
 
 ;; egraph -> uint
 (define-eggmath egraph_size (_fun _egraph-pointer -> _uint))
@@ -260,22 +240,6 @@
 ;; egraph -> id -> id
 (define-eggmath egraph_find (_fun _egraph-pointer _uint -> _uint))
 
-;; egraph -> id -> (listof expr)
-(define-eggmath egraph_get_simplest
-                (_fun _egraph-pointer
-                      _uint ;; node id
-                      _uint ;; iteration
-                      ->
-                      _rust/datum)) ;; expr
-
-;; egraph -> id -> string -> (listof expr)
-(define-eggmath egraph_get_variants
-                (_fun _egraph-pointer
-                      _uint ;; node id
-                      _rust/datum ;; original expr
-                      ->
-                      _rust/data)) ;; listof expr
-
 ;; egraph -> string -> string -> string
 ;; TODO: in Herbie, we bail on converting the proof
 ;; if the string is too big. It would be more efficient
@@ -291,11 +255,5 @@
                 (_fun _egraph-pointer
                       _uint ;; node id
                       _uint ;; iteration
-                      ->
-                      _uint))
-
-(define-eggmath egraph_get_times_applied
-                (_fun _egraph-pointer
-                      _pointer ;; name of the rule
                       ->
                       _uint))

--- a/egg-herbie/src/lib.rs
+++ b/egg-herbie/src/lib.rs
@@ -2,8 +2,7 @@
 
 pub mod math;
 
-use egg::{BackoffScheduler, Extractor, FromOp, Id, Language, SimpleScheduler, StopReason, Symbol};
-use indexmap::IndexMap;
+use egg::{BackoffScheduler, FromOp, Id, Language, SimpleScheduler, StopReason};
 use libc::{c_void, strlen};
 use math::*;
 
@@ -15,7 +14,6 @@ use std::time::Duration;
 use std::{slice, sync::atomic::Ordering};
 
 pub struct Context {
-    iteration: usize,
     runner: Runner,
     rules: Vec<Rewrite>,
 }
@@ -24,7 +22,6 @@ pub struct Context {
 #[no_mangle]
 pub unsafe extern "C" fn egraph_create() -> *mut Context {
     Box::into_raw(Box::new(Context {
-        iteration: 0,
         runner: Runner::new(Default::default()).with_explanations_enabled(),
         rules: vec![],
     }))
@@ -68,24 +65,6 @@ pub struct FFIRule {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_add_expr(ptr: *mut Context, expr: *const c_char) -> u32 {
-    let _ = env_logger::try_init();
-    // Safety: `ptr` was box allocated by `egraph_create`
-    let mut context = Box::from_raw(ptr);
-
-    assert_eq!(context.iteration, 0);
-    let rec_expr = CStr::from_ptr(expr).to_str().unwrap().parse().unwrap();
-    context.runner = context.runner.with_expr(&rec_expr);
-    let id = usize::from(*context.runner.roots.last().unwrap())
-        .try_into()
-        .unwrap();
-
-    mem::forget(context);
-
-    id
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn egraph_add_root(ptr: *mut Context, id: u32) {
     let mut context = ManuallyDrop::new(Box::from_raw(ptr));
     context.runner.roots.push(Id::from(id as usize));
@@ -124,7 +103,6 @@ pub unsafe extern "C" fn egraph_copy(ptr: *mut Context) -> *mut Context {
     mem::forget(context);
 
     Box::into_raw(Box::new(Context {
-        iteration: 0,
         rules: vec![],
         runner,
     }))
@@ -273,38 +251,6 @@ pub unsafe extern "C" fn egraph_find(ptr: *mut Context, id: usize) -> u32 {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_serialize(ptr: *mut Context) -> *const c_char {
-    // Safety: `ptr` was box allocated by `egraph_create`
-    let context = ManuallyDrop::new(Box::from_raw(ptr));
-    let mut ids: Vec<Id> = context.runner.egraph.classes().map(|c| c.id).collect();
-    ids.sort();
-
-    // Iterate through the eclasses and print each eclass
-    let mut s = String::from("(");
-    for id in ids {
-        let c = &context.runner.egraph[id];
-        s.push_str(&format!("({}", id));
-        for node in &c.nodes {
-            if matches!(node, Math::Symbol(_) | Math::Constant(_)) {
-                s.push_str(&format!(" {}", node));
-            } else {
-                s.push_str(&format!("({}", node));
-                for c in node.children() {
-                    s.push_str(&format!(" {}", c));
-                }
-                s.push(')');
-            }
-        }
-
-        s.push(')');
-    }
-    s.push(')');
-
-    let c_string = ManuallyDrop::new(CString::new(s).unwrap());
-    c_string.as_ptr()
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn egraph_size(ptr: *mut Context) -> u32 {
     let context = ManuallyDrop::new(Box::from_raw(ptr));
     context.runner.egraph.number_of_classes() as u32
@@ -362,20 +308,6 @@ pub unsafe extern "C" fn egraph_get_node(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_get_simplest(
-    ptr: *mut Context,
-    node_id: u32,
-    iter: u32,
-) -> *const c_char {
-    // Safety: `ptr` was box allocated by `egraph_create`
-    let context = ManuallyDrop::new(Box::from_raw(ptr));
-    let ext = find_extracted(&context.runner, node_id, iter);
-    let best_str = ManuallyDrop::new(CString::new(ext.best.to_string()).unwrap());
-
-    best_str.as_ptr()
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn egraph_get_proof(
     ptr: *mut Context,
     expr: *const c_char,
@@ -399,49 +331,6 @@ pub unsafe extern "C" fn egraph_get_proof(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_get_variants(
-    ptr: *mut Context,
-    node_id: u32,
-    orig_expr: *const c_char,
-) -> *const c_char {
-    // Safety: `ptr` was box allocated by `egraph_create`
-    let context = ManuallyDrop::new(Box::from_raw(ptr));
-
-    // root (id, expr)
-    let id = Id::from(node_id as usize);
-    let orig_recexpr: RecExpr = CStr::from_ptr(orig_expr).to_str().unwrap().parse().unwrap();
-    let head_node = &orig_recexpr.as_ref()[orig_recexpr.as_ref().len() - 1];
-
-    // extractor
-    let extractor = Extractor::new(&context.runner.egraph, AltCost::new(&context.runner.egraph));
-    let mut cache: IndexMap<Id, RecExpr> = Default::default();
-
-    // extract variants
-    let mut exprs = vec![];
-    for n in &context.runner.egraph[id].nodes {
-        // assuming same ops in an eclass cannot
-        // have different precisions
-        if !n.matches(head_node) {
-            // extract if not in cache
-            n.for_each(|id| {
-                if cache.get(&id).is_none() {
-                    let (_, best) = extractor.find_best(id);
-                    cache.insert(id, best);
-                }
-            });
-
-            exprs.push(n.join_recexprs(|id| cache.get(&id).unwrap().as_ref()));
-        }
-    }
-
-    // format
-    let expr_strs: Vec<String> = exprs.iter().map(|r| r.to_string()).collect();
-    let best_str = ManuallyDrop::new(CString::new(expr_strs.join(" ")).unwrap());
-
-    best_str.as_ptr()
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn egraph_is_unsound_detected(ptr: *mut Context) -> bool {
     // Safety: `ptr` was box allocated by `egraph_create`
     let context = ManuallyDrop::new(Box::from_raw(ptr));
@@ -455,37 +344,10 @@ pub unsafe extern "C" fn egraph_is_unsound_detected(ptr: *mut Context) -> bool {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn egraph_get_times_applied(ptr: *mut Context, name: *const c_char) -> u32 {
-    // Safety: `ptr` was box allocated by `egraph_create`
-    let context = ManuallyDrop::new(Box::from_raw(ptr));
-    let sym = Symbol::from(ptr_to_string(name));
-
-    context
-        .runner
-        .iterations
-        .iter()
-        .map(|iter| *iter.applied.get(&sym).unwrap_or(&0) as u32)
-        .sum()
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn egraph_get_cost(ptr: *mut Context, node_id: u32, iter: u32) -> u32 {
     // Safety: `ptr` was box allocated by `egraph_create`
     let context = ManuallyDrop::new(Box::from_raw(ptr));
     let ext = find_extracted(&context.runner, node_id, iter);
 
     ext.cost as u32
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn egraph_get_size(ptr: *mut Context) -> u32 {
-    // Safety: `ptr` was box allocated by `egraph_create`
-    let context = ManuallyDrop::new(Box::from_raw(ptr));
-
-    context
-        .runner
-        .iterations
-        .last()
-        .map(|iteration| iteration.egraph_nodes as u32)
-        .unwrap_or_default()
 }

--- a/src/core/egg-herbie.rkt
+++ b/src/core/egg-herbie.rkt
@@ -38,9 +38,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; FFI utils
 
-(define (u32vector-empty? x)
-  (zero? (u32vector-length x)))
-
 (define (in-u32vector vec)
   (make-do-sequence
    (lambda ()
@@ -116,16 +113,6 @@
       ['simple #t]
       [_ (error 'egraph-run "unknown scheduler: `~a`" scheduler)]))
   (egraph_run ptr ffi-rules iter_limit node_limit simple_scheduler?))
-
-(define (egraph-get-simplest ptr node-id iteration ctx)
-  (define expr (egraph_get_simplest ptr node-id iteration))
-  (egg-expr->expr expr ctx))
-
-(define (egraph-get-variants ptr node-id orig-expr ctx)
-  (define egg-expr (expr->egg-expr orig-expr ctx))
-  (define exprs (egraph_get_variants ptr node-id egg-expr))
-  (for/list ([expr (in-list exprs)])
-    (egg-expr->expr expr ctx)))
 
 (define empty-u32vec (make-u32vector 0))
 
@@ -853,7 +840,6 @@
 ;;
 ;; Typed cost functions take:
 ;;  - the regraph we are extracting from
-;;  - a mutable cache (to possibly stash per-node data)
 ;;  - the node we are computing cost for
 ;;  - 3 argument procedure taking:
 ;;       - an eclass id
@@ -886,10 +872,8 @@
       [(list _ ids ...) (andmap (lambda (id) (vector-ref costs id)) ids)]))
 
   ; computes cost of a node (as long as each of its children have costs)
-  ; cost function has access to a mutable value through `cache`
-  (define cache (box #f))
   (define (node-cost node type)
-    (and (node-ready? node) (platform-egg-cost-proc regraph cache node type unsafe-eclass-cost)))
+    (and (node-ready? node) (platform-egg-cost-proc regraph node type unsafe-eclass-cost)))
 
   ; updates the cost of the current eclass.
   ; returns whether the cost of the current eclass has improved.
@@ -993,7 +977,7 @@
     [_ #f]))
 
 ;; Old cost model version
-(define (default-egg-cost-proc regraph cache node type rec)
+(define (default-egg-cost-proc regraph node rec)
   (match node
     [(? number?) 1]
     [(? symbol?) 1]
@@ -1014,11 +998,10 @@
     [(list _ args ...) (apply + 1 (map rec args))]))
 
 ;; Per-node cost function according to the platform
-;; `rec` takes an id, type, and failure value
-(define (platform-egg-cost-proc regraph cache node type rec)
+;; `rec` takes an eclass id.
+(define (platform-egg-cost-proc regraph node type rec)
   (cond
     [(representation? type)
-     (define ctx (regraph-ctx regraph))
      (define node-cost-proc (platform-node-cost-proc (*active-platform*)))
      (match node
        [(? number? n) ((node-cost-proc (literal n type)))]
@@ -1035,15 +1018,14 @@
           [_
            (define cost-proc (node-cost-proc node))
            (apply cost-proc (map rec args))])])]
-    [else (default-egg-cost-proc regraph cache node type rec)]))
+    [else (default-egg-cost-proc regraph node rec)]))
 
 (module+ test
   (define cost-regraph (regraph #() #() #f (vector #f #f 2/3 1/2) #() #hash() ctx))
   (define (test-rec _)
     1)
-  (check-equal? (platform-egg-cost-proc cost-regraph #f '(pow.f64 0 2) <binary64> test-rec) +inf.0)
-  (check-not-equal? (platform-egg-cost-proc cost-regraph #f '(pow.f64 0 3) <binary64> test-rec)
-                    +inf.0))
+  (check-equal? (platform-egg-cost-proc cost-regraph '(pow.f64 0 2) <binary64> test-rec) +inf.0)
+  (check-not-equal? (platform-egg-cost-proc cost-regraph '(pow.f64 0 3) <binary64> test-rec) +inf.0))
 
 ;; Extracts the best expression according to the extractor.
 ;; Result is a single element list.


### PR DESCRIPTION
This PR removes a bunch of Rust-side code that we don't use any more. Noticed these when talking to @memoryleak47 yesterday and figured we should remove what's not used.